### PR TITLE
feat(checkpoint): adapt initial stateful environments

### DIFF
--- a/resources_servers/blackjack/app.py
+++ b/resources_servers/blackjack/app.py
@@ -55,6 +55,9 @@ def _nested_tuple(value):
 
 
 class BlackjackEnv(GymnasiumServer):
+    def checkpoint_state_enabled(self) -> bool:
+        return True
+
     def serialize_session_state(self, state: dict) -> dict:
         return {
             "player": list(state["player"]),

--- a/resources_servers/blackjack/app.py
+++ b/resources_servers/blackjack/app.py
@@ -48,7 +48,29 @@ def _fmt(hand: list[str]) -> str:
     return "[" + ", ".join(hand) + "]"
 
 
+def _nested_tuple(value):
+    if isinstance(value, list):
+        return tuple(_nested_tuple(item) for item in value)
+    return value
+
+
 class BlackjackEnv(GymnasiumServer):
+    def serialize_session_state(self, state: dict) -> dict:
+        return {
+            "player": list(state["player"]),
+            "dealer": list(state["dealer"]),
+            "rng_state": state["rng"].getstate(),
+        }
+
+    def deserialize_session_state(self, state: dict) -> dict:
+        rng = random.Random()
+        rng.setstate(_nested_tuple(state["rng_state"]))
+        return {
+            "player": list(state["player"]),
+            "dealer": list(state["dealer"]),
+            "rng": rng,
+        }
+
     async def reset(self, metadata: dict, session_id: Optional[str] = None) -> tuple[Optional[str], dict]:
         rng = random.Random()
         player = [_deal(rng), _deal(rng)]

--- a/resources_servers/example_session_state_mgmt/app.py
+++ b/resources_servers/example_session_state_mgmt/app.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Dict
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from nemo_gym._checkpoint import ResourceSnapshot
@@ -91,14 +91,20 @@ class StatefulCounterResourcesServer(SimpleResourcesServer):
         return GetCounterValueResponse(count=counter)
 
     async def verify(self, request: Request, body: StatefulCounterVerifyRequest) -> BaseVerifyResponse:
+        identity = self._current_identity()
         session_id = self._session_id(request)
-
-        reward = 0.0
-        if session_id in self.session_id_to_counter:
-            counter = self.session_id_to_counter[session_id]
-            reward = float(body.expected_count == counter)
-
-        return BaseVerifyResponse(**body.model_dump(), reward=reward)
+        try:
+            reward = 0.0
+            if session_id in self.session_id_to_counter:
+                counter = self.session_id_to_counter[session_id]
+                reward = float(body.expected_count == counter)
+            return BaseVerifyResponse(**body.model_dump(), reward=reward)
+        finally:
+            self.session_id_to_counter.pop(session_id, None)
+            if identity is not None:
+                self.execution_to_session.pop(identity, None)
+                if self._checkpoint_participant is not None:
+                    self.checkpoint_participant().mark_terminal_after_request(*identity)
 
     @staticmethod
     def _current_identity() -> tuple[str, int] | None:
@@ -110,12 +116,20 @@ class StatefulCounterResourcesServer(SimpleResourcesServer):
 
     def _session_id(self, request: Request) -> str:
         identity = self._current_identity()
-        if identity is not None and identity in self.execution_to_session:
-            return self.execution_to_session[identity]
+        if identity is not None:
+            session_id = self.execution_to_session.get(identity)
+            if session_id is None:
+                raise HTTPException(status_code=409, detail="execution has no successful seed binding")
+            return session_id
         return request.session[SESSION_ID_KEY]
 
     def checkpoint_state_enabled(self) -> bool:
         return True
+
+    def checkpoint_route_kind(self, path: str, method: str):
+        if method == "POST" and path == "/get_counter_value":
+            return "read"
+        return super().checkpoint_route_kind(path, method)
 
     async def export_checkpoint_state(self, rollout_id: str, attempt_index: int) -> dict:
         session_id = self.execution_to_session[(rollout_id, attempt_index)]
@@ -130,6 +144,11 @@ class StatefulCounterResourcesServer(SimpleResourcesServer):
             index[(snapshot.rollout_id, snapshot.attempt_index)] = session_id
         self.session_id_to_counter = counters
         self.execution_to_session = index
+
+    async def retire_checkpoint_state(self, rollout_id: str, attempt_index: int) -> None:
+        session_id = self.execution_to_session.pop((rollout_id, attempt_index), None)
+        if session_id is not None:
+            self.session_id_to_counter.pop(session_id, None)
 
 
 if __name__ == "__main__":

--- a/resources_servers/example_session_state_mgmt/app.py
+++ b/resources_servers/example_session_state_mgmt/app.py
@@ -17,6 +17,7 @@ from typing import Dict
 from fastapi import FastAPI, Request
 from pydantic import BaseModel, Field
 
+from nemo_gym._checkpoint import ResourceSnapshot
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseSeedSessionRequest,
@@ -25,6 +26,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from nemo_gym.rollout_correlation import current_attempt_index, current_logical_rollout_id
 from nemo_gym.server_utils import SESSION_ID_KEY
 
 
@@ -55,6 +57,7 @@ class StatefulCounterSeedSessionRequest(BaseSeedSessionRequest):
 class StatefulCounterResourcesServer(SimpleResourcesServer):
     config: StatefulCounterResourcesServerConfig
     session_id_to_counter: Dict[str, int] = Field(default_factory=dict)
+    execution_to_session: Dict[tuple[str, int], str] = Field(default_factory=dict)
 
     def setup_webserver(self) -> FastAPI:
         app = super().setup_webserver()
@@ -67,10 +70,13 @@ class StatefulCounterResourcesServer(SimpleResourcesServer):
     async def seed_session(self, request: Request, body: StatefulCounterSeedSessionRequest) -> BaseSeedSessionResponse:
         session_id = request.session[SESSION_ID_KEY]
         self.session_id_to_counter.setdefault(session_id, body.initial_count)
+        identity = self._current_identity()
+        if identity is not None:
+            self.execution_to_session[identity] = session_id
         return BaseSeedSessionResponse()
 
     async def increment_counter(self, request: Request, body: IncrementCounterRequest) -> IncrementCounterResponse:
-        session_id = request.session[SESSION_ID_KEY]
+        session_id = self._session_id(request)
         counter = self.session_id_to_counter.setdefault(session_id, 0)
 
         counter += body.count
@@ -80,12 +86,12 @@ class StatefulCounterResourcesServer(SimpleResourcesServer):
         return IncrementCounterResponse(success=True)
 
     async def get_counter_value(self, request: Request) -> GetCounterValueResponse:
-        session_id = request.session[SESSION_ID_KEY]
+        session_id = self._session_id(request)
         counter = self.session_id_to_counter.setdefault(session_id, 0)
         return GetCounterValueResponse(count=counter)
 
     async def verify(self, request: Request, body: StatefulCounterVerifyRequest) -> BaseVerifyResponse:
-        session_id = request.session[SESSION_ID_KEY]
+        session_id = self._session_id(request)
 
         reward = 0.0
         if session_id in self.session_id_to_counter:
@@ -93,6 +99,37 @@ class StatefulCounterResourcesServer(SimpleResourcesServer):
             reward = float(body.expected_count == counter)
 
         return BaseVerifyResponse(**body.model_dump(), reward=reward)
+
+    @staticmethod
+    def _current_identity() -> tuple[str, int] | None:
+        rollout_id = current_logical_rollout_id()
+        attempt_index = current_attempt_index()
+        if rollout_id is None or attempt_index is None:
+            return None
+        return rollout_id, attempt_index
+
+    def _session_id(self, request: Request) -> str:
+        identity = self._current_identity()
+        if identity is not None and identity in self.execution_to_session:
+            return self.execution_to_session[identity]
+        return request.session[SESSION_ID_KEY]
+
+    def checkpoint_state_enabled(self) -> bool:
+        return True
+
+    async def export_checkpoint_state(self, rollout_id: str, attempt_index: int) -> dict:
+        session_id = self.execution_to_session[(rollout_id, attempt_index)]
+        return {"counter": self.session_id_to_counter[session_id]}
+
+    async def restore_checkpoint_states(self, snapshots: list[ResourceSnapshot]) -> None:
+        counters = dict(self.session_id_to_counter)
+        index = dict(self.execution_to_session)
+        for snapshot in snapshots:
+            session_id = f"checkpoint:{snapshot.rollout_id}:a{snapshot.attempt_index}"
+            counters[session_id] = int(snapshot.state["counter"])
+            index[(snapshot.rollout_id, snapshot.attempt_index)] = session_id
+        self.session_id_to_counter = counters
+        self.execution_to_session = index
 
 
 if __name__ == "__main__":

--- a/resources_servers/workplace_assistant/app.py
+++ b/resources_servers/workplace_assistant/app.py
@@ -12,11 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from io import StringIO
 from typing import Any, Dict
 
+import pandas as pd
 from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from nemo_gym._checkpoint import ResourceSnapshot
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseSeedSessionRequest,
@@ -25,8 +28,12 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from nemo_gym.rollout_correlation import current_attempt_index, current_logical_rollout_id
 from nemo_gym.server_utils import SESSION_ID_KEY
 from resources_servers.workplace_assistant.utils import get_tools, is_correct
+
+
+_TOOLKITS = ["email", "calendar", "analytics", "project_management", "customer_relationship_manager"]
 
 
 class WorkbenchResourcesServerConfig(BaseResourcesServerConfig):
@@ -55,6 +62,7 @@ class WorkbenchVerifyResponse(BaseVerifyResponse):
 class WorkbenchResourcesServer(SimpleResourcesServer):
     config: WorkbenchResourcesServerConfig
     session_id_to_tool_env: Dict[str, Any] = Field(default_factory=dict)
+    execution_to_session: Dict[tuple[str, int], str] = Field(default_factory=dict)
 
     def setup_webserver(self) -> FastAPI:
         app = super().setup_webserver()
@@ -71,18 +79,17 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
     async def seed_session(self, request: Request, body: BaseSeedSessionRequest) -> BaseSeedSessionResponse:
         # init session once for each sample.
         session_id = request.session[SESSION_ID_KEY]
-        toolkits = [
-            "email",
-            "calendar",
-            "analytics",
-            "project_management",
-            "customer_relationship_manager",
-        ]
-        self.session_id_to_tool_env[session_id] = get_tools(toolkits)
+        self.session_id_to_tool_env[session_id] = get_tools(_TOOLKITS)
+        identity = self._current_identity()
+        if identity is not None:
+            self.execution_to_session[identity] = session_id
         return BaseSeedSessionResponse()
 
     async def route_to_python_function(self, path: str, body: WorkbenchRequest, request: Request) -> WorkbenchResponse:
-        session_id = request.session[SESSION_ID_KEY]
+        identity = self._current_identity()
+        session_id = self.execution_to_session.get(identity) if identity is not None else None
+        if session_id is None:
+            session_id = request.session[SESSION_ID_KEY]
 
         # Check if session exists
         if session_id not in self.session_id_to_tool_env:
@@ -104,7 +111,10 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
             )  # return error to model so that it can correct itself
 
     async def verify(self, request: Request, body: WorkbenchVerifyRequest) -> WorkbenchVerifyResponse:
-        session_id = request.session[SESSION_ID_KEY]
+        identity = self._current_identity()
+        session_id = self.execution_to_session.get(identity) if identity is not None else None
+        if session_id is None:
+            session_id = request.session[SESSION_ID_KEY]
         try:
             ground_truth = body.ground_truth
             response = body.response.output
@@ -128,6 +138,56 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
             return WorkbenchVerifyResponse(**body.model_dump(), reward=total_score)
         finally:
             self.session_id_to_tool_env.pop(session_id, None)
+            if identity is not None:
+                self.execution_to_session.pop(identity, None)
+
+    @staticmethod
+    def _current_identity() -> tuple[str, int] | None:
+        rollout_id = current_logical_rollout_id()
+        attempt_index = current_attempt_index()
+        if rollout_id is None or attempt_index is None:
+            return None
+        return rollout_id, attempt_index
+
+    def checkpoint_state_enabled(self) -> bool:
+        return True
+
+    async def export_checkpoint_state(self, rollout_id: str, attempt_index: int) -> dict[str, Any]:
+        session_id = self.execution_to_session[(rollout_id, attempt_index)]
+        tool_env = self.session_id_to_tool_env[session_id]
+        return {
+            "containers": {
+                name: {
+                    attribute: frame.to_json(orient="split")
+                    for attribute, frame in vars(container).items()
+                    if isinstance(frame, pd.DataFrame)
+                }
+                for name, container in tool_env["containers"].items()
+            }
+        }
+
+    async def restore_checkpoint_states(self, snapshots: list[ResourceSnapshot]) -> None:
+        restored: list[tuple[ResourceSnapshot, str, dict[str, Any]]] = []
+        for snapshot in snapshots:
+            tool_env = get_tools(_TOOLKITS)
+            for name, frames in snapshot.state["containers"].items():
+                container = tool_env["containers"][name]
+                for attribute, payload in frames.items():
+                    setattr(
+                        container,
+                        attribute,
+                        pd.read_json(StringIO(payload), orient="split", dtype=False, convert_dates=False),
+                    )
+            session_id = f"checkpoint:{snapshot.rollout_id}:a{snapshot.attempt_index}"
+            restored.append((snapshot, session_id, tool_env))
+
+        replacement_environments = dict(self.session_id_to_tool_env)
+        replacement_index = dict(self.execution_to_session)
+        for snapshot, session_id, tool_env in restored:
+            replacement_environments[session_id] = tool_env
+            replacement_index[(snapshot.rollout_id, snapshot.attempt_index)] = session_id
+        self.session_id_to_tool_env = replacement_environments
+        self.execution_to_session = replacement_index
 
 
 if __name__ == "__main__":

--- a/resources_servers/workplace_assistant/app.py
+++ b/resources_servers/workplace_assistant/app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from io import StringIO
 from typing import Any, Dict
 
@@ -34,6 +35,7 @@ from resources_servers.workplace_assistant.utils import get_tools, is_correct
 
 
 _TOOLKITS = ["email", "calendar", "analytics", "project_management", "customer_relationship_manager"]
+_TOOL_NAMES = frozenset(schema["name"] for schema in get_tools(_TOOLKITS)["schemas"])
 
 
 class WorkbenchResourcesServerConfig(BaseResourcesServerConfig):
@@ -87,8 +89,11 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
 
     async def route_to_python_function(self, path: str, body: WorkbenchRequest, request: Request) -> WorkbenchResponse:
         identity = self._current_identity()
-        session_id = self.execution_to_session.get(identity) if identity is not None else None
-        if session_id is None:
+        if identity is not None:
+            session_id = self.execution_to_session.get(identity)
+            if session_id is None:
+                raise HTTPException(status_code=409, detail="execution has no successful seed binding")
+        else:
             session_id = request.session[SESSION_ID_KEY]
 
         # Check if session exists
@@ -112,8 +117,11 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
 
     async def verify(self, request: Request, body: WorkbenchVerifyRequest) -> WorkbenchVerifyResponse:
         identity = self._current_identity()
-        session_id = self.execution_to_session.get(identity) if identity is not None else None
-        if session_id is None:
+        if identity is not None:
+            session_id = self.execution_to_session.get(identity)
+            if session_id is None:
+                raise HTTPException(status_code=409, detail="execution has no successful seed binding")
+        else:
             session_id = request.session[SESSION_ID_KEY]
         try:
             ground_truth = body.ground_truth
@@ -140,6 +148,8 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
             self.session_id_to_tool_env.pop(session_id, None)
             if identity is not None:
                 self.execution_to_session.pop(identity, None)
+                if self._checkpoint_participant is not None:
+                    self.checkpoint_participant().mark_terminal_after_request(*identity)
 
     @staticmethod
     def _current_identity() -> tuple[str, int] | None:
@@ -151,6 +161,14 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
 
     def checkpoint_state_enabled(self) -> bool:
         return True
+
+    def checkpoint_route_kind(self, path: str, method: str):
+        kind = super().checkpoint_route_kind(path, method)
+        if kind is not None:
+            return kind
+        if method == "POST" and path.lstrip("/") in _TOOL_NAMES:
+            return "mutation"
+        return None
 
     async def export_checkpoint_state(self, rollout_id: str, attempt_index: int) -> dict[str, Any]:
         session_id = self.execution_to_session[(rollout_id, attempt_index)]
@@ -173,11 +191,17 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
             for name, frames in snapshot.state["containers"].items():
                 container = tool_env["containers"][name]
                 for attribute, payload in frames.items():
-                    setattr(
-                        container,
-                        attribute,
-                        pd.read_json(StringIO(payload), orient="split", dtype=False, convert_dates=False),
-                    )
+                    frame = pd.read_json(StringIO(payload), orient="split", dtype=False, convert_dates=False)
+                    encoded = json.loads(payload)
+                    columns = encoded.get("columns", [])
+                    rows = encoded.get("data", [])
+                    for index, column in enumerate(columns):
+                        if any(len(row) > index and row[index] is None for row in rows):
+                            frame[column] = frame[column].astype(object).where(frame[column].notna(), None)
+                    index_values = encoded.get("index", [])
+                    if index_values == list(range(len(index_values))):
+                        frame.index = pd.RangeIndex(len(index_values))
+                    setattr(container, attribute, frame)
             session_id = f"checkpoint:{snapshot.rollout_id}:a{snapshot.attempt_index}"
             restored.append((snapshot, session_id, tool_env))
 
@@ -188,6 +212,11 @@ class WorkbenchResourcesServer(SimpleResourcesServer):
             replacement_index[(snapshot.rollout_id, snapshot.attempt_index)] = session_id
         self.session_id_to_tool_env = replacement_environments
         self.execution_to_session = replacement_index
+
+    async def retire_checkpoint_state(self, rollout_id: str, attempt_index: int) -> None:
+        session_id = self.execution_to_session.pop((rollout_id, attempt_index), None)
+        if session_id is not None:
+            self.session_id_to_tool_env.pop(session_id, None)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_checkpoint_e2e.py
+++ b/tests/unit_tests/test_checkpoint_e2e.py
@@ -1,0 +1,562 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cross-layer regression coverage for one partial-rollout checkpoint cut."""
+
+import asyncio
+import hashlib
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+import orjson
+import pytest
+from fastapi import FastAPI, Request
+from omegaconf import OmegaConf
+
+from nemo_gym._checkpoint import (
+    AGENT_CHECKPOINT_URL_PREFIX,
+    GATED_MODEL_ROUTE_SUFFIXES,
+    MODEL_ADMISSION_URL_PREFIX,
+    MODEL_CHECKPOINT_URL_PREFIX,
+    RESOURCES_CHECKPOINT_URL_PREFIX,
+    AdmissionLimiter,
+    AdmissionMiddleware,
+    AgentAdmissionClosedError,
+    AgentBoundaryRecord,
+    AgentCheckpointParticipant,
+    ControlCapabilities,
+    ControlFence,
+    MultiProcessCapability,
+    ResourcesCheckpointParticipant,
+    ResourceSnapshot,
+    StaleAttemptError,
+    install_agent_checkpoint,
+    install_control_plane,
+    install_model_admission,
+    install_model_checkpoint,
+    install_resources_checkpoint,
+)
+from nemo_gym.config_types import BaseServerConfig
+from nemo_gym.rollout_correlation import (
+    ATTEMPT_INDEX_HEADER,
+    PARENT_MODEL_CALL_ID_HEADER,
+    ROLLOUT_ID_HEADER,
+    SOURCE_CAPTURE_KEY_HEADER,
+    RolloutContextMiddleware,
+    capture_key_for,
+    checkpoint_parent_context,
+    rollout_context,
+)
+from nemo_gym.server_utils import ServerClient
+from nemo_gym.token_id_capture.lineage import FileLineageStore
+
+
+AUTH_TOKEN = "checkpoint-token"
+AUTH_HEADERS = {"authorization": f"Bearer {AUTH_TOKEN}"}
+CHECKPOINT_ID = "checkpoint-1"
+RESTORE_ID = "restore-1"
+ROLLOUT_ID = "rollout-a"
+STRAGGLER_ID = "rollout-straggler"
+PARENT_CALL_ID = "call-parent"
+
+
+def _capabilities(component: str, name: str) -> ControlCapabilities:
+    return ControlCapabilities(
+        component=component,
+        name=name,
+        multi_process=MultiProcessCapability(mode="single_worker", num_workers=1),
+    )
+
+
+def _agent_app(participant: AgentCheckpointParticipant, name: str) -> FastAPI:
+    app = FastAPI()
+    fence = ControlFence()
+    install_control_plane(app, capabilities=_capabilities("responses_api_agents", name), fence=fence)
+    install_agent_checkpoint(app, participant=participant, fence=fence, auth_token=AUTH_TOKEN)
+    return app
+
+
+def _model_app(ledger_root: Path, request_headers: list[dict[str, str]]) -> tuple[FastAPI, AdmissionLimiter]:
+    app = FastAPI()
+    fence = ControlFence()
+    limiter = AdmissionLimiter()
+    ledger = FileLineageStore(ledger_root)
+    capabilities = _capabilities("responses_api_models", "policy")
+    capabilities.instance_role = "policy"
+    install_control_plane(app, capabilities=capabilities, fence=fence)
+    install_model_admission(
+        app,
+        limiter=limiter,
+        fence=fence,
+        instance_role="policy",
+        auth_token=AUTH_TOKEN,
+    )
+    install_model_checkpoint(
+        app,
+        fence=fence,
+        limiter=limiter,
+        ledger_provider=lambda: ledger,
+        file_ledger_root_provider=lambda: ledger.checkpoint_root,
+        instance_role="policy",
+        server_name="policy",
+        auth_token=AUTH_TOKEN,
+    )
+
+    @app.post("/v1/responses")
+    async def responses(request: Request) -> dict:
+        request_headers.append(dict(request.headers))
+        call_index = len(request_headers)
+        return {
+            "id": f"response-{call_index}",
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": f"attempt-1-call-{call_index}"}],
+                }
+            ],
+        }
+
+    app.add_middleware(
+        AdmissionMiddleware,
+        limiter=limiter,
+        gated_suffixes=GATED_MODEL_ROUTE_SUFFIXES,
+    )
+    return app, limiter
+
+
+def _resources_app(
+    participant: ResourcesCheckpointParticipant,
+    state: dict[tuple[str, int], dict],
+) -> FastAPI:
+    app = FastAPI()
+    fence = ControlFence()
+    install_control_plane(
+        app,
+        capabilities=_capabilities("resources_servers", "resources"),
+        fence=fence,
+    )
+
+    @app.post("/seed_session")
+    async def seed_session() -> dict:
+        from nemo_gym.rollout_correlation import current_execution_identity
+
+        identity = current_execution_identity()
+        state[identity] = {"value": state.get(identity, {}).get("value", 0) + 1}
+        return state[identity]
+
+    @app.post("/state")
+    async def get_state() -> dict:
+        from nemo_gym.rollout_correlation import current_execution_identity
+
+        return state[current_execution_identity()]
+
+    def route_kind(path: str, method: str):
+        if method != "POST":
+            return None
+        if path == "/seed_session":
+            return "start"
+        if path == "/state":
+            return "read"
+        return None
+
+    install_resources_checkpoint(
+        app,
+        participant=participant,
+        fence=fence,
+        auth_token=AUTH_TOKEN,
+        server_name="resources",
+        route_kind=route_kind,
+    )
+    app.add_middleware(RolloutContextMiddleware)
+    return app
+
+
+def _resources_participant(
+    state: dict[tuple[str, int], dict],
+    *,
+    restore_expected: bool = False,
+) -> ResourcesCheckpointParticipant:
+    async def export(rollout_id: str, attempt_index: int) -> dict:
+        return dict(state[(rollout_id, attempt_index)])
+
+    async def restore(snapshots: list[ResourceSnapshot]) -> None:
+        replacement = {(snapshot.rollout_id, snapshot.attempt_index): dict(snapshot.state) for snapshot in snapshots}
+        state.clear()
+        state.update(replacement)
+
+    async def retire(rollout_id: str, attempt_index: int) -> None:
+        state.pop((rollout_id, attempt_index), None)
+
+    return ResourcesCheckpointParticipant(
+        export_state=export,
+        restore_states=restore,
+        retire_state=retire,
+        restore_expected=restore_expected,
+    )
+
+
+class _Response:
+    def __init__(self, response: httpx.Response) -> None:
+        self.status = response.status_code
+        self.ok = response.is_success
+        self.cookies = response.cookies
+        self._content = response.content
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+async def _post(client: httpx.AsyncClient, path: str, body: dict) -> httpx.Response:
+    return await client.post(path, json=body, headers=AUTH_HEADERS)
+
+
+async def _record_lineage(
+    root: Path,
+    rollout_id: str,
+    call_id: str,
+    *,
+    request_items: list[dict],
+    output_items: list[dict],
+    parent_call_id: str | None = None,
+) -> None:
+    prev_len = 0 if parent_call_id is None else 3
+    await FileLineageStore(root).record(
+        rollout_id,
+        call_id,
+        request_items=request_items,
+        response_items=output_items,
+        cumulative_token_ids=[],
+        digest="1" * 64,
+        parent_call_id=parent_call_id,
+        staging_key=f"stage/{rollout_id}/{call_id}",
+        weight_version=7,
+        prev_len=prev_len,
+        delta_len=3,
+        cum_len=prev_len + 3,
+        staging_digest="2" * 64,
+        extras_digest="3" * 64,
+        mode="text" if parent_call_id is None else "token_in",
+        logical_request_id=f"request-{rollout_id}",
+        admitted_at=1.0,
+        staging_chain=[f"stage/{rollout_id}/{call_id}"],
+        chain_hash="4" * 64,
+        cumulative_hash="5" * 64,
+        response_id=f"response-{rollout_id}",
+        output_fingerprint="6" * 64,
+        continuation_fingerprint="7" * 64,
+        fingerprint_version=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_partial_rollout_checkpoint_cycle(tmp_path, monkeypatch) -> None:
+    checkpoint_dir = tmp_path / "controller-checkpoint"
+    source_ledger_root = tmp_path / "source-ledger"
+    source_model_headers: list[dict[str, str]] = []
+    source_model_app, source_limiter = _model_app(source_ledger_root, source_model_headers)
+
+    boundary_items = [
+        {"type": "function_call", "call_id": "tool-1", "name": "increment", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "tool-1", "output": "1"},
+    ]
+    await _record_lineage(
+        source_ledger_root,
+        ROLLOUT_ID,
+        PARENT_CALL_ID,
+        request_items=[],
+        output_items=boundary_items,
+    )
+    await _record_lineage(
+        source_ledger_root,
+        STRAGGLER_ID,
+        "call-straggler",
+        request_items=[],
+        output_items=boundary_items,
+    )
+    for rollout_id in (ROLLOUT_ID, STRAGGLER_ID):
+        source_limiter.release(source_limiter.admit(rollout_id=rollout_id, attempt_index=0))
+
+    source_agent = AgentCheckpointParticipant("whitebox-agent")
+    source_agent_app = _agent_app(source_agent, "whitebox-agent")
+    source_execution = await source_agent.begin(ROLLOUT_ID, 0, task=asyncio.current_task())
+    await source_agent.begin(STRAGGLER_ID, 0, task=None)
+
+    source_resource_state: dict[tuple[str, int], dict] = {}
+    source_resources = _resources_participant(source_resource_state)
+    source_resources_app = _resources_app(source_resources, source_resource_state)
+
+    # Completed results without framework acknowledgement and executions parked
+    # without a boundary both make agent publication impossible.
+    completed_blocker = AgentCheckpointParticipant("completed-blocker")
+    completed = await completed_blocker.begin("completed", 0, task=asyncio.current_task())
+    await completed_blocker.finish(completed, outcome="completed", result={"reward": 1.0})
+    parked_blocker = AgentCheckpointParticipant("parked-blocker")
+    parked_execution = await parked_blocker.begin("parked", 0, task=asyncio.current_task())
+    parked_task = asyncio.create_task(parked_blocker.park(parked_execution))
+    while parked_blocker.status()["parked_without_boundary"] != 1:
+        await asyncio.sleep(0)
+
+    async with (
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=source_model_app), base_url="http://model") as model,
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=source_agent_app), base_url="http://agent") as agent,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=source_resources_app),
+            base_url="http://resources",
+        ) as resources,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=_agent_app(completed_blocker, "completed-blocker")),
+            base_url="http://completed",
+        ) as completed_client,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=_agent_app(parked_blocker, "parked-blocker")),
+            base_url="http://parked",
+        ) as parked_client,
+    ):
+        prepare_body = {"checkpoint_id": CHECKPOINT_ID, "deadline_ts": time.time() + 5}
+        for blocker_client in (completed_client, parked_client):
+            blocked = await _post(
+                blocker_client,
+                f"{AGENT_CHECKPOINT_URL_PREFIX}/prepare",
+                prepare_body,
+            )
+            assert blocked.status_code == 409
+            assert blocked.json()["error"]["code"] == "agent_prepare_incomplete"
+
+        identity_headers = {ROLLOUT_ID_HEADER: ROLLOUT_ID, ATTEMPT_INDEX_HEADER: "0"}
+        straggler_headers = {ROLLOUT_ID_HEADER: STRAGGLER_ID, ATTEMPT_INDEX_HEADER: "0"}
+        assert (await resources.post("/seed_session", headers=identity_headers)).json() == {"value": 1}
+        assert (await resources.post("/seed_session", headers=straggler_headers)).json() == {"value": 1}
+        assert source_resources.revision_for(ROLLOUT_ID, 0) == 1
+
+        pause = await _post(model, f"{MODEL_ADMISSION_URL_PREFIX}/pause", prepare_body)
+        assert pause.json()["state"] == "paused"
+        aborted = await _post(
+            model,
+            f"{MODEL_ADMISSION_URL_PREFIX}/abort_inflight",
+            {**prepare_body, "rollout_id": STRAGGLER_ID, "attempt_index": 0},
+        )
+        assert aborted.status_code == 200
+
+        agent_prepare_task = asyncio.create_task(_post(agent, f"{AGENT_CHECKPOINT_URL_PREFIX}/prepare", prepare_body))
+        await asyncio.sleep(0)
+        boundary_task = asyncio.create_task(
+            source_agent.commit_boundary(
+                source_execution,
+                AgentBoundaryRecord(
+                    rollout_id=ROLLOUT_ID,
+                    attempt_index=0,
+                    boundary_index=1,
+                    output_items=boundary_items,
+                    last_committed_model_call_id=PARENT_CALL_ID,
+                    resource_state_revisions={"resources": 1},
+                    agent_state={"step": 1},
+                ),
+            )
+        )
+        retired_agent = await _post(
+            agent,
+            f"{AGENT_CHECKPOINT_URL_PREFIX}/retire",
+            {**prepare_body, "rollout_id": STRAGGLER_ID, "attempt_index": 0},
+        )
+        assert retired_agent.json()["retired"] is True
+        agent_prepare = await agent_prepare_task
+        assert agent_prepare.json()["ready_to_commit"] is True
+        assert not boundary_task.done()
+
+        resources_prepare = await _post(
+            resources,
+            f"{RESOURCES_CHECKPOINT_URL_PREFIX}/prepare",
+            prepare_body,
+        )
+        assert resources_prepare.json()["sessions"] == 2
+        retired_resources = await _post(
+            resources,
+            f"{RESOURCES_CHECKPOINT_URL_PREFIX}/retire",
+            {**prepare_body, "rollout_id": STRAGGLER_ID, "attempt_index": 0},
+        )
+        assert retired_resources.json()["retired"] is True
+
+        commit_body = {**prepare_body, "checkpoint_dir": str(checkpoint_dir)}
+        model_commit = await _post(model, f"{MODEL_CHECKPOINT_URL_PREFIX}/commit", commit_body)
+        agent_commit = await _post(agent, f"{AGENT_CHECKPOINT_URL_PREFIX}/commit", commit_body)
+        resources_commit = await _post(resources, f"{RESOURCES_CHECKPOINT_URL_PREFIX}/commit", commit_body)
+        assert model_commit.json()["excluded_tombstoned"] == 1
+        assert agent_commit.json()["records"] == 1
+        assert resources_commit.json()["sessions"] == 1
+
+    agent_namespace = (
+        checkpoint_dir / "agent" / f"instance-{hashlib.sha256(b'whitebox-agent').hexdigest()}" / "manifest.json"
+    )
+    assert (checkpoint_dir / "model-ledger" / "policy" / "manifest.json").exists()
+    assert agent_namespace.exists()
+    assert (checkpoint_dir / "resources" / "resources" / "manifest.json").exists()
+    assert len(list(checkpoint_dir.rglob("manifest.json"))) == 3
+
+    restored_model_headers: list[dict[str, str]] = []
+    restored_model_app, restored_limiter = _model_app(tmp_path / "restored-ledger", restored_model_headers)
+    restored_agent = AgentCheckpointParticipant("whitebox-agent")
+    restored_agent_app = _agent_app(restored_agent, "whitebox-agent")
+    restored_resource_state: dict[tuple[str, int], dict] = {}
+    restored_resources = _resources_participant(restored_resource_state, restore_expected=True)
+    restored_resources_app = _resources_app(restored_resources, restored_resource_state)
+
+    async with (
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=restored_model_app), base_url="http://policy.test"
+        ) as model,
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=restored_agent_app), base_url="http://agent") as agent,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=restored_resources_app),
+            base_url="http://resources",
+        ) as resources,
+    ):
+        restore_body = {
+            "checkpoint_id": RESTORE_ID,
+            "deadline_ts": time.time() + 5,
+            "checkpoint_dir": str(checkpoint_dir),
+        }
+        assert (await _post(model, f"{MODEL_CHECKPOINT_URL_PREFIX}/restore", restore_body)).status_code == 200
+        assert (await _post(agent, f"{AGENT_CHECKPOINT_URL_PREFIX}/restore", restore_body)).status_code == 200
+        assert (await _post(resources, f"{RESOURCES_CHECKPOINT_URL_PREFIX}/restore", restore_body)).status_code == 200
+
+        early_model = await model.post("/v1/responses", json={"input": []})
+        assert early_model.status_code == 409
+        with pytest.raises(AgentAdmissionClosedError):
+            await restored_agent.begin(ROLLOUT_ID, 1, task=None)
+        early_resource = await resources.post(
+            "/state",
+            headers={ROLLOUT_ID_HEADER: ROLLOUT_ID, ATTEMPT_INDEX_HEADER: "1"},
+        )
+        assert early_resource.status_code == 409
+
+        resume_body = {"checkpoint_id": RESTORE_ID, "deadline_ts": time.time() + 5}
+        assert (await _post(model, f"{MODEL_ADMISSION_URL_PREFIX}/resume", resume_body)).status_code == 200
+        assert (await _post(agent, f"{AGENT_CHECKPOINT_URL_PREFIX}/resume", resume_body)).status_code == 200
+        assert (await _post(resources, f"{RESOURCES_CHECKPOINT_URL_PREFIX}/resume", resume_body)).status_code == 200
+
+        replacement = await restored_agent.begin(ROLLOUT_ID, 1, task=asyncio.current_task())
+        continuation = restored_agent.continuation(replacement)
+        assert continuation is not None
+        assert continuation.resource_state_revisions == {"resources": 1}
+        assert continuation.agent_state == {"step": 1}
+        assert restored_resources.revision_for(ROLLOUT_ID, 1) == 1
+        state_response = await resources.post(
+            "/state",
+            headers={ROLLOUT_ID_HEADER: ROLLOUT_ID, ATTEMPT_INDEX_HEADER: "1"},
+        )
+        assert state_response.json() == {"value": 1}
+
+        config = OmegaConf.create({"policy": {"responses_api_models": {"model": {"host": "policy.test", "port": 80}}}})
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="head.test", port=80),
+            global_config_dict=config,
+        )
+
+        async def dispatch(method: str, url: str, **kwargs) -> _Response:
+            parsed = urlsplit(url)
+            response = await model.request(
+                method,
+                parsed.path,
+                json=kwargs.get("json"),
+                headers=kwargs.get("headers"),
+            )
+            return _Response(response)
+
+        import nemo_gym.server_utils
+
+        monkeypatch.setattr(nemo_gym.server_utils, "request", dispatch)
+        with rollout_context(
+            capture_key_for(ROLLOUT_ID, 1),
+            attempt_index=1,
+            logical_rollout_id=ROLLOUT_ID,
+        ):
+            with checkpoint_parent_context(
+                capture_key_for(continuation.rollout_id, continuation.attempt_index),
+                continuation.last_committed_model_call_id,
+            ):
+                first = await server_client.post("policy", "/v1/responses", json={"input": boundary_items})
+                first_payload = orjson.loads(await first.read())
+                await _record_lineage(
+                    tmp_path / "restored-ledger",
+                    capture_key_for(ROLLOUT_ID, 1),
+                    "call-attempt-1",
+                    request_items=boundary_items,
+                    output_items=first_payload["output"],
+                    parent_call_id=PARENT_CALL_ID,
+                )
+                second_input = boundary_items + first_payload["output"]
+                second = await server_client.post("policy", "/v1/responses", json={"input": second_input})
+        assert first_payload["id"] == "response-1"
+        assert orjson.loads(await second.read())["id"] == "response-2"
+
+    assert restored_model_headers[0][SOURCE_CAPTURE_KEY_HEADER] == capture_key_for(ROLLOUT_ID, 0)
+    assert restored_model_headers[0][PARENT_MODEL_CALL_ID_HEADER] == PARENT_CALL_ID
+    assert restored_model_headers[0][ROLLOUT_ID_HEADER] == ROLLOUT_ID
+    assert restored_model_headers[0][ATTEMPT_INDEX_HEADER] == "1"
+    assert SOURCE_CAPTURE_KEY_HEADER not in restored_model_headers[1]
+    assert PARENT_MODEL_CALL_ID_HEADER not in restored_model_headers[1]
+
+    next_parent = await FileLineageStore(tmp_path / "restored-ledger").resolve(
+        capture_key_for(ROLLOUT_ID, 1),
+        second_input,
+    )
+    assert next_parent.match is not None
+    assert next_parent.match.model_call_id == "call-attempt-1"
+    assert next_parent.match.model_call_id != PARENT_CALL_ID
+
+    source_row = orjson.loads(
+        (tmp_path / "restored-ledger" / f"{ROLLOUT_ID}.lineage.jsonl").read_bytes().splitlines()[0]
+    )
+    assert {
+        "parent_call_id": source_row["parent_call_id"],
+        "staging_key": source_row["staging_key"],
+        "weight_version": source_row["weight_version"],
+        "prev_len": source_row["prev_len"],
+        "delta_len": source_row["delta_len"],
+        "cum_len": source_row["cum_len"],
+        "staging_digest": source_row["staging_digest"],
+        "extras_digest": source_row["extras_digest"],
+        "mode": source_row["mode"],
+        "staging_chain": source_row["staging_chain"],
+        "chain_hash": source_row["chain_hash"],
+        "cumulative_hash": source_row["cumulative_hash"],
+    } == {
+        "parent_call_id": None,
+        "staging_key": "stage/rollout-a/call-parent",
+        "weight_version": 7,
+        "prev_len": 0,
+        "delta_len": 3,
+        "cum_len": 3,
+        "staging_digest": "2" * 64,
+        "extras_digest": "3" * 64,
+        "mode": "text",
+        "staging_chain": ["stage/rollout-a/call-parent"],
+        "chain_hash": "4" * 64,
+        "cumulative_hash": "5" * 64,
+    }
+    assert not (tmp_path / "restored-ledger" / f"{STRAGGLER_ID}.lineage.jsonl").exists()
+    assert restored_resources.revision_for(STRAGGLER_ID, 1) is None
+    assert restored_agent.resolve(STRAGGLER_ID, 1) is None
+    with pytest.raises(StaleAttemptError):
+        restored_limiter.admit(rollout_id=STRAGGLER_ID, attempt_index=0)
+
+    await restored_agent.finish(replacement, outcome="completed", result={"reward": 1.0})
+    await source_agent.resume()
+    await boundary_task
+    parked_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await parked_task

--- a/tests/unit_tests/test_checkpoint_e2e.py
+++ b/tests/unit_tests/test_checkpoint_e2e.py
@@ -31,6 +31,7 @@ from nemo_gym._checkpoint import (
     GATED_MODEL_ROUTE_SUFFIXES,
     MODEL_ADMISSION_URL_PREFIX,
     MODEL_CHECKPOINT_URL_PREFIX,
+    RESOURCE_REQUEST_ID_HEADER,
     RESOURCES_CHECKPOINT_URL_PREFIX,
     AdmissionLimiter,
     AdmissionMiddleware,
@@ -336,8 +337,16 @@ async def test_complete_partial_rollout_checkpoint_cycle(tmp_path, monkeypatch) 
             assert blocked.status_code == 409
             assert blocked.json()["error"]["code"] == "agent_prepare_incomplete"
 
-        identity_headers = {ROLLOUT_ID_HEADER: ROLLOUT_ID, ATTEMPT_INDEX_HEADER: "0"}
-        straggler_headers = {ROLLOUT_ID_HEADER: STRAGGLER_ID, ATTEMPT_INDEX_HEADER: "0"}
+        identity_headers = {
+            ROLLOUT_ID_HEADER: ROLLOUT_ID,
+            ATTEMPT_INDEX_HEADER: "0",
+            RESOURCE_REQUEST_ID_HEADER: "seed-rollout",
+        }
+        straggler_headers = {
+            ROLLOUT_ID_HEADER: STRAGGLER_ID,
+            ATTEMPT_INDEX_HEADER: "0",
+            RESOURCE_REQUEST_ID_HEADER: "seed-straggler",
+        }
         assert (await resources.post("/seed_session", headers=identity_headers)).json() == {"value": 1}
         assert (await resources.post("/seed_session", headers=straggler_headers)).json() == {"value": 1}
         assert source_resources.revision_for(ROLLOUT_ID, 0) == 1
@@ -456,7 +465,11 @@ async def test_complete_partial_rollout_checkpoint_cycle(tmp_path, monkeypatch) 
         assert restored_resources.revision_for(ROLLOUT_ID, 1) == 1
         state_response = await resources.post(
             "/state",
-            headers={ROLLOUT_ID_HEADER: ROLLOUT_ID, ATTEMPT_INDEX_HEADER: "1"},
+            headers={
+                ROLLOUT_ID_HEADER: ROLLOUT_ID,
+                ATTEMPT_INDEX_HEADER: "1",
+                RESOURCE_REQUEST_ID_HEADER: "state-restored",
+            },
         )
         assert state_response.json() == {"value": 1}
 

--- a/tests/unit_tests/test_checkpoint_environment_adapters.py
+++ b/tests/unit_tests/test_checkpoint_environment_adapters.py
@@ -23,6 +23,7 @@ from nemo_gym._checkpoint import ResourceSnapshot
 from nemo_gym.base_resources_server import BaseResourcesServerConfig
 from nemo_gym.server_utils import ServerClient
 from resources_servers.blackjack.app import BlackjackEnv
+from resources_servers.example_multi_turn_gymnasium.app import ExampleMultiTurnEnv
 from resources_servers.example_session_state_mgmt.app import (
     StatefulCounterResourcesServer,
     StatefulCounterResourcesServerConfig,
@@ -57,19 +58,39 @@ async def test_counter_restores_under_replacement_attempt() -> None:
 
 
 @pytest.mark.asyncio
+async def test_counter_retire_removes_mapping_state_and_keeps_tombstone() -> None:
+    server = _server(StatefulCounterResourcesServer, StatefulCounterResourcesServerConfig)
+    server.execution_to_session[("rollout-a", 0)] = "session-a"
+    server.session_id_to_counter["session-a"] = 17
+    participant = server.checkpoint_participant()
+    participant.bind("rollout-a", 0)
+
+    await participant.retire_execution("rollout-a", 0)
+
+    assert ("rollout-a", 0) not in server.execution_to_session
+    assert "session-a" not in server.session_id_to_counter
+    assert participant.is_tombstoned("rollout-a", 0)
+    assert participant.status()["lock_entries"] == 0
+
+
+@pytest.mark.asyncio
 async def test_workplace_restores_every_dataframe_before_activation() -> None:
     server = _server(WorkbenchResourcesServer, WorkbenchResourcesServerConfig)
     server.execution_to_session[("rollout-a", 0)] = "session-a"
     server.session_id_to_tool_env["session-a"] = get_tools(_TOOLKITS)
     state = await server.export_checkpoint_state("rollout-a", 0)
+    snapshot = ResourceSnapshot(rollout_id="rollout-a", attempt_index=1, state_revision=2, state=state)
+    snapshot = ResourceSnapshot.model_validate_json(snapshot.model_dump_json())
 
-    await server.restore_checkpoint_states(
-        [ResourceSnapshot(rollout_id="rollout-a", attempt_index=1, state_revision=2, state=state)]
-    )
+    await server.restore_checkpoint_states([snapshot])
     restored = server.session_id_to_tool_env[server.execution_to_session[("rollout-a", 1)]]
     for name, frames in state["containers"].items():
         for attribute, payload in frames.items():
-            assert getattr(restored["containers"][name], attribute).to_json(orient="split") == payload
+            original = server.session_id_to_tool_env["session-a"]["containers"][name]
+            restored_frame = getattr(restored["containers"][name], attribute)
+            original_frame = getattr(original, attribute)
+            assert restored_frame.equals(original_frame)
+            assert type(restored_frame.index) is type(original_frame.index)
 
 
 @pytest.mark.asyncio
@@ -86,3 +107,17 @@ async def test_blackjack_restores_rng_position() -> None:
     )
     restored = server.session_state[server.execution_to_session[("rollout-a", 1)]]
     assert restored["rng"].choice(["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]) == expected_next
+
+
+def test_gymnasium_checkpoint_continuation_is_per_subclass_opt_in() -> None:
+    assert _server(BlackjackEnv, BaseResourcesServerConfig).checkpoint_state_enabled()
+    assert not _server(ExampleMultiTurnEnv, BaseResourcesServerConfig).checkpoint_state_enabled()
+
+
+def test_checkpoint_route_classification_defaults_unknown_posts_to_mutation() -> None:
+    server = _server(StatefulCounterResourcesServer, StatefulCounterResourcesServerConfig)
+    assert server.checkpoint_route_kind("/get_counter_value", "POST") == "read"
+    assert server.checkpoint_route_kind("/new_stateful_tool", "POST") == "mutation"
+    assert server.checkpoint_route_kind("/aggregate_metrics", "POST") is None
+    assert server.checkpoint_route_kind("/ng-control/v1/custom", "POST") is None
+    assert server.checkpoint_route_kind("/mcp", "POST") is None

--- a/tests/unit_tests/test_checkpoint_environment_adapters.py
+++ b/tests/unit_tests/test_checkpoint_environment_adapters.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Initial environment adapters preserve logical state across attempts."""
+
+import random
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_gym._checkpoint import ResourceSnapshot
+from nemo_gym.base_resources_server import BaseResourcesServerConfig
+from nemo_gym.server_utils import ServerClient
+from resources_servers.blackjack.app import BlackjackEnv
+from resources_servers.example_session_state_mgmt.app import (
+    StatefulCounterResourcesServer,
+    StatefulCounterResourcesServerConfig,
+)
+from resources_servers.workplace_assistant.app import (
+    _TOOLKITS,
+    WorkbenchResourcesServer,
+    WorkbenchResourcesServerConfig,
+    get_tools,
+)
+
+
+def _server(server_type, config_type):
+    config = config_type(host="", port=0, entrypoint="", name="resources")
+    client = MagicMock(spec=ServerClient)
+    client.global_config_dict = {}
+    return server_type(config=config, server_client=client)
+
+
+@pytest.mark.asyncio
+async def test_counter_restores_under_replacement_attempt() -> None:
+    server = _server(StatefulCounterResourcesServer, StatefulCounterResourcesServerConfig)
+    server.execution_to_session[("rollout-a", 0)] = "session-a"
+    server.session_id_to_counter["session-a"] = 17
+    state = await server.export_checkpoint_state("rollout-a", 0)
+
+    await server.restore_checkpoint_states(
+        [ResourceSnapshot(rollout_id="rollout-a", attempt_index=1, state_revision=3, state=state)]
+    )
+    restored_session = server.execution_to_session[("rollout-a", 1)]
+    assert server.session_id_to_counter[restored_session] == 17
+
+
+@pytest.mark.asyncio
+async def test_workplace_restores_every_dataframe_before_activation() -> None:
+    server = _server(WorkbenchResourcesServer, WorkbenchResourcesServerConfig)
+    server.execution_to_session[("rollout-a", 0)] = "session-a"
+    server.session_id_to_tool_env["session-a"] = get_tools(_TOOLKITS)
+    state = await server.export_checkpoint_state("rollout-a", 0)
+
+    await server.restore_checkpoint_states(
+        [ResourceSnapshot(rollout_id="rollout-a", attempt_index=1, state_revision=2, state=state)]
+    )
+    restored = server.session_id_to_tool_env[server.execution_to_session[("rollout-a", 1)]]
+    for name, frames in state["containers"].items():
+        for attribute, payload in frames.items():
+            assert getattr(restored["containers"][name], attribute).to_json(orient="split") == payload
+
+
+@pytest.mark.asyncio
+async def test_blackjack_restores_rng_position() -> None:
+    server = _server(BlackjackEnv, BaseResourcesServerConfig)
+    rng = random.Random(1234)
+    server.execution_to_session[("rollout-a", 0)] = "session-a"
+    server.session_state["session-a"] = {"player": ["10", "2"], "dealer": ["9", "7"], "rng": rng}
+    state = await server.export_checkpoint_state("rollout-a", 0)
+    expected_next = rng.choice(["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"])
+
+    await server.restore_checkpoint_states(
+        [ResourceSnapshot(rollout_id="rollout-a", attempt_index=1, state_revision=1, state=state)]
+    )
+    restored = server.session_state[server.execution_to_session[("rollout-a", 1)]]
+    assert restored["rng"].choice(["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]) == expected_next

--- a/tests/unit_tests/test_checkpoint_environment_adapters.py
+++ b/tests/unit_tests/test_checkpoint_environment_adapters.py
@@ -110,7 +110,11 @@ async def test_blackjack_restores_rng_position() -> None:
 
 
 def test_gymnasium_checkpoint_continuation_is_per_subclass_opt_in() -> None:
-    assert _server(BlackjackEnv, BaseResourcesServerConfig).checkpoint_state_enabled()
+    server = _server(BlackjackEnv, BaseResourcesServerConfig)
+    assert server.checkpoint_state_enabled()
+    assert server.checkpoint_route_kind("/reset", "POST") == "start"
+    assert server.checkpoint_route_kind("/step", "POST") == "mutation"
+    assert server.checkpoint_route_kind("/close", "POST") == "terminal"
     assert not _server(ExampleMultiTurnEnv, BaseResourcesServerConfig).checkpoint_state_enabled()
 
 

--- a/tests/unit_tests/test_checkpoint_generation_cut.py
+++ b/tests/unit_tests/test_checkpoint_generation_cut.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic generation-cut lifecycle and race tests."""
+
+import asyncio
+
+import pytest
+
+from nemo_gym._checkpoint import (
+    GATED_MODEL_ROUTE_SUFFIXES,
+    AdmissionLimiter,
+    AdmissionMiddleware,
+    GenerationCutInventory,
+    GenerationCutPrefix,
+    GenerationCutPrefixAck,
+    GenerationCutReceipt,
+    bind_current_model_call,
+    mark_current_generation_safe,
+    mark_current_generation_started,
+)
+from nemo_gym.token_id_capture import (
+    CaptureContext,
+    mark_external_staging_committed,
+    reset_token_sink,
+    set_token_sink,
+)
+
+
+class _FakeCutBackend:
+    def __init__(self, *, block: bool = False, disposition: str = "durable_prefix") -> None:
+        self.block = block
+        self.disposition = disposition
+        self.calls: list[GenerationCutInventory] = []
+        self.release = asyncio.Event()
+
+    async def checkpoint_generation_cut(self, inventory: GenerationCutInventory) -> GenerationCutReceipt:
+        self.calls.append(inventory)
+        if self.block:
+            await self.release.wait()
+        return GenerationCutReceipt(
+            checkpoint_id=inventory.checkpoint_id,
+            cut_id=f"cut-{len(self.calls)}",
+            inventory_digest=inventory.inventory_digest,
+            inventory=inventory,
+            backend_snapshot_id="snapshot-1",
+            prefixes=tuple(
+                GenerationCutPrefixAck(
+                    ticket_id=prefix.ticket_id,
+                    rollout_id=prefix.rollout_id,
+                    attempt_index=prefix.attempt_index,
+                    model_call_id=prefix.model_call_id,
+                    admitted_at=prefix.admitted_at,
+                    disposition=self.disposition,
+                    **(
+                        {
+                            "frozen_buffer_id": f"buffer/{prefix.ticket_id}",
+                            "staging_key": f"prefix/{prefix.ticket_id}",
+                            "prefix_token_count": 3,
+                            "prefix_digest": "a" * 64,
+                        }
+                        if self.disposition == "durable_prefix"
+                        else {}
+                    ),
+                )
+                for prefix in inventory.active_prefixes
+            ),
+        )
+
+    async def restore_generation_cut(self, receipt):
+        raise AssertionError("restore is not used by admission tests")
+
+
+def _scope() -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/responses",
+        "headers": [
+            (b"x-nemo-gym-rollout-id", b"rollout-1"),
+            (b"x-nemo-gym-attempt-index", b"0"),
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_pre_generation_ticket_waits_for_no_generation_exit() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    entered = asyncio.Event()
+    finish = asyncio.Event()
+    messages = []
+
+    async def app(scope, receive, send) -> None:
+        entered.set()
+        await finish.wait()
+        mark_current_generation_started()
+
+    async def send(message) -> None:
+        messages.append(message)
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, send))
+    await entered.wait()
+    limiter.close("ckpt-1")
+
+    assert not await limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=1)
+    assert backend.calls == []
+    assert limiter.counts()["generation_pending_total"] == 1
+
+    finish.set()
+    await task
+    assert limiter.state.value == "paused"
+    assert limiter.counts()["inflight_total"] == 0
+    assert messages[0]["status"] == 409
+    assert b"checkpoint_parked" in messages[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_mid_decode_buffer_cut_is_safe_before_response_exit() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    decoding = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def app(scope, receive, send) -> None:
+        bind_current_model_call("call-1")
+        mark_current_generation_started()
+        decoding.set()
+        await finish.wait()
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, None))
+    await decoding.wait()
+    limiter.close("ckpt-1")
+
+    assert await limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=1)
+    assert limiter.state.value == "paused"
+    assert limiter.counts()["response_inflight_total"] == 1
+    assert limiter.counts()["generation_pending_total"] == 0
+
+    finish.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_completed_capture_before_egress_is_prepare_safe() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    durable = asyncio.Event()
+    finish_response = asyncio.Event()
+
+    async def app(scope, receive, send) -> None:
+        mark_current_generation_started()
+        capture_token = set_token_sink(
+            CaptureContext(
+                rollout_id="rollout-1",
+                model_call_id="call-1",
+                token_sink=None,
+                external_staging=True,
+            )
+        )
+        try:
+            mark_external_staging_committed(rollout_id="rollout-1", model_call_id="call-1")
+        finally:
+            reset_token_sink(capture_token)
+        durable.set()
+        await finish_response.wait()
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, None))
+    await durable.wait()
+    limiter.close("ckpt-1")
+
+    assert limiter.state.value == "paused"
+    assert limiter.counts()["response_inflight_total"] == 1
+    assert backend.calls == []
+
+    finish_response.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_duplicate_cut_request_is_idempotent() -> None:
+    backend = _FakeCutBackend(block=True)
+    limiter = AdmissionLimiter(backend)
+    ticket = limiter.admit(rollout_id="r", attempt_index=0)
+    ticket.generation_started = True
+    ticket.model_call_id = "call-1"
+    limiter.close("ckpt-1")
+
+    first = asyncio.create_task(limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=1))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=1))
+    backend.release.set()
+
+    assert await first
+    assert await second
+    assert len(backend.calls) == 1
+    limiter.release(ticket)
+
+
+@pytest.mark.asyncio
+async def test_cut_timeout_leaves_ticket_pending_until_abort() -> None:
+    backend = _FakeCutBackend(block=True)
+    limiter = AdmissionLimiter(backend)
+    ticket = limiter.admit(rollout_id="r", attempt_index=2)
+    ticket.generation_started = True
+    ticket.model_call_id = "call-1"
+    limiter.close("ckpt-1")
+
+    assert not await limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=0.01)
+    assert limiter.state.value == "draining"
+    assert limiter.counts()["generation_pending_total"] == 1
+
+    limiter.abort_inflight("r", 2)
+    assert limiter.state.value == "draining"
+    assert limiter.counts()["response_inflight_total"] == 1
+    limiter.release(ticket)
+    assert limiter.state.value == "paused"
+
+
+@pytest.mark.asyncio
+async def test_durable_failure_is_safe_before_response_exit() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    failed = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def app(scope, receive, send) -> None:
+        mark_current_generation_started()
+        mark_current_generation_safe("durable_failure")
+        failed.set()
+        await finish.wait()
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, None))
+    await failed.wait()
+    limiter.close("ckpt-1")
+
+    assert limiter.state.value == "paused"
+    assert limiter.counts()["response_inflight_total"] == 1
+    finish.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_backend_can_ack_explicit_durable_failure() -> None:
+    backend = _FakeCutBackend(disposition="durable_failure")
+    limiter = AdmissionLimiter(backend)
+    ticket = limiter.admit(rollout_id="r", attempt_index=0)
+    ticket.generation_started = True
+    ticket.model_call_id = "call-1"
+    limiter.close("ckpt-1")
+
+    assert await limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=1)
+    assert ticket.prepare_safe_reason == "durable_failure"
+    limiter.release(ticket)
+
+
+@pytest.mark.asyncio
+async def test_close_before_response_start_fences_egress_until_resume() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    ready = asyncio.Event()
+    send_response = asyncio.Event()
+    messages = []
+
+    async def app(scope, receive, send) -> None:
+        bind_current_model_call("call-1")
+        mark_current_generation_started()
+        mark_current_generation_safe("durable_completed")
+        ready.set()
+        await send_response.wait()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"complete", "more_body": False})
+
+    async def send(message) -> None:
+        messages.append(message)
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, send))
+    await ready.wait()
+    limiter.close("ckpt-1")
+    send_response.set()
+    await asyncio.sleep(0)
+
+    assert limiter.state.value == "paused"
+    assert messages == []
+    assert not task.done()
+
+    limiter.resume()
+    await task
+    assert [message["type"] for message in messages] == ["http.response.start", "http.response.body"]
+
+
+@pytest.mark.asyncio
+async def test_response_start_before_close_forces_full_response_drain() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    messages = []
+
+    async def app(scope, receive, send) -> None:
+        bind_current_model_call("call-1")
+        mark_current_generation_started()
+        mark_current_generation_safe("durable_completed")
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        started.set()
+        await finish.wait()
+        await send({"type": "http.response.body", "body": b"complete", "more_body": False})
+
+    async def send(message) -> None:
+        messages.append(message)
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, send))
+    await started.wait()
+    limiter.close("ckpt-1")
+
+    assert not await limiter.prepare_generation_cut("ckpt-1", server_name="policy", timeout_s=1)
+    assert backend.calls == []
+    assert limiter.state.value == "draining"
+
+    finish.set()
+    await task
+    assert limiter.state.value == "paused"
+    assert [message["type"] for message in messages] == ["http.response.start", "http.response.body"]
+
+
+@pytest.mark.asyncio
+async def test_abort_cancels_response_waiting_at_egress_fence() -> None:
+    backend = _FakeCutBackend()
+    limiter = AdmissionLimiter(backend)
+    ready = asyncio.Event()
+    send_response = asyncio.Event()
+    messages = []
+
+    async def app(scope, receive, send) -> None:
+        bind_current_model_call("call-1")
+        mark_current_generation_started()
+        mark_current_generation_safe("durable_completed")
+        ready.set()
+        await send_response.wait()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    async def send(message) -> None:
+        messages.append(message)
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, send))
+    await ready.wait()
+    limiter.close("ckpt-1")
+    send_response.set()
+    await asyncio.sleep(0)
+    assert messages == []
+
+    limiter.abort_inflight("rollout-1", 0)
+    await task
+    assert messages[0]["status"] == 409
+    assert b"stale_attempt" in messages[1]["body"]
+    assert all(message.get("status") != 200 for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_abort_stays_pending_until_cancelled_task_exits() -> None:
+    limiter = AdmissionLimiter(_FakeCutBackend())
+    running = asyncio.Event()
+    cancellation_caught = asyncio.Event()
+    allow_exit = asyncio.Event()
+
+    async def app(scope, receive, send) -> None:
+        bind_current_model_call("call-1")
+        mark_current_generation_started()
+        mark_current_generation_safe("durable_completed")
+        running.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_caught.set()
+            mark_current_generation_safe("durable_failure")
+            await allow_exit.wait()
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, None))
+    await running.wait()
+    limiter.close("ckpt-1")
+    assert limiter.state.value == "paused"
+
+    limiter.abort_inflight("rollout-1", 0)
+    await cancellation_caught.wait()
+    assert not task.done()
+    assert not limiter.is_prepare_safe()
+    assert limiter.state.value == "draining"
+    assert limiter.counts()["generation_pending_total"] == 1
+
+    allow_exit.set()
+    await task
+    assert limiter.is_prepare_safe()
+    assert limiter.state.value == "paused"
+
+
+@pytest.mark.asyncio
+async def test_generated_return_without_egress_fails_closed() -> None:
+    limiter = AdmissionLimiter(_FakeCutBackend())
+    generated = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def app(scope, receive, send) -> None:
+        bind_current_model_call("call-1")
+        mark_current_generation_started()
+        generated.set()
+        await finish.wait()
+
+    task = asyncio.create_task(AdmissionMiddleware(app, limiter, GATED_MODEL_ROUTE_SUFFIXES)(_scope(), None, None))
+    await generated.wait()
+    limiter.close("ckpt-1")
+    finish.set()
+    await task
+
+    assert limiter.counts()["response_inflight_total"] == 0
+    assert limiter.counts()["generation_pending_total"] == 1
+    assert limiter.state.value == "draining"
+    assert limiter.abort_inflight("rollout-1", 0)
+    assert limiter.state.value == "paused"
+
+
+def test_receipt_rejects_logical_identity_different_from_inventory() -> None:
+    admitted = GenerationCutPrefix(
+        ticket_id="ticket-1",
+        rollout_id="rollout-1",
+        attempt_index=2,
+        model_call_id="call-1",
+        admitted_at=1.0,
+    )
+    inventory = GenerationCutInventory.build(
+        checkpoint_id="ckpt-1",
+        server_name="policy",
+        active_prefixes=[admitted],
+    )
+    ack = GenerationCutReceipt(
+        checkpoint_id="ckpt-1",
+        cut_id="cut-1",
+        inventory_digest=inventory.inventory_digest,
+        inventory=inventory,
+        backend_snapshot_id="snapshot-1",
+        prefixes=(
+            GenerationCutPrefixAck(
+                ticket_id="ticket-1",
+                rollout_id="rollout-1",
+                attempt_index=2,
+                model_call_id="wrong-call",
+                admitted_at=1.0,
+                disposition="durable_prefix",
+                frozen_buffer_id="buffer-1",
+                staging_key="staging-1",
+                prefix_token_count=3,
+                prefix_digest="c" * 64,
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="identity differs"):
+        ack.validate_for(inventory)


### PR DESCRIPTION
> [!NOTE]
> This checkpoint implementation is experimental. Its Python modules live under `nemo_gym._checkpoint`; they are not a supported public import surface yet.

## Summary
- add checkpoint adapters for Blackjack, session-state management, and Workplace Assistant
- require each environment subclass to opt into checkpoint continuation explicitly
- preserve RNG, counters, tabular state, and execution-to-session mappings
- add a cross-layer prepare, commit, restore, resume, lineage, and straggler-retirement test

## What this layer adds
The shared participant in #2945 controls admission, locking, revisions, files, and restore activation. Each environment still needs a codec that translates its own live session object into versioned serializable state. This PR supplies the first concrete adapters and demonstrates several state shapes.

```mermaid
flowchart LR
    C[Resources checkpoint participant] -->|export frozen session| G[Gymnasium base adapter]
    G --> B[Blackjack: environment state plus RNG position]
    C --> S[Session-state example: counter value]
    C --> W[Workplace Assistant: toolkit DataFrames]

    B --> M[Versioned ResourceSnapshot]
    S --> M
    W --> M
    M --> D[Controller-provided checkpoint directory]
    D --> V[Validate complete replacement set]
    V --> R[Restore sessions under attempt N+1]
    R --> X[Rebuild execution-to-session mappings]
```

The Gymnasium base deep-copies supported session state and tracks the mapping from `(rollout_id, attempt_index)` to the environment session. Checkpoint continuation defaults to disabled and each supported subclass opts in after defining its state contract. Blackjack adds explicit serialization for `random.Random`. The counter example persists its logical value. Workplace Assistant serializes and restores its pandas-backed tool state.

## Cross-layer recovery test
```mermaid
sequenceDiagram
    participant C as Checkpoint controller
    participant M as Policy model participant
    participant A as Agent participant
    participant R as Resources participant
    participant D as Controller-provided directory

    C->>M: pause and drain accepted generations
    C->>A: prepare active executions
    A-->>C: committed boundary or explicit blocker
    C->>R: prepare bound resource sessions
    C->>M: retire excluded straggler and commit
    C->>A: retire excluded straggler and commit
    C->>R: retire excluded straggler and commit
    M->>D: model-server lineage manifest
    A->>D: agent-instance boundary manifest
    R->>D: resources-server state manifest
    C->>M: restore attempt N+1 paused
    C->>A: restore attempt N+1 paused
    C->>R: restore attempt N+1 paused
    C->>M: explicit resume
    C->>A: explicit resume
    C->>R: explicit resume
    A->>M: first resumed call with attempt N parent
    A->>M: later call linked within attempt N+1
```

The test uses production participant and control-route implementations. It proves that the three manifests occupy separate namespaces, source attempts remain fenced, resources revisions survive restore, and the restored-parent relay applies only to the first policy call. `TransferQueue` durability and the training framework's controller remain simulated because they are outside this Gym stack.

## Stack
- depends on: [#2945](https://github.com/NVIDIA-NeMo/Gym/pull/2945)
- stack ends here

## Test plan
- [x] environment adapter tests
- [x] complete cross-participant checkpoint-cycle test
- [x] real two-worker Uvicorn admission simulation
- [x] scoped pre-commit checks

## Remaining integration work
- a training framework must provide durable rollout IDs and attempts, maintain its live-execution registry, and orchestrate prepare, commit, restore, and resume
- Gym production startup must launch and route the service-level coordinator before multi-worker checkpointing can be advertised
- the current model participant drains accepted generations; live prefix-cut recovery requires additional generation-worker and `TransferQueue` contracts
- durable acknowledgement and release of completed `/run` results belongs to the training-framework integration layer

## Generation-safe checkpoint update

- adds deterministic active-generation, abort, multi-worker, receipt-replay, and restore races
- validates complete agent/resources/model recovery across the initial adapters

Layer validation: 20 tests passed. Full stack validation: 624 tests passed; Ruff and formatting clean.