### PR TITLE
fix(cli): preserve table cells in redirected output

### DIFF
--- a/nemo_gym/cli/utils.py
+++ b/nemo_gym/cli/utils.py
@@ -116,22 +116,22 @@ def fuzzy_matches(query: str, *fields: str) -> bool:
 
 
 def print_rich_table(table) -> None:
-    """Print a Rich table without the 80-col truncation Rich applies when stdout is piped.
+    """Print a Rich table without truncating cells when standard output is piped.
 
-    On a TTY, Rich sizes the console to the terminal. When stdout is redirected (e.g.
-    `gym list benchmarks | cat`), Rich falls back to an 80-column console and truncates cells
-    with an ellipsis, silently losing data. We measure the table's natural width and render at
-    that width so piped output is lossless, while leaving interactive terminal output unchanged.
+    Rich normally renders redirected output with an 80-column console.
+    `FORCE_COLOR` can also make Rich report a pipe as a terminal.
+    Use the stream's actual TTY status so redirected output preserves every cell.
     """
 
     from rich.console import Console
 
     console = Console()
-    if not console.is_terminal:
-        # Rich clamps `measure()` to the measuring console's own width so we need to
-        # measure against an unbounded console to get the table's true natural width
-        natural_width = Console(width=10**6).measure(table).maximum
-        console = Console(width=natural_width)
+    if not console.file.isatty():
+        # Rich clamps measurements to the console width.
+        # An explicit height prevents TERM=dumb from replacing the requested width with 80.
+        height = console.height
+        natural_width = Console(width=10**6, height=height).measure(table).maximum
+        console = Console(width=natural_width, height=height)
     console.print(table)
 
 

--- a/tests/unit_tests/test_cli_utils.py
+++ b/tests/unit_tests/test_cli_utils.py
@@ -48,6 +48,7 @@ class TestPrintRichTable:
     def test_uses_default_console_on_tty(self) -> None:
         fake_console = MagicMock()
         fake_console.is_terminal = True
+        fake_console.file.isatty.return_value = True
         # `Console` is imported inside the function from `rich.console`, so patch it there.
         with patch("rich.console.Console", return_value=fake_console) as console_cls:
             table = _long_table()
@@ -57,9 +58,11 @@ class TestPrintRichTable:
         console_cls.assert_called_once_with()
         fake_console.print.assert_called_once_with(table)
 
-    def test_not_truncated_regardless_of_ambient_width(self, capsys, monkeypatch) -> None:
-        # Rich derives a non-TTY console's width from COLUMNS (falling back to 80). Whatever that
-        # ambient width is, the table must render at its natural width, never truncated to fit.
+    def test_not_truncated_when_force_color_misclassifies_pipe(self, capsys, monkeypatch) -> None:
+        # Rich treats FORCE_COLOR as enabled based on presence alone.
+        # TERM=dumb then ignores a requested width unless the height is also explicit.
+        monkeypatch.setenv("FORCE_COLOR", "0")
+        monkeypatch.setenv("TERM", "dumb")
         monkeypatch.setenv("COLUMNS", "10")
         print_rich_table(_long_table())
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary

Rich treats the presence of `FORCE_COLOR` as evidence that redirected output is a terminal. When `TERM=dumb` is also set, Rich replaces the requested table width with 80 columns and truncates long cell values.

- Detect redirected output from the standard output stream instead of Rich's color-aware terminal flag.
- Supply an explicit console height so Rich honors the measured table width on dumb terminals.
- Cover the `FORCE_COLOR=0`, `TERM=dumb`, and narrow `COLUMNS` combination that previously failed.

## Test plan

- [x] `uv run pytest tests/unit_tests/test_cli_utils.py tests/unit_tests/test_cli.py tests/unit_tests/test_cli_main.py -q`
- [x] `uv run pre-commit run --files nemo_gym/cli/utils.py tests/unit_tests/test_cli_utils.py`