### PR TITLE
fix(agents): recover from vLLM context errors

### DIFF
--- a/resources_servers/legal_agent_bench/legal_harbor_agent.py
+++ b/resources_servers/legal_agent_bench/legal_harbor_agent.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from nemo_gym.context_errors import is_context_overflow_error
 from resources_servers.legal_agent_bench.prepare import (
     DEFAULT_SKILLS_DIR,
     discover_harness_skills,
@@ -404,7 +405,7 @@ async def _run_agent_async(
             except Exception as exc:
                 err_msg = str(exc)
                 _log_model_error(transcript_file, turn_count, exc)
-                if _is_context_overflow_error(err_msg):
+                if is_context_overflow_error(exc):
                     context_overflow = True
                     break
                 model_error = err_msg
@@ -546,20 +547,6 @@ def _reasoning_effort(params: dict) -> str | None:
         effort = reasoning.get("effort")
         return str(effort) if effort else None
     return None
-
-
-def _is_context_overflow_error(message: str) -> bool:
-    lower = message.lower()
-    return any(
-        phrase in lower
-        for phrase in (
-            "prompt is too long",
-            "context_length_exceeded",
-            "context length",
-            "maximum input length",
-            "too many tokens",
-        )
-    )
 
 
 def _log_model_input(

--- a/resources_servers/legal_agent_bench/tests/test_harbor_integration.py
+++ b/resources_servers/legal_agent_bench/tests/test_harbor_integration.py
@@ -10,7 +10,7 @@ import time
 from asyncio import Semaphore
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from omegaconf import OmegaConf
@@ -20,6 +20,7 @@ from resources_servers.legal_agent_bench.legal_harbor_agent import (
     LegalAgentBenchHarborAgent,
     OpenAICompatibleAdapter,
     _chat_with_timeout,
+    _run_agent_async,
 )
 from resources_servers.legal_agent_bench.prepare import (
     EXPECTED_TASK_COUNT,
@@ -81,6 +82,31 @@ def test_folder_config_is_public_docker_only() -> None:
     assert agent["harbor_environment_type"] == "docker"
     assert agent["harbor_environment_import_path"] is None
     assert "docker_image" not in json.dumps(agent)
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_detects_context_overflow_in_response_content(tmp_path) -> None:
+    exc = RuntimeError("400, message='Bad Request'")
+    exc.response_content = b'{"error":{"message":"maximum context length is 512 tokens"}}'
+    adapter = MagicMock()
+    adapter.timeout_seconds = None
+    adapter.make_system_message.return_value = {"role": "system", "content": "system"}
+    adapter.make_user_message.return_value = {"role": "user", "content": "start"}
+    adapter.chat = AsyncMock(side_effect=exc)
+    tool_executor = MagicMock()
+    tool_executor.get_metrics.return_value = {}
+
+    result = await _run_agent_async(
+        adapter=adapter,
+        system_prompt="system",
+        tool_executor=tool_executor,
+        tools=[],
+        max_turns=1,
+        transcript_path=tmp_path / "transcript.jsonl",
+    )
+
+    assert result["context_overflow"] is True
+    assert result["model_error"] is None
 
 
 def test_pinned_snapshot_has_1749_tasks_and_five_committed_examples() -> None:

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -29,7 +29,6 @@ installed.
 import asyncio
 import json
 import logging
-import re
 import time
 from enum import Enum
 from typing import Any, List, Optional
@@ -50,6 +49,7 @@ from nemo_gym.base_responses_api_agent import (
     SimpleResponsesAPIAgent,
 )
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.context_errors import is_context_overflow_error
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -65,32 +65,6 @@ from nemo_gym.server_utils import get_response_json, raise_for_status
 logger = logging.getLogger(__name__)
 
 _MODEL_OUTPUT_TYPES = frozenset({"reasoning", "function_call"})
-
-# The model is reached over HTTP, so a context-window rejection arrives as error
-# text rather than a typed exception and has to be recognised by shape.
-_CONTEXT_OVERFLOW_RE = re.compile(
-    r"maximum context length is \d+ tokens|"
-    r"context length is (?:only )?\d+ tokens|"
-    r"maximum input length of \d+ tokens|"
-    r"Please reduce the length of the input|"
-    r"exceed.* context (limit|window|length)|"
-    r"context window exceeds|"
-    r"exceeds maximum length|"
-    r"too long.*tokens.*maximum|"
-    r"too large for model with \d+ maximum context length|"
-    r"longer than the model's context length|"
-    r"too many tokens.*size limit exceeded|"
-    r"prompt is too long|"
-    r"maximum prompt length|"
-    r"input length should be|"
-    r"sent message larger than max|"
-    r"input tokens exceeded|"
-    r"(messages?|total length).*too long|"
-    r"payload.*too large|"
-    r"string too long|"
-    r"input exceeded the context window",
-    re.IGNORECASE,
-)
 
 
 def _decoded_object(raw: str) -> Optional[dict]:
@@ -181,7 +155,7 @@ class FinanceAgent(SimpleResponsesAPIAgent):
     @staticmethod
     def _is_context_overflow_error(exc: Exception) -> bool:
         """True when *exc* indicates the input exceeded the model's context window."""
-        return _CONTEXT_OVERFLOW_RE.search(str(exc)) is not None
+        return is_context_overflow_error(exc)
 
     @staticmethod
     def _is_model_output(item: Any) -> bool:

--- a/responses_api_agents/finance_agent/tests/test_app.py
+++ b/responses_api_agents/finance_agent/tests/test_app.py
@@ -310,6 +310,11 @@ class TestContextOverflowDetection:
     def test_ignores_non_overflow(self, msg: str) -> None:
         assert not FinanceAgent._is_context_overflow_error(Exception(msg))
 
+    def test_detects_overflow_in_aiohttp_response_content(self) -> None:
+        exc = RuntimeError("400, message='Bad Request'")
+        exc.response_content = b'{"error":{"message":"maximum context length is 512 tokens"}}'
+        assert FinanceAgent._is_context_overflow_error(exc)
+
 
 # ---------------------------------------------------------------------------
 # Tests: _is_model_output

--- a/responses_api_agents/harbor_agent/custom_agents/llms/nemo_gym_llm.py
+++ b/responses_api_agents/harbor_agent/custom_agents/llms/nemo_gym_llm.py
@@ -31,20 +31,13 @@ from tenacity import (
     wait_exponential,
 )
 
+from nemo_gym.context_errors import is_context_overflow_error
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 
 
 _RoutedExperts = list[list[list[int]]] | str
 _RolloutDetailsKey = tuple[tuple[int, ...], tuple[int, ...], tuple[float, ...] | None]
 
-
-# Phrases in vLLM / OpenAI error bodies that signal context-length overflow.
-_CONTEXT_LENGTH_ERROR_PHRASES = (
-    "context length exceeded",
-    "context_length_exceeded",
-    "maximum context length",
-    "`inputs` tokens + `max_new_tokens`",
-)
 
 _THINK_OPEN = "<think>"
 _THINK_CLOSE = "</think>"
@@ -143,15 +136,6 @@ class NemoGymLLM(BaseLLM):
         payload.update(self._extra_chat_params)
 
         response_dict = await self._post_chat_completions(payload)
-
-        # Detect silently-swallowed context-length errors from the Gym proxy.
-        # When vLLM returns 400 "maximum context length", the proxy catches it
-        # and returns a fake 200 with id="chtcmpl-123" and content=None.
-        if response_dict.get("id") == "chtcmpl-123":
-            self.context_length_exceeded = True
-            raise ContextLengthExceededError(
-                f"Model {self._model_name} context length exceeded (detected fake response id='chtcmpl-123')"
-            )
 
         choices = response_dict.get("choices", [])
         choice = choices[0] if isinstance(choices, list) and choices else {}
@@ -284,8 +268,7 @@ class NemoGymLLM(BaseLLM):
         response = await self._http_client.post(endpoint, json=payload, timeout=timeout)
 
         if response.status_code >= 400:
-            error_text = response.text.lower()
-            if any(phrase in error_text for phrase in _CONTEXT_LENGTH_ERROR_PHRASES):
+            if is_context_overflow_error(response.text):
                 self.context_length_exceeded = True
                 raise ContextLengthExceededError(f"Model {self._model_name} context length exceeded: {response.text}")
             response.raise_for_status()

--- a/responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py
+++ b/responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py
@@ -235,7 +235,14 @@ async def test_context_length_error_propagates():
 
 
 @pytest.mark.asyncio
-async def test_context_length_error_from_http_400():
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        "maximum context length exceeded",
+        "max_completion_tokens=1024 cannot be greater than max_model_len=512",
+    ],
+)
+async def test_context_length_error_from_http_400(error_text):
     """HTTP 400 with context-length phrase raises ContextLengthExceededError."""
     llm = _make_llm()
     mock_client = AsyncMock()
@@ -244,7 +251,7 @@ async def test_context_length_error_from_http_400():
     mock_client.post = AsyncMock(
         return_value=httpx.Response(
             status_code=400,
-            text="maximum context length exceeded",
+            text=error_text,
             request=httpx.Request("POST", "http://localhost:8000/v1/chat/completions"),
         )
     )
@@ -255,11 +262,12 @@ async def test_context_length_error_from_http_400():
 
 
 @pytest.mark.asyncio
-async def test_fake_response_id_raises_context_length_error():
-    """Gym proxy returns fake 200 with id='chtcmpl-123' for context-length overflow."""
+async def test_synthetic_response_id_is_not_treated_as_context_length_error():
+    """A shared synthetic response ID does not identify the response's execution outcome."""
     llm = _make_llm()
-    with pytest.raises(ContextLengthExceededError, match="chtcmpl-123"):
-        await _call(llm, _mock_response(content=None, id="chtcmpl-123"), prompt="hello")
+    response, _ = await _call(llm, _mock_response(content=None, id="chtcmpl-123"), prompt="hello")
+    assert response.content == ""
+    assert llm.context_length_exceeded is False
 
 
 @pytest.mark.asyncio

--- a/responses_api_agents/kilocode_agent/README.md
+++ b/responses_api_agents/kilocode_agent/README.md
@@ -53,10 +53,10 @@ The shipped `context_window` (32768) and `max_output_tokens` (8192) assume a 32k
 Both need to match whatever you actually serve, and `max_output_tokens` is the one that bites: Kilo's
 system prompt and tool definitions run to roughly 10k tokens, so a large output budget pushes
 `prompt + max_tokens` past `max_model_len`. vLLM rejects that with a 400, which the Gym model server
-converts into an empty completion with `finish_reason: length` rather than an error. The run then
-produces no assistant message and scores zero, with nothing in the CLI's own output to say why. The
-agent logs a warning when it sees that shape; the fix is to lower `max_output_tokens` (or serve a
-larger window), not to raise it.
+preserves for the caller. Kilo logs the provider error and exits nonzero; the Gym agent currently pads
+the missing assistant output and returns a completed response, so evaluation typically records an empty
+answer and a zero rather than an HTTP failure. Lower `max_output_tokens` (or serve a larger window) to
+avoid that outcome.
 
 ### Calling a provider directly
 

--- a/responses_api_agents/kilocode_agent/app.py
+++ b/responses_api_agents/kilocode_agent/app.py
@@ -115,9 +115,8 @@ def parse_kilo_events(stdout: str) -> tuple[list[Any], dict[str, int]]:
             input_tokens += int(tokens.get("input") or 0) + int(cache.get("read") or 0)
             step_output = int(tokens.get("output") or 0)
             output_tokens += step_output
-            # Stopping on "length" with nothing generated is what an over-window request looks like by
-            # the time it reaches kilo; see KiloCodeAgentConfig.max_output_tokens. Warn once: the run
-            # is otherwise silent about why it produced no answer.
+            # Some providers report an exhausted output budget as a zero-output length stop instead
+            # of an HTTP error. Keep a diagnostic for that provider-side shape.
             if part.get("reason") == "length" and not step_output and not warned_empty_length:
                 warned_empty_length = True
                 LOG.warning(
@@ -243,12 +242,10 @@ class KiloCodeAgentConfig(BaseResponsesAPIAgentConfig):
     # `max_output_tokens` is the per-request output budget; kilo asks the model server for
     # min(this, its own OUTPUT_TOKEN_MAX of 32000), so values above 32000 have no effect.
     #
-    # Setting it too high fails silently, which is why the default is conservative. Kilo's system
-    # prompt and tool definitions run to ~10k tokens, and vLLM rejects prompt + max_tokens >
-    # max_model_len with a 400 that the Gym model server turns into an empty completion with
-    # finish_reason "length" (vllm_model/app.py `is_out_of_context_length`) rather than an error, so
-    # the run yields no assistant message at all. Raise it only alongside a model server whose window
-    # has room for it. Verified against @kilocode/cli 7.4.15 and vLLM serving a 32768-token window.
+    # Setting it too high causes vLLM to reject prompt + max_tokens > max_model_len with a 400.
+    # Keep the default conservative so Kilo's ~10k tokens of system prompt and tool definitions leave
+    # enough room for generation. Raise it only alongside a model server whose window has room for it.
+    # Verified against @kilocode/cli 7.4.15 and vLLM serving a 32768-token window.
     max_output_tokens: int = 8192
     # Response field carrying reasoning text, for kilo's `interleaved.field`. Gym model servers write
     # `reasoning_content` (vLLM >= 0.16 also sends `reasoning`, which is why this is configurable).

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -140,8 +140,7 @@ Stirrup's `ChatCompletionsClient` sends a static
 `max_completion_tokens = self._max_tokens` on every call.  For long-context
 models (Ultra V3, Qwen3-Coder-30B's 131K, etc.), this can exceed
 `max_model_len − prompt_tokens` once the prompt grows, and the server
-returns an HTTP 400 (or `finish_reason=length` with zero output) that the
-agent cannot recover from.
+returns an HTTP 400 that the upstream agent cannot recover from.
 
 The wrapper ships a `DynamicMaxTokensChatCompletionsClient`
 (`nemo_client.py`) that, on every request:
@@ -150,8 +149,10 @@ The wrapper ships a `DynamicMaxTokensChatCompletionsClient`
    `AutoTokenizer` loaded from `model_id`.
 2. Computes `max_completion_tokens = context_window − input_tokens − completion_token_buffer`.
 3. Replicates upstream's response parsing but does **not** raise
-   `ContextOverflowError` on `finish_reason=length`; the agent loop
-   terminates normally via the `finish` tool or `max_turns`.
+   `ContextOverflowError` on `finish_reason=length`.
+4. Converts a provider context-length HTTP 400 into Stirrup's
+   `ContextOverflowError`, which invokes Stirrup's built-in history unwind and
+   retry path when an imperfect estimate still exceeds the server window.
 
 Set `model_id` to the same checkpoint (or HF id) you are serving via
 vLLM and the tokeniser match is exact.  Leave it unset and the client

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -19,7 +19,7 @@ that break on long-context models served by vLLM:
 1. It sends ``max_completion_tokens = self._max_tokens`` with every call —
    a static value that does not account for the input size.  When the
    prompt consumes a non-trivial fraction of the model's context window,
-   the server can return ``finish_reason=length`` with zero output tokens.
+   the server can reject the request with a context-length HTTP 400.
 
 2. On any ``finish_reason in ("max_tokens", "length")`` it raises
    ``ContextOverflowError`` unconditionally, even when the response has
@@ -32,11 +32,11 @@ and size ``max_completion_tokens`` as::
 
     context_window − tokenized(messages) − completion_token_buffer
 
-clamped to a minimum of ``_MIN_COMPLETION_TOKENS``.  On the response
-side, we replicate Stirrup parsing but do *not* raise on
-``finish_reason=length`` — the agent loop will either terminate when the
-model invokes the ``finish`` tool or exhaust ``max_turns``, yielding a
-clean timeout instead of a crash.
+clamped to a minimum of ``_MIN_COMPLETION_TOKENS``.  On the response side,
+we replicate Stirrup parsing but do *not* raise on ``finish_reason=length``.
+If the estimate still undershoots and the provider rejects the request for
+context length, we raise Stirrup's ``ContextOverflowError`` so its built-in
+history unwind and retry path can recover.
 
 ``model_id`` selects the HuggingFace tokenizer (or local checkpoint path).
 When unset, a conservative character-count fallback is used.
@@ -49,9 +49,11 @@ from time import perf_counter
 from typing import Any, Optional
 
 import stirrup.core.agent as _stirrup_agent_mod
+from openai import BadRequestError
 from pydantic import ValidationError as _PydanticValidationError
 from stirrup.clients.chat_completions_client import ChatCompletionsClient
 from stirrup.clients.utils import to_openai_tools
+from stirrup.core.exceptions import ContextOverflowError
 from stirrup.core.models import (
     AssistantMessage,
     ChatMessage,
@@ -61,6 +63,7 @@ from stirrup.core.models import (
     ToolCall,
 )
 
+from nemo_gym.context_errors import is_context_overflow_error
 from nemo_gym.openai_utils import NeMoGymChatCompletionMessageParam
 from responses_api_agents.stirrup_agent.stirrup_utils import to_provider_openai_messages
 
@@ -349,6 +352,12 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
         request_start_time = perf_counter()
         try:
             response = await self._client.chat.completions.create(**request_kwargs)
+        except BadRequestError as exc:
+            if not is_context_overflow_error(exc):
+                LOGGER.error("API call raised %s: %s", type(exc).__name__, exc)
+                raise
+            LOGGER.warning("Model request exceeded the context window; asking Stirrup to unwind history.")
+            raise ContextOverflowError(str(exc)) from exc
         except Exception as exc:
             LOGGER.error("API call raised %s: %s", type(exc).__name__, exc)
             raise

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -23,6 +23,9 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from httpx import Request, Response
+from openai import BadRequestError
+from stirrup.core.exceptions import ContextOverflowError
 from stirrup.core.models import AssistantMessage, SystemMessage, TokenUsage, ToolCall, ToolMessage, UserMessage
 
 from responses_api_agents.stirrup_agent.nemo_agent import NeMoUserMessage
@@ -51,6 +54,11 @@ def _make_response(content: str = "ok"):
     response.usage.completion_tokens = 5
     response.usage.completion_tokens_details = None
     return response
+
+
+def _bad_request(message: str) -> BadRequestError:
+    response = Response(400, request=Request("POST", "http://test/v1/chat/completions"))
+    return BadRequestError(message, response=response, body={"message": message, "type": "BadRequestError"})
 
 
 @pytest.mark.asyncio
@@ -155,6 +163,49 @@ async def test_max_completion_tokens_cap_overrides_dynamic_size() -> None:
 
     sent = fake_create.await_args.kwargs
     assert sent["max_completion_tokens"] == 512
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "This model's maximum context length is 8192 tokens",
+        "max_completion_tokens=1024 cannot be greater than max_model_len=512",
+    ],
+)
+async def test_context_length_bad_request_triggers_stirrup_recovery(message: str) -> None:
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=10_000,
+        base_url="http://test",
+        api_key="k",
+    )
+    client._client = MagicMock()
+    client._client.chat.completions.create = AsyncMock(side_effect=_bad_request(message))
+
+    with pytest.raises(ContextOverflowError) as exc_info:
+        await client.generate([UserMessage(content="hi")], tools={})
+
+    assert message in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, BadRequestError)
+
+
+@pytest.mark.asyncio
+async def test_non_context_bad_request_still_raises() -> None:
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=10_000,
+        base_url="http://test",
+        api_key="k",
+    )
+    error = _bad_request("max_tokens must be at least 1")
+    client._client = MagicMock()
+    client._client.chat.completions.create = AsyncMock(side_effect=error)
+
+    with pytest.raises(BadRequestError) as exc_info:
+        await client.generate([UserMessage(content="hi")], tools={})
+
+    assert exc_info.value is error
 
 
 def test_defaults_match_pre_lift_behaviour() -> None:

--- a/responses_api_agents/terminus_2_agent/llm.py
+++ b/responses_api_agents/terminus_2_agent/llm.py
@@ -31,19 +31,13 @@ from tenacity import (
     wait_exponential,
 )
 
+from nemo_gym.context_errors import is_context_overflow_error
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 
 
 _RoutedExperts = list[list[list[int]]] | str
 _RolloutDetailsKey = tuple[tuple[int, ...], tuple[int, ...], tuple[float, ...] | None]
 
-
-_CONTEXT_LENGTH_ERROR_PHRASES = (
-    "context length exceeded",
-    "context_length_exceeded",
-    "maximum context length",
-    "`inputs` tokens + `max_new_tokens`",
-)
 
 _THINK_OPEN = "<think>"
 _THINK_CLOSE = "</think>"
@@ -127,13 +121,6 @@ class NemoGymLLM(BaseLLM):
         payload.update(self._extra_chat_params)
 
         response_dict = await self._post_chat_completions(payload)
-
-        # Gym's proxy uses this sentinel when it turns a vLLM context error into HTTP 200.
-        if response_dict.get("id") == "chtcmpl-123":
-            self.context_length_exceeded = True
-            raise ContextLengthExceededError(
-                f"Model {self._model_name} context length exceeded (detected fake response id='chtcmpl-123')"
-            )
 
         choices = response_dict.get("choices", [])
         choice = choices[0] if isinstance(choices, list) and choices else {}
@@ -245,8 +232,7 @@ class NemoGymLLM(BaseLLM):
         response = await self._http_client.post(endpoint, json=payload, timeout=timeout)
 
         if response.status_code >= 400:
-            error_text = response.text.lower()
-            if any(phrase in error_text for phrase in _CONTEXT_LENGTH_ERROR_PHRASES):
+            if is_context_overflow_error(response.text):
                 self.context_length_exceeded = True
                 raise ContextLengthExceededError(f"Model {self._model_name} context length exceeded: {response.text}")
             response.raise_for_status()

--- a/responses_api_agents/terminus_2_agent/tests/test_llm.py
+++ b/responses_api_agents/terminus_2_agent/tests/test_llm.py
@@ -207,7 +207,14 @@ async def test_context_length_error_propagates():
 
 
 @pytest.mark.asyncio
-async def test_context_length_error_from_http_400():
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        "maximum context length exceeded",
+        "max_completion_tokens=1024 cannot be greater than max_model_len=512",
+    ],
+)
+async def test_context_length_error_from_http_400(error_text):
     llm = _make_llm()
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -215,7 +222,7 @@ async def test_context_length_error_from_http_400():
     mock_client.post = AsyncMock(
         return_value=httpx.Response(
             status_code=400,
-            text="maximum context length exceeded",
+            text=error_text,
             request=httpx.Request("POST", "http://localhost:8000/v1/chat/completions"),
         )
     )
@@ -226,10 +233,11 @@ async def test_context_length_error_from_http_400():
 
 
 @pytest.mark.asyncio
-async def test_fake_response_id_raises_context_length_error():
+async def test_synthetic_response_id_is_not_treated_as_context_length_error():
     llm = _make_llm()
-    with pytest.raises(ContextLengthExceededError, match="chtcmpl-123"):
-        await _call(llm, _mock_response(content=None, id="chtcmpl-123"), prompt="hello")
+    response, _ = await _call(llm, _mock_response(content=None, id="chtcmpl-123"), prompt="hello")
+    assert response.content == ""
+    assert llm.context_length_exceeded is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

- replaces duplicated or sentinel-based context-overflow checks in Stirrup, Finance, Legal Agent Bench, Harbor, and Terminus with Gym's shared provider-error classifier
- inspects aiohttp `response_content`, which is not included in `ClientResponseError.__str__`, so real vLLM 400 bodies are recognized reliably
- maps a real overflow into each harness's existing recovery behavior: Stirrup unwinds history, Finance truncates when configured, Legal stops its loop, and Harbor/Terminus surface their context-limit exception
- removes KiloCode assumptions tied to the old synthetic `chatcmpl-123` success response and updates harness documentation

This PR contains only non-OpenCode harness and resources-server consumers. Its code depends on #2924; it is stacked above #2958 to keep the complete issue fix in one linear review and merge sequence.

## Stack

1. #2924 — vLLM adapter/core
2. #2958 — OpenCode recovery and integration coverage
3. **#2959 — remaining in-repo harness consumers (this PR)**

Review and merge bottom-up.

## Validation

- 184 focused tests passed across Legal Agent Bench, Finance, Harbor, KiloCode, Stirrup, and Terminus
- the complete implementation previously passed the repository unit suite with 4,080 passed and 112 skipped
- scoped pre-commit checks passed
- a real Stirrup client classified vLLM's current `cannot be greater than max_model_len` HTTP 400 as Stirrup `ContextOverflowError`

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally.
- [x] Scoped pre-commit checks pass locally.
- [x] All commits have DCO sign-off (`git commit -s`).
