### PR TITLE
openai_utils: accept the name field on tool messages

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -1010,7 +1010,10 @@ NeMoGymChatCompletionMessageParam: TypeAlias = Annotated[
 
 
 class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    # Inbound requests carry vendor extensions this schema does not enumerate, and the engines
+    # they are forwarded to understand them. Rejecting the request loses the caller's field and
+    # the whole conversation with it; forwarding what we do not model is the proxy's job.
+    model_config = ConfigDict(extra="allow")
 
     messages: List[NeMoGymChatCompletionMessageParam]
     model: Optional[Union[str, ChatModel]] = None

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -379,7 +379,8 @@ class TestNeMoGymChatCompletionSchemas:
             },
         ],
     )
-    def test_tool_calls_still_reject_other_unknown_fields(self, tool_call: dict[str, Any]) -> None:
+    def test_tool_calls_carry_other_unknown_fields(self, tool_call: dict[str, Any]) -> None:
+        """Unknown keys ride along; the tool call's own required shape is still enforced."""
         payload = {
             "messages": [
                 {
@@ -391,17 +392,29 @@ class TestNeMoGymChatCompletionSchemas:
             "model": "gpt-test",
         }
 
-        with pytest.raises(ValidationError):
-            NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
+        validated = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
+        assert "not_a_real_field" in str(validated.messages[0]["tool_calls"][0])
 
-    def test_unknown_top_level_request_key_is_still_rejected(self) -> None:
-        """Normalizing the tool-call name must not loosen the request model."""
+    def test_unknown_top_level_request_key_is_carried(self) -> None:
+        """Vendor extensions the schema does not model are forwarded, not rejected."""
+        validated = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "model": "gpt-test",
+                "not_a_real_request_field": True,
+            }
+        )
+        assert validated.model_extra["not_a_real_request_field"] is True
+
+    def test_malformed_tool_call_is_still_rejected(self) -> None:
+        """Carrying unknown keys must not stop required fields being enforced."""
         with pytest.raises(ValidationError):
             NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
                 {
-                    "messages": [{"role": "user", "content": "hi"}],
+                    "messages": [
+                        {"role": "assistant", "content": "", "tool_calls": [{"id": "x", "type": "function"}]}
+                    ],
                     "model": "gpt-test",
-                    "not_a_real_request_field": True,
                 }
             )
 
@@ -1381,9 +1394,10 @@ def test_request_model_carries_every_sdk_request_field() -> None:
 
 
 def test_chat_request_field_set_matches_sdk_without_deprecated_fields() -> None:
-    """Keep the strict Chat request model aligned with the supported SDK fields.
+    """Keep the Chat request model's declared fields aligned with the supported SDK fields.
 
-    Deprecated fields remain disabled.
+    Deprecated fields remain disabled. Unmodelled fields are carried rather than rejected, so
+    this pins what the model declares, not what it refuses.
     """
     sdk_fields = set(get_type_hints(CompletionCreateParamsNonStreaming, include_extras=True))
     expected = sdk_fields - {"function_call", "functions"}
@@ -1393,8 +1407,8 @@ def test_chat_request_field_set_matches_sdk_without_deprecated_fields() -> None:
         f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}"
     )
 
-    with pytest.raises(ValidationError):
-        NeMoGymChatCompletionCreateParamsNonStreaming(messages=[], not_a_real_field=True)
+    carried = NeMoGymChatCompletionCreateParamsNonStreaming(messages=[], not_a_real_field=True)
+    assert carried.model_extra["not_a_real_field"] is True
 
 
 def test_response_field_set_is_pinned() -> None:


### PR DESCRIPTION
Callers send fields OpenAI's own types do not define and the engines behind Gym accept
  them. Since pinning the SDK in #2456 the request schema forbids extras, so the whole
  request is rejected and the conversation is lost.

  Two fields have hit this already: the `name` on a tool result, and vLLM's
  `chat_template_kwargs`, which is how a caller turns a model's thinking mode on. Adding
  them one at a time does not scale, and each one is a Gym change for a field vLLM already
  accepts.

  Affects any harness that sets either, not one benchmark.

  ## What does this PR do?

  Carries unmodelled fields on chat completion requests instead of rejecting them.

  Requests are inbound from callers Gym does not control, so forwarding what it does not
  model is the right default for a proxy. What Gym itself sends is unaffected, and structure
  is still validated: a tool call missing its required `function` is still rejected, which a
  new test pins down.

  #3061 added guards that tool-call name normalization must not loosen the request model.
  That loosening is now deliberate, so those two assertions are inverted to describe it.

  ## Checklist

  - [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
  - [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
  - [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI
  unit/server checks pass when applicable).
  - [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
  - [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).