### PR TITLE
fix(vllm): optionally propagate context errors

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -178,7 +178,7 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     return_token_id_information: bool
     # Request inline prompt and generation token IDs from compatible vLLM endpoints.
     request_prompt_and_generation_token_ids: bool = False
-    propagate_context_overflow_errors: bool = True
+    propagate_context_overflow_errors: bool = False
 
     uses_reasoning_parser: bool
     uses_interleaved_reasoning: bool = True

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -24,7 +24,7 @@ from time import monotonic, time, time_ns
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
 from aiohttp.client_exceptions import ClientResponseError
-from fastapi import Request
+from fastapi import Request, Response
 from pydantic import Field, PrivateAttr, model_validator
 
 from nemo_gym.base_responses_api_model import (
@@ -75,6 +75,7 @@ from nemo_gym.token_id_capture.staging.records import (
 
 
 LOG = logging.getLogger("nemo_gym.vllm_model")
+_PROPAGATE_CONTEXT_ERROR_ATTRIBUTE = "nemo_gym_vllm_propagate_context_error"
 
 _TRANSPORT_LOG_CONTEXT_HEADERS = {
     "run_id": "x-nemo-gym-log-run-id",
@@ -177,6 +178,7 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     return_token_id_information: bool
     # Request inline prompt and generation token IDs from compatible vLLM endpoints.
     request_prompt_and_generation_token_ids: bool = False
+    propagate_context_overflow_errors: bool = True
 
     uses_reasoning_parser: bool
     uses_interleaved_reasoning: bool = True
@@ -294,6 +296,22 @@ class VLLMModel(SimpleResponsesAPIModel):
         "required_prefix_token_ids",
     )
     _external_capture_enabled: bool = PrivateAttr(default=False)
+
+    def setup_exception_middleware(self, app) -> None:
+        @app.middleware("http")
+        async def context_error_middleware(request: Request, call_next):
+            try:
+                return await call_next(request)
+            except ClientResponseError as error:
+                if getattr(error, _PROPAGATE_CONTEXT_ERROR_ATTRIBUTE, False):
+                    return Response(
+                        content=error.response_content,
+                        status_code=error.status,
+                        media_type="application/json",
+                    )
+                raise
+
+        super().setup_exception_middleware(app)
 
     def get_converter(self) -> "VLLMConverter":
         """Return the converter used for Responses API <-> Chat Completions mapping.
@@ -910,6 +928,9 @@ class VLLMModel(SimpleResponsesAPIModel):
                 "context length" in result_content_str or "max_tokens" in result_content_str
             )
             if is_out_of_context_length:
+                if self.config.propagate_context_overflow_errors:
+                    setattr(e, _PROPAGATE_CONTEXT_ERROR_ATTRIBUTE, True)
+                    raise
                 res = self._create_empty_chat_completion()
                 res.choices[0].finish_reason = "length"
                 return res
@@ -1362,6 +1383,9 @@ class VLLMModel(SimpleResponsesAPIModel):
                 "context length" in result_content_str or "max_tokens" in result_content_str
             )
             if is_out_of_context_length:
+                if self.config.propagate_context_overflow_errors:
+                    setattr(e, _PROPAGATE_CONTEXT_ERROR_ATTRIBUTE, True)
+                    raise
                 res = self._create_empty_chat_completion()
                 res.choices[0].finish_reason = "length"
                 return res

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any, Union
 from unittest.mock import AsyncMock, MagicMock
 
+from aiohttp import ClientResponseError
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch, mark, raises
 
@@ -761,7 +762,7 @@ PARAMETERIZE_DATA = [
 
 
 class TestApp:
-    def _setup_server(self, monkeypatch: MonkeyPatch):
+    def _setup_server(self, monkeypatch: MonkeyPatch, *, propagate_context_overflow_errors: bool = True):
         config = VLLMModelConfig(
             host="0.0.0.0",
             port=8081,
@@ -772,6 +773,7 @@ class TestApp:
             name="",
             return_token_id_information=False,
             uses_reasoning_parser=False,
+            propagate_context_overflow_errors=propagate_context_overflow_errors,
         )
 
         get_global_config_dict_mock = MagicMock()
@@ -781,7 +783,31 @@ class TestApp:
         return VLLMModel(config=config, server_client=MagicMock(spec=ServerClient, global_config_dict={}))
 
     async def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
-        self._setup_server(monkeypatch)
+        assert self._setup_server(monkeypatch).config.propagate_context_overflow_errors
+
+    @mark.parametrize("propagate", [False, True])
+    def test_context_overflow_propagation_flag(self, monkeypatch: MonkeyPatch, propagate: bool) -> None:
+        server = self._setup_server(monkeypatch, propagate_context_overflow_errors=propagate)
+        request_info = MagicMock(real_url="http://vllm.test/v1/chat/completions")
+        error = ClientResponseError(request_info, (), status=400, message="Bad Request")
+        error.response_content = b'{"error":{"message":"maximum context length","code":400}}'
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=error)
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"model": "dummy_model", "messages": [{"role": "user", "content": "hi"}], "stream": True},
+        )
+
+        if propagate:
+            assert response.status_code == 400
+            assert response.json() == {"error": {"message": "maximum context length", "code": 400}}
+        else:
+            assert response.status_code == 200
+            assert '"finish_reason": "length"' in response.text
 
     def test_session_client_routing_is_stable_across_workers(self, monkeypatch: MonkeyPatch) -> None:
         workers = [self._setup_server(monkeypatch) for _ in range(2)]

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -762,7 +762,7 @@ PARAMETERIZE_DATA = [
 
 
 class TestApp:
-    def _setup_server(self, monkeypatch: MonkeyPatch, *, propagate_context_overflow_errors: bool = True):
+    def _setup_server(self, monkeypatch: MonkeyPatch, *, propagate_context_overflow_errors: bool = False):
         config = VLLMModelConfig(
             host="0.0.0.0",
             port=8081,
@@ -783,7 +783,7 @@ class TestApp:
         return VLLMModel(config=config, server_client=MagicMock(spec=ServerClient, global_config_dict={}))
 
     async def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
-        assert self._setup_server(monkeypatch).config.propagate_context_overflow_errors
+        assert not self._setup_server(monkeypatch).config.propagate_context_overflow_errors
 
     @mark.parametrize("propagate", [False, True])
     def test_context_overflow_propagation_flag(self, monkeypatch: MonkeyPatch, propagate: bool) -> None:


### PR DESCRIPTION
## Summary

`VLLMModel` converts vLLM context-overflow HTTP 400 errors into an empty successful completion with `finish_reason: "length"`. Some OpenAI-compatible consumers, including OpenCode, expect the original HTTP 400 so they can trigger context compaction.

This change adds an adapter-local setting:

```yaml
policy_model:
  responses_api_models:
    vllm_model:
      propagate_context_overflow_errors: true
```

The setting defaults to `false`, preserving existing behavior and limiting the initial blast radius. Users can opt in where the consumer expects OpenAI-compatible HTTP 400 errors.

When enabled, context-overflow errors recognized by the existing vLLM adapter logic retain their original HTTP status and JSON body. The handling lives entirely in `VLLMModel`; shared model-server infrastructure is unchanged.

This works for `stream: true` on `/v1/chat/completions` because Gym completes the upstream vLLM call before creating its buffered SSE response. The same setting covers both internal vLLM backends: Chat Completions and Completions.

## Scope

- `responses_api_models/vllm_model/app.py`: add the setting and adapter-local propagation middleware.
- `responses_api_models/vllm_model/tests/test_app.py`: verify streaming legacy and propagation modes.

## Validation

- `pytest -q responses_api_models/vllm_model/tests/test_app.py`: 154 passed
- `pre-commit run --all-files`: passed
- Real vLLM Metal 0.28 with `mlx-community/Qwen2.5-0.5B-Instruct-4bit`:
  - setting `false`, streaming context overflow: HTTP 200 length SSE
  - setting `true`, streaming context overflow: HTTP 400 with upstream error body
- Full OpenCode/Gym eval suite: not run
