### PR TITLE
[Super 3.5 evals] Update Sep 02, 2026

### DIFF
--- a/benchmarks/nemotron_3.5_super/README.md
+++ b/benchmarks/nemotron_3.5_super/README.md
@@ -2,6 +2,8 @@
 - [Nemotron 3.5 Super Evaluation setup](#nemotron-35-super-evaluation-setup)
   - [Run production evals](#run-production-evals)
   - [Development commands](#development-commands)
+    - [vllm-router patch (decode-node cache imbalance)](#vllm-router-patch-decode-node-cache-imbalance)
+      - [Measured effect](#measured-effect)
     - [Build eval container](#build-eval-container)
     - [Launch vLLM](#launch-vllm)
     - [Interactive development on GPUs with Ray cluster](#interactive-development-on-gpus-with-ray-cluster)
@@ -15,6 +17,74 @@ Results will appear in that checkpoint folder.
 
 
 ## Development commands
+
+### vllm-router patch (decode-node cache imbalance)
+`build_eval_container.sh` requires `VLLM_ROUTER_WHEEL` and does **not** fall back to
+installing the released `vllm-router` wheel.
+
+The released router resets every worker's in-flight load counter from the registry
+health checker, every 10 health-check cycles -- 10 minutes at the default 60s
+interval. The `cache_aware` policy reads those counters to decide when to abandon
+prefix affinity in favour of shortest-queue routing, so the reset makes an
+already-saturated worker look idle. Under P/D disaggregation
+(`--vllm-pd-disaggregation --decode-policy cache_aware`, as used by
+`sbatch_external_vllm.sh`) that closes a feedback loop: the worker holding the hot
+prefixes keeps attracting requests, and shortest-queue never triggers to break it.
+
+Note the reset is *unconditional*. There is a second, dead copy of the same logic in
+`src/core/worker.rs` guarded by `max_load <= 2`; reading only that one leads to the
+wrong conclusion that the reset fired just when workers were idle and was therefore
+harmless. The one that actually ran, in `src/core/worker_registry.rs`, zeroed every
+worker every 10 cycles regardless of load.
+
+- bug: https://github.com/vllm-project/router/issues/197
+- fix: https://github.com/vllm-project/router/pull/216 (unmerged upstream)
+
+Build the wheel once with `build_vllm_router_wheel.sh`, then pass it to the container
+build. The wheel is built inside the eval base image, so its extension module matches
+the Python that runs `vllm-router` at eval time:
+
+```bash
+SBATCH_ACCOUNT=my-slurm-account \
+SBATCH_PARTITION=batch \
+SBATCH_QOS=interactive \
+SBATCH_GRES=gpu:4 \
+CONTAINER=/path/to/vllm/container \
+sbatch benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh
+# -> results/vllm_router/wheels/vllm_router-*.whl
+```
+
+The wheel's directory is mounted into the build automatically; it only has to live on
+storage the compute node can read.
+
+#### Measured effect
+
+Two SWE-bench Multilingual runs on the released router exhibited the runaway. Both
+are 2 prefill / 2 decode with 450 rollouts in parallel. Ratio is decode max/min
+running requests sampled per minute, over the minutes where the busiest decode node
+held at least 100 running; `starved` counts minutes where one node sat at ~0 running
+while its peer was busy:
+
+| run | router | loaded | starved | median | max | early -> late | max KV | max queued |
+|-----|--------|--------|---------|--------|-----|---------------|--------|------------|
+| 6800138 | stock 0.1.15 | 153m | 3 | 9.84 | 333.00 | 2.62 -> 103.50 | 100% | 224 |
+| 6794553 | stock 0.1.15 | 104m | 0 | 4.72 | 183.60 | 2.28 -> 37.92 | 99.8% | 207 |
+| 6802686 | #216 | 32m | 0 | 1.03 | 1.11 | 1.03 -> 1.02 | 27.8% | 0 |
+| 6803266 | #216 | 34m | 0 | 1.04 | 1.14 | 1.03 -> 1.04 | 27.5% | 0 |
+| 6803267 | #216 | 31m | 0 | 1.04 | 1.21 | 1.04 -> 1.02 | 27.7% | 0 |
+| 6803268 | #216 | 31m | 0 | 1.04 | 1.30 | 1.06 -> 1.04 | 28.7% | 0 |
+| 6803269 | #216 | 34m | 0 | 1.04 | 1.34 | 1.04 -> 1.06 | 27.9% | 0 |
+
+Both bad runs show the same signature: an even start that diverges monotonically
+(`early -> late`), ending with one decode node pinned near 100% KV cache with 200+
+requests queued while its peer drains toward idle. 6800138 stalled at 583/900
+rollouts. The patched runs stay flat, never queue, and hold KV below 29%.
+
+Not every run on the released router hits this -- it needs a sustained saturated
+decode regime -- so a clean run does not tell you which router you are on. Use the
+fingerprint above instead.
+
+
 ### Build eval container
 Example run:
 ```bash
@@ -22,6 +92,7 @@ SBATCH_ACCOUNT=my-slurm-account \
 SBATCH_PARTITION=batch \
 INPUT_CONTAINER=/path/to/vllm/container \
 OUTPUT_CONTAINER=/path/to/vllm/container___with_gym.sqsh \
+VLLM_ROUTER_WHEEL=/path/to/vllm_router/whl \
 MOUNTS=/path/to/env.yaml:/opt/Gym/env.yaml:x-create=file,/path/to/config.yaml:/opt/Gym/config.yaml:x-create=file \
 GYM_CONFIG=benchmarks/nemotron_3.5_super/eval_container_config.yaml \
 sbatch --gres=gpu:4 \

--- a/benchmarks/nemotron_3.5_super/build_eval_container.sh
+++ b/benchmarks/nemotron_3.5_super/build_eval_container.sh
@@ -10,6 +10,7 @@ INPUT_CONTAINER=$INPUT_CONTAINER
 OUTPUT_CONTAINER=$OUTPUT_CONTAINER
 MOUNTS=$MOUNTS
 GYM_CONFIG=$GYM_CONFIG
+VLLM_ROUTER_WHEEL=$VLLM_ROUTER_WHEEL
 NEMO_GYM_GIT_URL=${NEMO_GYM_GIT_URL:-https://github.com/NVIDIA-NeMo/Gym}
 NEMO_GYM_GIT_REF=${NEMO_GYM_GIT_REF:-main}
 TAU_2_MOUNT_BASE_GYM_DIR=${TAU_2_MOUNT_BASE_GYM_DIR:-""}
@@ -19,18 +20,30 @@ if [[ -n "$TAU_2_MOUNT_BASE_GYM_DIR" ]]; then
     MOUNTS="$MOUNTS,$TAU_2_MOUNT_BASE_GYM_DIR:$TAU_2_MOUNT_BASE_GYM_DIR"
 fi
 
+VLLM_ROUTER_WHEEL=$(readlink -f "$VLLM_ROUTER_WHEEL")
+MOUNTS="$MOUNTS,$(dirname "$VLLM_ROUTER_WHEEL"):$(dirname "$VLLM_ROUTER_WHEEL")"
+
+# pyxis --container-save exports the image when the step tears down, whatever the
+# inner script exited with, and it overwrites whatever already sits at the target.
+# So stage the build and publish only on success; otherwise a failed build silently
+# replaces a good container with a broken one.
+staged_container="$OUTPUT_CONTAINER.partial"
+rm -f "$staged_container"
+save_status=0
+
 srun --nodes=1 --ntasks=1 \
     --container-image=$INPUT_CONTAINER \
     --container-mounts=$MOUNTS \
     --no-container-mount-home \
-    --container-save=$OUTPUT_CONTAINER \
-    bash -s <<INNER_BUILD
+    --container-save="$staged_container" \
+    bash -s <<INNER_BUILD || save_status=$?
 set -xeuo pipefail
 
 # Hardlink, not clone to save space
 export UV_LINK_MODE=hardlink
 
-uv pip install --system vllm-router
+uv pip install --system --reinstall-package vllm-router "$VLLM_ROUTER_WHEEL"
+uv pip show --system vllm-router
 
 apt-get update
 apt-get install -y --no-install-recommends \
@@ -81,3 +94,11 @@ gym env start \
 
 echo ">>> Inner build complete. Container will now be packed into sqsh."
 INNER_BUILD
+
+if (( save_status != 0 )); then
+    rm -f "$staged_container"
+    echo "Build failed (exit $save_status). $OUTPUT_CONTAINER left untouched." >&2
+    exit "$save_status"
+fi
+mv -f "$staged_container" "$OUTPUT_CONTAINER"
+echo ">>> Published $OUTPUT_CONTAINER"

--- a/benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh
+++ b/benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+#SBATCH --output=slurm-logs/%j-%x.log
+#SBATCH --job-name=gym-build_vllm_router_wheel
+
+# Build a patched vllm-router wheel inside the eval base container.
+#
+# Why we do not just `uv pip install vllm-router`:
+#   The released router resets every worker's in-flight load counter from the
+#   registry health checker (every 10 health-check cycles). The cache-aware
+#   policy uses those counters to decide when to abandon prefix affinity for
+#   shortest-queue routing, so the reset makes a saturated worker look idle and
+#   requests keep piling onto it.
+#     bug: https://github.com/vllm-project/router/issues/197
+#     fix: https://github.com/vllm-project/router/pull/216 (unmerged upstream)
+#
+# This is the only place the router is built. build_eval_container.sh takes the
+# resulting wheel via its required VLLM_ROUTER_WHEEL input and asserts that what it
+# installs really carries the fix, so a container cannot be built with the bad
+# router by omission. The wheel is built inside the eval base image, so its
+# extension module matches the Python that runs vllm-router at eval time.
+#
+# Usage:
+#   SBATCH_ACCOUNT=... SBATCH_PARTITION=cpu SBATCH_QOS=cpu-short \
+#   CONTAINER=/path/to/vllm-openai.sqsh \
+#   sbatch benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh
+
+set -euo pipefail
+
+CONTAINER=$CONTAINER
+OUTPUT_DIR=${OUTPUT_DIR:-$(pwd)/results/vllm_router}
+VLLM_ROUTER_GIT_URL=${VLLM_ROUTER_GIT_URL:-https://github.com/vllm-project/router}
+# Head of vllm-project/router#216 ("[Bugfix]: Fix health checker to preserve
+# worker load during checks"). Fetching a bare SHA works because GitHub serves
+# any commit reachable from a ref, and PR heads are refs.
+VLLM_ROUTER_COMMIT=${VLLM_ROUTER_COMMIT:-9e6fce282a877c65185468692c6ba8a483409d9b}
+RUST_TOOLCHAIN=${RUST_TOOLCHAIN:-1.95.0}
+# Load-accounting unit tests from the fix. Compiling the test binary roughly
+# doubles the job, so it is opt-out.
+RUN_TESTS=${RUN_TESTS:-1}
+
+mkdir -p "$OUTPUT_DIR" slurm-logs
+
+srun --nodes=1 --ntasks=1 --cpus-per-task="${SLURM_CPUS_ON_NODE:-16}" \
+    --container-image="$CONTAINER" \
+    --container-mounts="$OUTPUT_DIR:/out" \
+    --no-container-mount-home \
+    bash -s <<INNER_BUILD
+set -xeuo pipefail
+
+echo ">>> Container baseline"
+cat /etc/os-release | head -3
+uname -m
+python3 -VV
+(uv pip show --system vllm-router 2>/dev/null || pip3 show vllm-router 2>/dev/null || echo "vllm-router not installed in base image")
+
+# ldconfig segfaults in this image on the cluster's 64K-page aarch64 kernels, so
+# the libc-bin dpkg trigger fails and apt returns non-zero even though every
+# package unpacked and configured fine. Ubuntu's glibc searches the multiarch
+# dirs without ld.so.cache, so a stale cache is harmless here; check that the
+# toolchain we asked for actually landed instead of trusting apt's exit code.
+apt_install() {
+    apt-get install -y --no-install-recommends "\$@" \
+        || { echo ">>> apt exited non-zero, re-running dpkg --configure"; dpkg --configure -a || true; }
+}
+require() {
+    local missing=0
+    for item in "\$@"; do
+        if [[ "\$item" == /* ]]; then
+            [[ -e "\$item" ]] || { echo "MISSING FILE: \$item" >&2; missing=1; }
+        else
+            command -v "\$item" > /dev/null || { echo "MISSING BINARY: \$item" >&2; missing=1; }
+        fi
+    done
+    return "\$missing"
+}
+
+# protobuf-compiler: opentelemetry-otlp's grpc-tonic feature runs protoc at build time.
+# libssl-dev/pkg-config: openssl-sys needs the headers. libzmq is vendored by zmq-sys.
+apt-get update
+apt_install build-essential pkg-config libssl-dev protobuf-compiler curl git ca-certificates
+require cc c++ pkg-config protoc curl git /usr/include/openssl/ssl.h
+rm -rf /var/lib/apt/lists/*
+
+# Cargo needs tens of GB of scratch; fall back to the mounted output dir when
+# the container's writable layer is small.
+build_root=/tmp/vllm-router-build
+mkdir -p "\$build_root"
+avail_kb=\$(df -Pk "\$build_root" | awk 'NR == 2 {print \$4}')
+if (( avail_kb < 25000000 )); then
+    echo ">>> /tmp has only \$((avail_kb / 1024)) MiB free, building under /out instead"
+    build_root=/out/build
+    rm -rf "\$build_root"
+    mkdir -p "\$build_root"
+fi
+export CARGO_HOME="\$build_root/cargo"
+export RUSTUP_HOME="\$build_root/rustup"
+export CARGO_TARGET_DIR="\$build_root/target"
+export PATH="\$CARGO_HOME/bin:\$PATH"
+# Reproducible CI-style builds; incremental only helps repeated local builds.
+export CARGO_INCREMENTAL=0
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --no-modify-path --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
+rustc --version
+cargo --version
+
+src="\$build_root/router"
+rm -rf "\$src"
+mkdir -p "\$src"
+cd "\$src"
+git init -q
+git remote add origin "$VLLM_ROUTER_GIT_URL"
+git fetch --depth 1 origin "$VLLM_ROUTER_COMMIT"
+git checkout -q FETCH_HEAD
+test "\$(git rev-parse HEAD)" = "$VLLM_ROUTER_COMMIT"
+echo ">>> Building vllm-router at \$(git rev-parse HEAD)"
+
+# Assert the fix is actually in this tree: the health checker must no longer
+# reset load counters. Guards against a moved/rewritten upstream ref.
+if grep -rn "LOAD_RESET_INTERVAL" src/; then
+    echo "ERROR: periodic load reset still present; expected vllm-project/router#216" >&2
+    exit 1
+fi
+
+if [[ "$RUN_TESTS" == "1" ]]; then
+    cargo test --lib -- \
+        core::worker::tests::test_worker_load_guard \
+        core::worker::tests::test_decrement_at_zero_clamps \
+        core::worker::tests::test_load_guard \
+        core::worker_registry::tests::test_health_checker_preserves
+fi
+
+# Build in a throwaway venv seeded from the container's own interpreter, so the
+# extension module matches the Python that will run vllm-router at eval time
+# without mutating the image's system site-packages. Mirrors the equivalent
+# section of build_eval_container.sh.
+buildenv="\$build_root/buildenv"
+rm -rf "\$buildenv"
+uv venv --python "\$(command -v python3)" "\$buildenv"
+VIRTUAL_ENV="\$buildenv" uv pip install setuptools wheel setuptools-rust build
+rm -rf dist
+"\$buildenv/bin/python" -m build --wheel --no-isolation --outdir dist
+
+mkdir -p /out/wheels
+cp dist/*.whl /out/wheels/
+ls -la /out/wheels
+
+echo ">>> Smoke test: install the freshly built wheel and start the router"
+uv pip install --system --force-reinstall /out/wheels/*.whl
+python3 -c "import vllm_router_rs; print('vllm_router_rs import OK')"
+vllm-router --help > /dev/null && echo "vllm-router --help OK"
+
+# The PR does not bump the version, so pip metadata cannot tell a patched router
+# from the stock 0.1.15 wheel. The compiled extension can: upstream carries the
+# periodic-reset log line, and only the fix carries the clamped-decrement warning.
+router_so=\$(python3 -c "import vllm_router_rs; print(vllm_router_rs.__file__)")
+if grep -aqF "Resetting worker loads (cycle" "\$router_so"; then
+    echo "ERROR: installed vllm-router still resets worker loads periodically" >&2
+    exit 1
+fi
+if ! grep -aqF "Attempted to decrement load counter that is already at 0" "\$router_so"; then
+    echo "ERROR: installed vllm-router is missing the #216 load-guard changes" >&2
+    exit 1
+fi
+echo ">>> vllm-router binary carries vllm-project/router#216"
+uv pip show --system vllm-router
+
+# The low-disk fallback puts build_root under the bind-mounted /out, where a
+# rustup toolchain, the cargo registry and both target profiles would otherwise
+# outlive the job on Lustre. Clean unconditionally; the wheel is already copied.
+rm -rf "\$build_root"
+
+echo ">>> Wheel build complete"
+INNER_BUILD

--- a/benchmarks/nemotron_3.5_super/policy_model_override.yaml
+++ b/benchmarks/nemotron_3.5_super/policy_model_override.yaml
@@ -2,6 +2,7 @@ policy_model:
   responses_api_models:
     vllm_model:
       sampling_overrides:
+        num_workers: 16
         max_output_tokens: null
         max_tokens: null
         max_completion_tokens: null

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -136,6 +136,8 @@ if (( SLURM_PROCID == 0 )); then
     router_args=( \
         --prefill-policy cache_aware \
         --decode-policy cache_aware \
+        --balance-abs-threshold 4 \
+        --balance-rel-threshold 1.1 \
         --vllm-pd-disaggregation \
         --host \$this_node_hostname \
         --port $ROUTER_SERVER_PORT \

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -47,6 +47,21 @@ logging.getLogger("opensandbox").setLevel(logging.WARNING)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
+class _MissingSandboxTerminateFilter(logging.Filter):
+    """Hide the SDK warning emitted when terminate reaches its desired state."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return not (
+            record.levelno == logging.WARNING
+            and message.startswith("Failed to terminate sandbox ")
+            and "[KUBERNETES::SANDBOX_NOT_FOUND]" in message
+        )
+
+
+logging.getLogger("opensandbox.adapters.sandboxes_adapter").addFilter(_MissingSandboxTerminateFilter())
+
+
 class OpenSandboxCreateError(SandboxCreateError):
     """Raised when OpenSandbox cannot create a sandbox."""
 

--- a/resources_servers/swebench/app.py
+++ b/resources_servers/swebench/app.py
@@ -39,13 +39,13 @@ from nemo_gym.global_config import get_global_config_dict
 from nemo_gym.rollout_observability import SandboxObservation
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
-from nemo_gym.sandbox.providers.base import SandboxPtySession
 from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import SESSION_ID_KEY
 from resources_servers.swebench.swebench_patches import (
     patch_swebench_multilingual_golden_patch_pass,
     patch_swebench_multilingual_log_parsing,
     patch_swebench_multilingual_sandbox,
+    patch_swebench_verified_env_vars,
     run_instance,
 )
 
@@ -236,7 +236,6 @@ class SWEBenchSeedSessionRequest(SWEBenchInstanceRequest, BaseSeedSessionRequest
 
 class SWEBenchSeedSessionResponse(BaseSeedSessionResponse):
     sandbox_handle: str  # @bxyu-nvidia: Just a plain string URI for now for OpenSandbox backend.
-    pty_session_id: str
 
 
 class SwebenchResourcesServer(SimpleResourcesServer):
@@ -245,7 +244,7 @@ class SwebenchResourcesServer(SimpleResourcesServer):
     def model_post_init(self, context: Any, /) -> None:
         super().model_post_init(context)
 
-        self._session_id_to_sandbox: Dict[str, Tuple[AsyncSandbox, SandboxPtySession]] = dict()
+        self._session_id_to_sandbox: Dict[str, AsyncSandbox] = dict()
 
     async def _create_sandbox(self, test_spec: TestSpec) -> AsyncSandbox:
         # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
@@ -260,6 +259,8 @@ class SwebenchResourcesServer(SimpleResourcesServer):
         env = dict(self.config.sandbox_config.get("env", {}))
         if self.config.sandbox_config.get("derive_cpu_env", True):
             env = cpu_cap_env(sandbox_resources.cpu) | env
+
+        patch_swebench_verified_env_vars(test_spec.repo, env)
 
         eval_sandbox_spec = SandboxSpec(
             image=test_spec.instance_image_key,
@@ -297,11 +298,7 @@ class SwebenchResourcesServer(SimpleResourcesServer):
     async def seed_session(self, request: Request, body: SWEBenchSeedSessionRequest) -> SWEBenchSeedSessionResponse:
         test_spec = self._make_test_spec(body)
         eval_sandbox = await self._create_sandbox(test_spec)
-        pty_session = await eval_sandbox.pty.create()
-        self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = (eval_sandbox, pty_session)
-
-        # @bxyu-nvidia: Activate the necessary conda environments for SWE Bench Verified Python instances
-        await eval_sandbox.pty.exec("source /opt/miniconda3/bin/activate && conda activate testbed")
+        self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox
 
         if self.config.apply_anti_cheating:
             # Remove the current Git repo's future history beyond the current commit to prevent the model from cheating.
@@ -318,9 +315,7 @@ Stdout:
 Stderr:
 {result.stderr}""")
 
-        return SWEBenchSeedSessionResponse(
-            sandbox_handle=eval_sandbox._handle.sandbox_id, pty_session_id=pty_session.session_id
-        )
+        return SWEBenchSeedSessionResponse(sandbox_handle=eval_sandbox._handle.sandbox_id)
 
     async def verify(self, request: Request, body: SWEBenchVerifyRequest) -> SWEBenchVerifyResponse:
         """
@@ -354,7 +349,7 @@ Stderr:
         if self.config.is_verifying_golden_patch:
             model_patch = body.patch
         else:
-            original_sandbox, original_pty_session = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
+            original_sandbox = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
             try:
                 original_workdir = (await eval_sandbox.exec("pwd")).stdout.strip()
                 model_patch_result = await original_sandbox.exec(f"cd {original_workdir} && git --no-pager diff")
@@ -362,7 +357,6 @@ Stderr:
             except:
                 print("Failed to extract patch from container", format_exc(), file=sys.stderr)
             try:
-                await original_pty_session.close()
                 await original_sandbox.stop()
             except:
                 print("Failed to stop original sandbox", format_exc(), file=sys.stderr)

--- a/resources_servers/swebench/swebench_patches.py
+++ b/resources_servers/swebench/swebench_patches.py
@@ -16,7 +16,7 @@
 This file contains patches copied from https://github.com/SWE-bench/SWE-bench/pull/630
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 # @bxyu-nvidia: We import wildcard because there are a million imports otherwise...
 from swebench.harness.constants import END_TEST_OUTPUT, MAP_REPO_TO_EXT, START_TEST_OUTPUT
@@ -254,6 +254,29 @@ async def run_instance(
             "completed": eval_completed,
             "resolved": report.get(instance_id, {}).get("resolved", False),
         }
+
+
+########################################
+# START SWE Bench Verified instance patches
+########################################
+
+
+def patch_swebench_verified_env_vars(repo: str, env: Dict[str, Any]) -> None:
+    if MAP_REPO_TO_EXT.get(repo) == "py":
+        # Activate the SWEBench Verified python conda environment
+        env["CONDA_EXE"] = "/opt/miniconda3/bin/conda"
+        env["_CE_M"] = ""
+        env["CONDA_PREFIX"] = "/opt/miniconda3/envs/testbed"
+        env["CONDA_PROMPT_MODIFIER"] = "(testbed) "
+        env["_CE_CONDA"] = ""
+        env["CONDA_SHLVL"] = "2"
+        env["SHLVL"] = "0"
+        env["CONDA_PYTHON_EXE"] = "/opt/miniconda3/bin/python"
+        env["CONDA_DEFAULT_ENV"] = "testbed"
+        env["PATH"] = (
+            "/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
+        env["CONDA_PREFIX_1"] = "/opt/miniconda3"
 
 
 ########################################

--- a/resources_servers/swebench/tests/test_app.py
+++ b/resources_servers/swebench/tests/test_app.py
@@ -152,9 +152,15 @@ class TestApp:
         derived = [name for name in CPU_CAP_ENV_VARS if name != "OMP_NUM_THREADS"]
         assert {name: spec.env[name] for name in derived} == {name: "2" for name in derived}
 
-        # Opt-out and no-cpu-limit paths keep env untouched.
-        assert (await created_spec({"resources": {"cpu": 2}, "derive_cpu_env": False})).env == {}
-        assert (await created_spec({"resources": {"memory_mib": 1024}})).env == {}
+        # Opt-out and no-cpu-limit paths omit only the derived caps; the
+        # SWE-bench Verified Python environment is applied independently.
+        for sandbox_config in (
+            {"resources": {"cpu": 2}, "derive_cpu_env": False},
+            {"resources": {"memory_mib": 1024}},
+        ):
+            spec = await created_spec(sandbox_config)
+            assert not set(CPU_CAP_ENV_VARS) & spec.env.keys()
+            assert spec.env["CONDA_DEFAULT_ENV"] == "testbed"
 
     def test_unobserved_response_omits_optional_field(self) -> None:
         response = SWEBenchVerifyResponse.model_construct(verifier_sandbox_observation=None)

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -24,7 +24,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.global_config import get_global_config_dict
-from nemo_gym.sandbox import AsyncSandbox, SandboxPtySession, SandboxResources, SandboxSpec
+from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import SESSION_ID_KEY
@@ -45,7 +45,6 @@ class TerminalBench21ResourcesServerConfig(BaseResourcesServerConfig):
 
 class TerminalBench21SeedSessionResponse(BaseSeedSessionResponse):
     sandbox_handle: str  # @bxyu-nvidia: Just a plain string URI for now for OpenSandbox backend.
-    pty_session_id: str
 
 
 class TerminalBench21SeedSessionRequest(BaseModel):
@@ -127,7 +126,7 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
     def model_post_init(self, context: Any, /) -> None:
         super().model_post_init(context)
 
-        self._session_id_to_sandbox: Dict[str, Tuple[AsyncSandbox, SandboxPtySession]] = dict()
+        self._session_id_to_sandbox: Dict[str, AsyncSandbox] = dict()
 
     def _patch_sandbox_provider_options_for_instances(
         self, task_name: str, resources: SandboxResources, provider_options: Dict[str, Any]
@@ -147,9 +146,7 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
                 "disk_gib": resources.disk_gib,
             }
 
-    async def _create_sandbox(
-        self, verify_request: TerminalBench21SeedSessionRequest
-    ) -> Tuple[AsyncSandbox, SandboxPtySession]:
+    async def _create_sandbox(self, verify_request: TerminalBench21SeedSessionRequest) -> AsyncSandbox:
         # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
         global_config_dict = get_global_config_dict()
         resolved_sandbox_provider = resolve_provider_config(self.config.sandbox_provider, global_config_dict)
@@ -188,19 +185,15 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
         eval_sandbox = AsyncSandbox(resolved_sandbox_provider)
         await eval_sandbox.start(eval_sandbox_spec)
 
-        pty_session = await eval_sandbox.pty.create()
-
-        return eval_sandbox, pty_session
+        return eval_sandbox
 
     async def seed_session(
         self, request: Request, body: TerminalBench21SeedSessionRequest
     ) -> TerminalBench21SeedSessionResponse:
-        eval_sandbox, pty_session = await self._create_sandbox(body)
-        self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox, pty_session
+        eval_sandbox = await self._create_sandbox(body)
+        self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox
 
-        return TerminalBench21SeedSessionResponse(
-            sandbox_handle=eval_sandbox._handle.sandbox_id, pty_session_id=pty_session.session_id
-        )
+        return TerminalBench21SeedSessionResponse(sandbox_handle=eval_sandbox._handle.sandbox_id)
 
     @contextmanager
     def _patch_golden_patch_solve_sh(
@@ -249,7 +242,7 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
         if self.config.is_verifying_golden_patch:
             if self.config.debug:
                 print(f"Creating eval sandbox for {body.task_name}", file=stderr)
-            eval_sandbox, pty_session = await self._create_sandbox(body)
+            eval_sandbox = await self._create_sandbox(body)
             cwd = (await eval_sandbox.exec("pwd")).stdout.strip()
             await self._upload_folder(
                 eval_sandbox, task_folder / "solution", cwd, GOLDEN_PATCH_SOLVE_SH_PATCHES, task_name=body.task_name
@@ -257,50 +250,55 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
 
             if self.config.debug:
                 print(f"Running golden patch for {body.task_name}", file=stderr)
-            golden_patch_result = await eval_sandbox.pty.exec(
-                f"bash {cwd}/solve.sh", session=pty_session, timeout_s=self.config.evaluation_timeout, detach=True
+            golden_patch_result = await eval_sandbox.exec(
+                f"bash {cwd}/solve.sh",
+                timeout_s=self.config.evaluation_timeout,
             )
-            # assert golden_patch_result.return_code == 0, (
-            #     f"Failed to apply golden patch for {body.task_name}: {golden_patch_result}"
-            # )
             golden_patch_output = (golden_patch_result.stderr or "") + (golden_patch_result.stdout or "")
             if self.config.debug:
                 print(f"Golden patch output for {body.task_name}: {golden_patch_output}", file=stderr)
         else:
-            # Re-use the original sandbox; attach(takeover=True) handles
-            # releasing and evicting the stale attachment from the agent phase.
-            eval_sandbox, pty_session = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
-            pty_session = await eval_sandbox.pty.attach(session_id=pty_session.session_id, takeover=True)
+            # Re-use the original sandbox
+            eval_sandbox = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
             golden_patch_output = None
 
         if self.config.debug:
             print(f"Running tests for {body.task_name}", file=stderr)
         start_time = time()
-        await self._upload_folder(eval_sandbox, task_folder / "tests", "/tests", TEST_SH_PATCHES, body.task_name)
-        eval_result = await eval_sandbox.pty.exec(
-            "bash /tests/test.sh", session=pty_session, timeout_s=self.config.evaluation_timeout, detach=True
-        )
+        try:
+            await self._upload_folder(eval_sandbox, task_folder / "tests", "/tests", TEST_SH_PATCHES, body.task_name)
+            eval_result = await eval_sandbox.exec(
+                "bash /tests/test.sh",
+                timeout_s=self.config.evaluation_timeout,
+            )
+            test_output = (eval_result.stderr or "") + (eval_result.stdout or "")
+        except:
+            print(f"Hit exception running TerminalBench 2.1 tests: {format_exc()}", file=stderr)
+            eval_result = None
+            test_output = ""
         verification_time_taken = time() - start_time
-        test_output = (eval_result.stderr or "") + (eval_result.stdout or "")
 
         if self.config.debug:
             print(f"Test output for {body.task_name}: {test_output}", file=stderr)
 
+        evaluation_completed = False
+        reward = 0.0
+        if eval_result is not None:
+            try:
+                with NamedTemporaryFile(mode="w+", suffix=".txt") as temp_file:
+                    await eval_sandbox.download("/logs/verifier/reward.txt", temp_file.name)
+                    temp_file.seek(0)
+                    reward = float(temp_file.read())
+
+                evaluation_completed = True
+            except:
+                if self.config.debug:
+                    print(f"Hit an exception downloading and converting reward: {format_exc()}", file=stderr)
+
         try:
-            with NamedTemporaryFile(mode="w+", suffix=".txt") as temp_file:
-                await eval_sandbox.download("/logs/verifier/reward.txt", temp_file.name)
-                temp_file.seek(0)
-                reward = float(temp_file.read())
-
-            evaluation_completed = True
+            await eval_sandbox.stop()
         except:
-            if self.config.debug:
-                print(f"Hit an exception downloading and converting reward: {format_exc()}", file=stderr)
-            evaluation_completed = False
-            reward = 0.0
-
-        await pty_session.close()
-        await eval_sandbox.stop()
+            print(f"Hit an exception stopping sandbox: {format_exc()}", file=stderr)
 
         return TerminalBench21VerifyResponse(
             **body.model_dump(),

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from shlex import quote
 from time import time
 from traceback import format_exc
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import Request
@@ -61,7 +61,6 @@ from nemo_gym.rollout_observability import (
 )
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec, create_provider
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
-from nemo_gym.sandbox.providers.base import SandboxPtySession
 from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import (
     SESSION_ID_KEY,
@@ -457,22 +456,19 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
     def model_post_init(self, context: Any, /) -> None:
         super().model_post_init(context)
 
-        self._sandbox_id_to_sandbox: Dict[str, Tuple[AsyncSandbox, SandboxPtySession]] = dict()
+        self._sandbox_id_to_sandbox: Dict[str, AsyncSandbox] = dict()
         self._sandbox_id_to_run_result: Dict[str, Dict[str, Any]] = dict()
 
-    async def _start_sandbox(
-        self, sandbox_id: Optional[str] = None, pty_session_id: Optional[str] = None
-    ) -> Tuple[AsyncSandbox, SandboxPtySession]:
+    async def _start_sandbox(self, sandbox_id: Optional[str] = None) -> AsyncSandbox:
         global_config_dict = get_global_config_dict()
         resolved_sandbox_provider = create_provider(
             resolve_provider_config(self.config.sandbox_provider, global_config_dict)
         )
         provider_default_metadata = resolve_provider_metadata(self.config.sandbox_provider, global_config_dict)
 
-        if sandbox_id and pty_session_id:
+        if sandbox_id:
             sandbox = await AsyncSandbox.connect({"sandbox_id": sandbox_id}, provider=resolved_sandbox_provider)
-            pty_session = await sandbox.pty.attach(session_id=pty_session_id, takeover=True)
-            return sandbox, pty_session
+            return sandbox
 
         if self.config.debug:
             print("Creating new sandbox since one wasn't provided", file=sys.stderr)
@@ -502,9 +498,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         sandbox = AsyncSandbox(resolved_sandbox_provider)
         await sandbox.start(sandbox_spec)
 
-        pty_session = await sandbox.pty.create()
-
-        return sandbox, pty_session
+        return sandbox
 
     def _agent_sandbox_observation(
         self,
@@ -656,7 +650,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
-        sandbox, pty_session = self._sandbox_id_to_sandbox[request.cookies["sandbox_id"]]
+        sandbox = self._sandbox_id_to_sandbox[request.cookies["sandbox_id"]]
 
         query = None
         # This can be modified to handle system/developer prompts too.
@@ -729,9 +723,8 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
 
         run_error_type = None
         try:
-            result = await sandbox.pty.exec(
+            result = await sandbox.exec(
                 command=command,
-                session=pty_session,
                 timeout_s=self.config.sandbox_timeout,
             )
         except Exception as exc:
@@ -755,10 +748,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
                 env=session_env,
             )
             if session_list_result.return_code != 0:
-                raise RuntimeError(
-                    "Failed to list OpenCode sessions: "
-                    f"{(session_list_result.stderr or session_list_result.stdout or '').strip()}"
-                )
+                raise RuntimeError(f"Failed to list OpenCode sessions: {session_list_result}")
             session_id = _extract_opencode_session_id(session_list_result.stdout or "")
             export_result = await sandbox.exec(
                 command=(
@@ -777,13 +767,13 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         results_dir: Path = Path(__file__).parent / "results" / request.session[SESSION_ID_KEY]
         results_dir.mkdir(parents=True, exist_ok=True)
         results_local_fpath = results_dir / export_fname
-        if self.config.debug:
-            print(f"Downloading results from {export_remote_fpath} to {results_local_fpath}", file=sys.stderr)
-        try:
-            await sandbox.download(export_remote_fpath, results_local_fpath)
-        except:
-            print(f"Failed to download export results to {results_local_fpath}", format_exc(), file=sys.stderr)
-            if export_result:
+        if export_result is not None and export_result.return_code == 0:
+            if self.config.debug:
+                print(f"Downloading results from {export_remote_fpath} to {results_local_fpath}", file=sys.stderr)
+            try:
+                await sandbox.download(export_remote_fpath, results_local_fpath)
+            except:
+                print(f"Failed to download export results to {results_local_fpath}", format_exc(), file=sys.stderr)
                 print("Export stdout:\n", export_result.stdout, file=sys.stderr)
                 print("Export stderr:\n", export_result.stderr, file=sys.stderr)
 
@@ -911,11 +901,10 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         # @bxyu-nvidia: "sandbox_handle" comes from resources_servers/swebench/app.py
         # Once we graduate to use the sandbox server, this will be in a generic seed_session type that can be model validated.
         seed_session_result = await seed_session_response.json()
-        sandbox, pty_session = await self._start_sandbox(
+        sandbox = await self._start_sandbox(
             sandbox_id=seed_session_result.get("sandbox_handle"),
-            pty_session_id=seed_session_result.get("pty_session_id"),
         )
-        self._sandbox_id_to_sandbox[request.session[SESSION_ID_KEY]] = (sandbox, pty_session)
+        self._sandbox_id_to_sandbox[request.session[SESSION_ID_KEY]] = sandbox
 
         # Propagating the sandbox handle
         cookies["sandbox_id"] = session_key
@@ -941,7 +930,6 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         await raise_for_status(verify_response)
 
         try:
-            await pty_session.close()
             await sandbox.stop()
         except Exception:
             print("Failed to stop sandbox", format_exc(), file=sys.stderr)

--- a/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
@@ -189,14 +189,15 @@ class TestOpenCodeSandboxedAgent:
         sandbox_mock = MagicMock()
         sandbox_mock.exec = AsyncMock(
             side_effect=[
-                SimpleNamespace(stdout="OpenCode run finished", stderr="", return_code=0, error_type=None),
+                SimpleNamespace(
+                    stdout="Shell: /bin/bash\nOpenCode run finished", stderr="", return_code=0, error_type=None
+                ),
+                SimpleNamespace(stdout='[{"id": "session-id"}]', stderr="", return_code=0, error_type=None),
                 SimpleNamespace(stdout="", stderr="", return_code=0, error_type=None),
-                SimpleNamespace(stdout="my dir"),
             ]
         )
         sandbox_mock.download = AsyncMock()
-        pty_mock = AsyncMock()
-        monkeypatch.setattr(server, "_sandbox_id_to_sandbox", {"": (sandbox_mock, pty_mock)})
+        monkeypatch.setattr(server, "_sandbox_id_to_sandbox", {"": sandbox_mock})
         monkeypatch.setattr(server, "_create_opencode_config", AsyncMock(return_value=dict()))
 
         monkeypatch.setattr(
@@ -458,6 +459,9 @@ class TestOpenCodeSandboxedAgent:
         sandbox._handle = SandboxHandle(sandbox_id="connected-sandbox", provider_name="opensandbox", raw=None)
         sandbox.exec = AsyncMock(
             side_effect=[
+                SimpleNamespace(
+                    stdout="Shell: /bin/bash\nOpenCode run finished", stderr="", return_code=0, error_type=None
+                ),
                 SimpleNamespace(stdout='[{"id": "session-id"}]', stderr="", return_code=0, error_type=None),
                 SimpleNamespace(stdout="", stderr="", return_code=0, error_type=None),
                 SimpleNamespace(stdout="", stderr="", return_code=0, error_type=None),
@@ -484,11 +488,7 @@ class TestOpenCodeSandboxedAgent:
 
         sandbox.download = AsyncMock(side_effect=download)
         sandbox.stop = AsyncMock(side_effect=RuntimeError("resource server already stopped the sandbox"))
-        sandbox.pty = AsyncMock()
-        sandbox.pty.exec.return_value = SimpleNamespace(
-            stdout="Shell: /bin/bash\nOpenCode run finished", stderr="", return_code=0, error_type=None
-        )
-        server._start_sandbox = AsyncMock(return_value=(sandbox, AsyncMock()))
+        server._start_sandbox = AsyncMock(return_value=sandbox)
         monkeypatch.setattr(
             "responses_api_agents.opencode_sandboxed_agent.app.__file__",
             str(tmp_path / "app.py"),
@@ -551,15 +551,15 @@ class TestOpenCodeSandboxedAgent:
         assert sandbox_records[0].wall_time_s is None
         assert "sandbox_lifecycle_timing_unavailable" in {gap.code for gap in result.ng_agent_observations.gaps}
         assert "sandbox_cleanup_failed" not in {gap.code for gap in result.ng_agent_observations.gaps}
-        session_list_env = sandbox.exec.await_args_list[0].kwargs["env"]
-        export_env = sandbox.exec.await_args_list[1].kwargs["env"]
+        session_list_env = sandbox.exec.await_args_list[1].kwargs["env"]
+        export_env = sandbox.exec.await_args_list[2].kwargs["env"]
         remote_data_home = session_list_env["XDG_DATA_HOME"]
         assert remote_data_home.startswith("/tmp/nemo-gym-opencode-")
-        assert f"XDG_DATA_HOME={remote_data_home}" in sandbox.pty.exec.await_args.kwargs["command"]
+        assert f"XDG_DATA_HOME={remote_data_home}" in sandbox.exec.await_args_list[0].kwargs["command"]
         assert export_env["XDG_DATA_HOME"] == remote_data_home
         assert (
             "opencode export session-id > /tmp/opencode_export.json"
-            in sandbox.exec.await_args_list[1].kwargs["command"]
+            in sandbox.exec.await_args_list[2].kwargs["command"]
         )
         assert not hasattr(request.state, "_ng_observation_invocation_id")
         assert server._sandbox_id_to_run_result == {}

--- a/responses_api_agents/terminus_2_sandboxed_agent/app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/app.py
@@ -40,7 +40,6 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.sandbox import AsyncSandbox, create_provider
 from nemo_gym.sandbox.config import resolve_provider_config
-from nemo_gym.sandbox.providers.base import SandboxPtySession
 from nemo_gym.server_utils import (
     SESSION_ID_KEY,
     get_response_json,
@@ -87,9 +86,8 @@ class Terminus2AgentVerifyResponse(BaseVerifyResponse):
 class NeMoGymSandboxEnvironment:
     """The Harbor environment surface used by Terminus 2, backed by AsyncSandbox."""
 
-    def __init__(self, sandbox: AsyncSandbox, logs_dir: Path, pty_session: SandboxPtySession, session_id: str):
+    def __init__(self, sandbox: AsyncSandbox, logs_dir: Path, session_id: str):
         self._sandbox = sandbox
-        self._pty_session = pty_session
         self.default_user = None
         self.trial_paths = SimpleNamespace(agent_dir=logs_dir)
         self.session_id = session_id
@@ -103,13 +101,7 @@ class NeMoGymSandboxEnvironment:
         env: dict[str, str] | None = None,
         **_: Any,
     ) -> Any:
-        if env is None:
-            result = await self._sandbox.pty.exec(command, session=self._pty_session, timeout_s=timeout_sec, cwd=cwd)
-        else:
-            raise NotImplementedError
-
-        if "new-session" in command:
-            print(f"Created new tmux session for {self.session_id}: {result}", file=sys.stderr)
+        result = await self._sandbox.exec(command, timeout_s=timeout_sec, cwd=cwd, user=user, env=env)
 
         return SimpleNamespace(
             stdout=result.stdout or "",
@@ -241,23 +233,21 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
 
     def model_post_init(self, context: Any, /) -> None:
         super().model_post_init(context)
-        self._session_sandboxes: dict[str, tuple[AsyncSandbox, SandboxPtySession]] = {}
+        self._session_sandboxes: dict[str, AsyncSandbox] = {}
 
         if not self.config.debug:
             harbor_logger.setLevel(logging.WARNING)
 
-    async def _connect_sandbox(self, sandbox_id: str, pty_session_id: str) -> tuple[AsyncSandbox, SandboxPtySession]:
+    async def _connect_sandbox(self, sandbox_id: str) -> AsyncSandbox:
         provider = create_provider(resolve_provider_config(self.config.sandbox_provider, get_global_config_dict()))
         sandbox = await AsyncSandbox.connect({"sandbox_id": sandbox_id}, provider=provider)
-        pty_session = await sandbox.pty.attach(session_id=pty_session_id, takeover=True)
-        return sandbox, pty_session
+        return sandbox
 
     async def _execute(
         self,
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming,
         sandbox: AsyncSandbox,
-        pty_session: SandboxPtySession | None,
     ) -> Tuple[NeMoGymResponse, bool]:
         instruction = _instruction(body.input)
 
@@ -273,9 +263,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         )
 
         with tempfile.TemporaryDirectory(prefix="nemo-gym-terminus-2-") as log_dir:
-            environment = NeMoGymSandboxEnvironment(
-                sandbox, Path(log_dir), pty_session, request.session[SESSION_ID_KEY]
-            )
+            environment = NeMoGymSandboxEnvironment(sandbox, Path(log_dir), request.session[SESSION_ID_KEY])
             context = AgentContext()
             agent = NeMoGymTerminus2(
                 logs_dir=Path(log_dir),
@@ -294,13 +282,12 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             await environment.exec("mkdir -p /logs/agent", user="root")
             if self.config.remote_tmux_binary_path:
                 # We add the /usr/local/bin path at the end to not supersede and pre-existing orderings.
-                tmux_install_result = await sandbox.pty.exec(
+                tmux_install_result = await sandbox.exec(
                     f"""mkdir -p /usr/local/bin \
 && cp {self.config.remote_tmux_binary_path} /usr/local/bin/tmux \
 && chmod +x /usr/local/bin/tmux \
 && export PATH=$PATH:/usr/local/bin \
 && tmux -V""",
-                    session=pty_session,
                 )
                 assert tmux_install_result.return_code == 0, tmux_install_result
             else:
@@ -316,6 +303,9 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
                 terminus2_completed = True
             except TimeoutError:
                 terminus2_completed = False
+            except:
+                terminus2_completed = False
+                print(f"Hit exception while running Terminus2: {format_exc()}", file=sys.stderr)
             finally:
                 await agent._session.stop()
 
@@ -340,8 +330,8 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
 
     async def responses(self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
         session_key = request.session[SESSION_ID_KEY]
-        sandbox, pty_session = self._session_sandboxes[session_key]
-        response, _ = await self._execute(request, body, sandbox, pty_session)
+        sandbox = self._session_sandboxes[session_key]
+        response, _ = await self._execute(request, body, sandbox)
         return response
 
     async def run(self, request: Request, body: Terminus2AgentRunRequest) -> Terminus2AgentVerifyResponse:
@@ -357,15 +347,12 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         seed_session_result = await seed_session_response.json()
 
         sandbox_id = seed_session_result["sandbox_handle"]
-        pty_session_id = seed_session_result["pty_session_id"]
 
-        sandbox, pty_session = await self._connect_sandbox(sandbox_id, pty_session_id)
+        sandbox = await self._connect_sandbox(sandbox_id)
         session_key = request.session[SESSION_ID_KEY]
-        self._session_sandboxes[session_key] = (sandbox, pty_session)
+        self._session_sandboxes[session_key] = sandbox
 
-        response, terminus2_completed = await self._execute(
-            request, body.responses_create_params, sandbox, pty_session
-        )
+        response, terminus2_completed = await self._execute(request, body.responses_create_params, sandbox)
 
         verification = await self.server_client.post(
             server_name=self.config.resources_server.name,
@@ -377,10 +364,9 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
 
         self._session_sandboxes.pop(session_key)
         try:
-            await pty_session.close()
             await sandbox.stop()
         except:
-            print(f"Hit an exception stopping sandbox in Terminus2: {format_exc()}")
+            print("Failed to stop sandbox", format_exc(), file=sys.stderr)
 
         result = await get_response_json(verification)
         result["terminus2_completed"] = terminus2_completed

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -35,23 +35,14 @@ def test_instruction_joins_text_content():
 
 @pytest.mark.asyncio
 async def test_sandbox_environment_adapts_exec_and_is_dir():
-    sandbox = SimpleNamespace(pty=SimpleNamespace())
-    pty_calls = []
     sandbox_calls = []
-
-    async def pty_exec(command, **kwargs):
-        pty_calls.append((command, kwargs))
-        return SimpleNamespace(stdout="output", stderr=None, return_code=0)
 
     async def sandbox_exec(command, **kwargs):
         sandbox_calls.append((command, kwargs))
-        return SimpleNamespace(stdout="", stderr=None, return_code=0)
+        return SimpleNamespace(stdout="output", stderr=None, return_code=0)
 
-    sandbox.pty.exec = pty_exec
-    sandbox.exec = sandbox_exec
-    environment = NeMoGymSandboxEnvironment(
-        sandbox, logs_dir=SimpleNamespace(), pty_session="seeded-pty", session_id="session-1"
-    )
+    sandbox = SimpleNamespace(exec=sandbox_exec)
+    environment = NeMoGymSandboxEnvironment(sandbox, logs_dir=SimpleNamespace(), session_id="session-1")
 
     result = await environment.exec("pwd", timeout_sec=12, user="root", cwd="/work")
 
@@ -59,27 +50,26 @@ async def test_sandbox_environment_adapts_exec_and_is_dir():
     assert result.stderr == ""
     assert result.return_code == 0
     assert await environment.is_dir("/workspace")
-    assert pty_calls == [("pwd", {"session": "seeded-pty", "timeout_s": 12, "cwd": "/work"})]
-    assert sandbox_calls == [('test -d "/workspace"', {"user": None})]
+    assert sandbox_calls == [
+        ("pwd", {"timeout_s": 12, "cwd": "/work", "user": "root", "env": None}),
+        ('test -d "/workspace"', {"user": None}),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_sandbox_environment_uses_seeded_pty_for_stateful_commands():
-    sandbox = SimpleNamespace(pty=SimpleNamespace())
+async def test_sandbox_environment_uses_sandbox_exec_for_stateful_commands():
     calls = []
 
-    async def pty_exec(command, **kwargs):
+    async def sandbox_exec(command, **kwargs):
         calls.append((command, kwargs))
         return SimpleNamespace(stdout="output", stderr=None, return_code=0)
 
-    sandbox.pty.exec = pty_exec
-    environment = NeMoGymSandboxEnvironment(
-        sandbox, logs_dir=SimpleNamespace(), pty_session="seeded-pty", session_id="session-1"
-    )
+    sandbox = SimpleNamespace(exec=sandbox_exec)
+    environment = NeMoGymSandboxEnvironment(sandbox, logs_dir=SimpleNamespace(), session_id="session-1")
 
     await environment.exec("tmux new-session")
 
-    assert calls == [("tmux new-session", {"session": "seeded-pty", "timeout_s": None, "cwd": None})]
+    assert calls == [("tmux new-session", {"timeout_s": None, "cwd": None, "user": None, "env": None})]
 
 
 def test_agent_implements_required_responses_endpoint():
@@ -186,7 +176,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         sandbox_calls.append((command, kwargs))
         return SimpleNamespace(stdout="", stderr="", return_code=0)
 
-    sandbox = SimpleNamespace(exec=sandbox_exec, pty=SimpleNamespace())
+    sandbox = SimpleNamespace(exec=sandbox_exec)
 
     class FakeTerminus:
         session = SimpleNamespace()
@@ -223,11 +213,6 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         n_output_tokens = None
         metadata = None
 
-    async def pty_exec(command, **kwargs):
-        sandbox_calls.append((command, kwargs))
-        return SimpleNamespace(stdout="", stderr="", return_code=0)
-
-    sandbox.pty.exec = pty_exec
     monkeypatch.setattr(app_module, "NeMoGymTerminus2", FakeTerminus)
     monkeypatch.setattr(app_module, "AgentContext", FakeContext)
     monkeypatch.setattr(Terminus2Agent, "base_url_for_run", lambda *_args, **_kwargs: "http://model")
@@ -241,7 +226,6 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         request,
         NeMoGymResponseCreateParamsNonStreaming(input="solve this"),
         sandbox,
-        "seeded-pty",
     )
 
     assert terminus2_completed is True
@@ -253,7 +237,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
     else:
         set_level.assert_not_called()
     assert sandbox_calls == [
-        ("mkdir -p /logs/agent", {"session": "seeded-pty", "timeout_s": None, "cwd": None}),
-        ("tmux setup", {"session": "seeded-pty", "timeout_s": None, "cwd": None}),
-        ("tmux run", {"session": "seeded-pty", "timeout_s": None, "cwd": None}),
+        ("mkdir -p /logs/agent", {"timeout_s": None, "cwd": None, "user": "root", "env": None}),
+        ("tmux setup", {"timeout_s": None, "cwd": None, "user": None, "env": None}),
+        ("tmux run", {"timeout_s": None, "cwd": None, "user": None, "env": None}),
     ]

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -95,6 +95,23 @@ def test_sdk_info_logs_are_silenced(caplog: pytest.LogCaptureFixture) -> None:
     assert sdk_messages == ["SDK warning"]
 
 
+def test_sdk_missing_sandbox_terminate_warning_is_silenced(caplog: pytest.LogCaptureFixture) -> None:
+    sdk_logger = logging.getLogger("opensandbox.adapters.sandboxes_adapter")
+
+    with caplog.at_level(logging.WARNING):
+        sdk_logger.warning(
+            "Failed to terminate sandbox sandbox-1: Kill sandbox sandbox-1 failed: [KUBERNETES::SANDBOX_NOT_FOUND]"
+        )
+        sdk_logger.warning("Failed to terminate sandbox sandbox-2: backend unavailable")
+        sdk_logger.warning("Sandbox sandbox-3 not found | [KUBERNETES::SANDBOX_NOT_FOUND]")
+
+    sdk_messages = [record.message for record in caplog.records if record.name == sdk_logger.name]
+    assert sdk_messages == [
+        "Failed to terminate sandbox sandbox-2: backend unavailable",
+        "Sandbox sandbox-3 not found | [KUBERNETES::SANDBOX_NOT_FOUND]",
+    ]
+
+
 def test_sdk_import_helpers_and_retry_classification() -> None:
     assert len(opensandbox_provider._require_opensandbox_sdk()) == 5
     assert len(opensandbox_provider._require_tenacity()) == 4


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. Swap to no pty: resources_servers/swebench/app.py, resources_servers/swebench/swebench_patches.py, resources_servers/terminal_bench_2_1/app.py, responses_api_agents/opencode_sandboxed_agent/tests/test_app.py, responses_api_agents/opencode_sandboxed_agent/app.py, responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py, responses_api_agents/terminus_2_sandboxed_agent/app.py
2. vLLM router health check counter fix (see https://github.com/NVIDIA-NeMo/Gym/pull/2952): benchmarks/nemotron_3.5_super/build_eval_container.sh, benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh, benchmarks/nemotron_3.5_super/README.md, benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
3. Increase default vllm_model workers: benchmarks/nemotron_3.5_super/policy_model_override.yaml
4. Silence no-op termination logging from OpenSandbox: nemo_gym/sandbox/providers/opensandbox/provider.py, tests/unit_tests/test_opensandbox_provider.py

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
