### PR TITLE
[6667815] Surface nested HTTP errors and reject incompatible LibriSpeech model adapters

### DIFF
--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -440,11 +440,11 @@ ENVIRONMENT = _asset_selector("environment")
 RESOURCES_SERVER_CONFIG = _asset_selector("resources-server")
 MODEL_TYPE = _asset_selector("model-type")
 
-# Override for the verifier-side `allowed_agents` guard. Offered wherever --agent-type composes.
+# Override for verifier-side agent/model compatibility guards. Offered wherever runtime configs compose.
 ALLOW_UNSUPPORTED_PAIRING = _bool_flag(
     "allow-unsupported-pairing",
     "allow_unsupported_pairing",
-    "Run even if the environment's resources server does not declare support for the selected agent.",
+    "Run even if the environment's resources server does not declare support for the selected agent or model type.",
 )
 
 AGENT_TYPE = Flag(

--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -188,6 +188,10 @@ class UnsupportedAgentPairingError(ConfigError, ValueError):
     """The selected agent is not one the environment's resources server declares support for."""
 
 
+class UnsupportedModelPairingError(ConfigError, ValueError):
+    """The selected model server is not one the environment's resources server declares support for."""
+
+
 class UnsupportedAgentOverrideError(ConfigError, ValueError):
     """A command line override configures an agent that no instance ends up running."""
 

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -51,6 +51,7 @@ from nemo_gym.config_types import (
     ServerRefNotFoundError,
     UnsupportedAgentOverrideError,
     UnsupportedAgentPairingError,
+    UnsupportedModelPairingError,
     is_almost_server,
     is_server_ref,
     maybe_get_server_instance_config,
@@ -157,6 +158,9 @@ AGENT_SERVER_TYPE_KEY_NAME = "responses_api_agents"
 _COMPOSED_AGENT_CARRY_OVER_KEYS = ("resources_server", "model_server", "datasets")
 # Declared on a resources server: the agent types it is known to score correctly. Absent means any harness.
 ALLOWED_AGENTS_KEY_NAME = "allowed_agents"
+# Declared on a resources server: the model adapter types that can carry its workload. Absent means any adapter.
+ALLOWED_MODEL_TYPES_KEY_NAME = "allowed_model_types"
+MODEL_SERVER_TYPE_KEY_NAME = "responses_api_models"
 RESOURCES_SERVER_TYPE_KEY_NAME = "resources_servers"
 
 
@@ -577,6 +581,73 @@ Duplicate config paths:
         """
         reference = OmegaConf.select(server_config, "resources_server")
         return reference if isinstance(reference, DictConfig) else None
+
+    @staticmethod
+    def _model_server_reference(server_config: DictConfig) -> Optional[DictConfig]:
+        """The agent's `model_server` block, or None when it declares none."""
+        reference = OmegaConf.select(server_config, "model_server")
+        return reference if isinstance(reference, DictConfig) else None
+
+    def raise_on_unsupported_model_pairings(self, global_config_dict: DictConfig) -> None:
+        """Reject resource/model bindings that explicitly disallow the selected model adapter.
+
+        This runs while parsing the merged config, before Ray or any server subprocess starts. A resources
+        server opts in with ``allowed_model_types``; existing configs that do not declare it stay unrestricted.
+        """
+        if pairing_override_enabled(global_config_dict):
+            return
+
+        restrictions: List[List[str]] = []
+        rejected: List[Tuple[_AgentInstance, str, str, str, List[str]]] = []
+        for agent in self._agent_instances(global_config_dict):
+            resources_reference = self._resources_server_reference(agent.server_config)
+            if not resources_reference or resources_reference.get("type") != RESOURCES_SERVER_TYPE_KEY_NAME:
+                continue
+            resources_server_name = resources_reference.get("name")
+            allowed = allowed_model_types_for(global_config_dict, resources_server_name)
+            if allowed is None:
+                continue
+
+            model_reference = self._model_server_reference(agent.server_config)
+            if not model_reference or model_reference.get("type") != MODEL_SERVER_TYPE_KEY_NAME:
+                continue
+            model_server_name = model_reference.get("name")
+            model_type = model_type_for(global_config_dict, model_server_name)
+            # ``dummy_model`` is injected for parser clients that only need benchmark data or static config
+            # inspection (for example, ``gym eval prepare``). It is not a runtime model selection.
+            if model_type is None or model_type == "dummy_model":
+                continue
+
+            restrictions.append(allowed)
+            if model_type not in allowed:
+                rejected.append((agent, str(resources_server_name), str(model_server_name), model_type, allowed))
+
+        if not rejected:
+            return
+
+        rejected_list = "\n".join(
+            f"  - agent '{agent.name}' uses model server '{model_server_name}' (type '{model_type}'), "
+            f"but resources server '{resources_server_name}' accepts only: {', '.join(allowed)}"
+            for agent, resources_server_name, model_server_name, model_type, allowed in rejected
+        )
+        supported = [
+            model_type
+            for model_type in restrictions[0]
+            if all(model_type in restriction for restriction in restrictions[1:])
+        ]
+        if supported:
+            remedy = (
+                f"Select a compatible model adapter (for example, --model-type {supported[0]}). "
+                f"Supported model types: {', '.join(supported)}."
+            )
+        else:
+            remedy = "No single model type satisfies all of these resources servers."
+        raise UnsupportedModelPairingError(
+            "The selected Gym model-server adapter is not compatible with this workload:\n"
+            f"{rejected_list}\n\n"
+            f"{remedy} Or pass --allow-unsupported-pairing (or set "
+            f"{ALLOW_UNSUPPORTED_PAIRING_ENV_VAR_NAME}=1) to bypass the check."
+        )
 
     def _runs_against_a_resources_server(self, server_config: DictConfig) -> bool:
         """True when the agent has a task to hand over, so another agent can take its place.
@@ -1084,6 +1155,7 @@ Found global config dict yaml:
                 raise AlmostServerError(error_msg)
 
         server_instance_configs = self.filter_for_server_instance_configs(global_config_dict)
+        self.raise_on_unsupported_model_pairings(global_config_dict)
 
         with open_dict(global_config_dict):
             use_absolute_ip = global_config_dict.setdefault(USE_ABSOLUTE_IP, False)
@@ -1386,8 +1458,43 @@ def allowed_agents_for(global_config_dict: DictConfig, resources_server_name: Op
     return [str(name) for name in declared]
 
 
+def allowed_model_types_for(
+    global_config_dict: DictConfig, resources_server_name: Optional[str]
+) -> Optional[List[str]]:
+    """The model adapter types `resources_server_name` declares support for, or None when unrestricted."""
+    instance = global_config_dict.get(resources_server_name) if resources_server_name else None
+    if not isinstance(instance, DictConfig) or RESOURCES_SERVER_TYPE_KEY_NAME not in instance:
+        return None
+    servers = instance[RESOURCES_SERVER_TYPE_KEY_NAME]
+    if not isinstance(servers, DictConfig) or len(servers) != 1:
+        return None
+    implementation = next(iter(servers))
+    declared = servers[implementation].get(ALLOWED_MODEL_TYPES_KEY_NAME)
+    if not declared:
+        return None
+    if isinstance(declared, str):
+        return [declared]
+    if not isinstance(declared, ListConfig):
+        raise ConfigError(
+            f"'{resources_server_name}.{RESOURCES_SERVER_TYPE_KEY_NAME}.{implementation}."
+            f"{ALLOWED_MODEL_TYPES_KEY_NAME}' must be a list of model types, got {type(declared).__name__}."
+        )
+    return [str(name) for name in declared]
+
+
+def model_type_for(global_config_dict: DictConfig, model_server_name: Optional[str]) -> Optional[str]:
+    """The single model adapter type hosted by `model_server_name`, or None when it cannot be determined."""
+    instance = global_config_dict.get(model_server_name) if model_server_name else None
+    if not isinstance(instance, DictConfig) or MODEL_SERVER_TYPE_KEY_NAME not in instance:
+        return None
+    models = instance[MODEL_SERVER_TYPE_KEY_NAME]
+    if not isinstance(models, DictConfig) or len(models) != 1:
+        return None
+    return str(next(iter(models)))
+
+
 def pairing_override_enabled(global_config_dict: DictConfig) -> bool:
-    """True when the `allowed_agents` guard has been waived by config key or environment variable."""
+    """True when a declared agent/model compatibility guard has been explicitly waived."""
     return bool(global_config_dict.get(ALLOW_UNSUPPORTED_PAIRING_KEY_NAME)) or getenv(
         ALLOW_UNSUPPORTED_PAIRING_ENV_VAR_NAME, ""
     ).lower() not in ("", "0", "false")

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -82,6 +82,7 @@ from nemo_gym.telemetry.span_groups import GymSpanGroup
 
 _GLOBAL_AIOHTTP_CLIENT: Union[None, ClientSession] = None
 _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG: bool = False
+_UPSTREAM_ERROR_LOG_BODY_CHARS = 2000
 
 
 class _PickleSafeRequestInfo(NamedTuple):
@@ -302,6 +303,33 @@ def _redacted_url(url: str) -> str:
     The path is the useful part for a trace; the query is a leak waiting to happen.
     """
     return url.split("?", 1)[0]
+
+
+def _format_upstream_error_body(content: Any) -> str:
+    """Render a bounded upstream error body without hiding its useful traceback."""
+    if isinstance(content, bytes):
+        prefix = content[: _UPSTREAM_ERROR_LOG_BODY_CHARS * 4].decode("utf-8", errors="replace")
+        truncated = len(content) > _UPSTREAM_ERROR_LOG_BODY_CHARS * 4
+    else:
+        prefix = str(content)
+        truncated = False
+
+    truncated = truncated or len(prefix) > _UPSTREAM_ERROR_LOG_BODY_CHARS
+    return prefix[:_UPSTREAM_ERROR_LOG_BODY_CHARS] + ("…" if truncated else "")
+
+
+def _format_upstream_error_log(server_name: str, error: ClientResponseError) -> str:
+    request_info = error.request_info
+    upstream_url = getattr(request_info, "real_url", None)
+    if upstream_url is None:
+        upstream_url = getattr(request_info, "url", None)
+    upstream_url = _redacted_url(str(upstream_url)) if upstream_url is not None else "unknown"
+    return (
+        "🚨 [upstream_request_failed] "
+        f"server={server_name} method={getattr(request_info, 'method', 'unknown')} "
+        f"url={upstream_url} status={error.status}\n"
+        f"Response content: {_format_upstream_error_body(error.response_content)}"
+    )
 
 
 async def _request_with_retries(
@@ -785,8 +813,7 @@ class SimpleServer(BaseServer):
                 )
 
                 response_content = f"Hit an exception in {self.get_session_middleware_key()} calling an inner server: {e.response_content}"
-                if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
-                    print(response_content)
+                print(_format_upstream_error_log(self.get_session_middleware_key(), e), flush=True)
 
                 return JSONResponse(content=response_content, status_code=500)
             except CancelledError:

--- a/resources_servers/asr_with_pc/configs/asr_with_pc.yaml
+++ b/resources_servers/asr_with_pc/configs/asr_with_pc.yaml
@@ -7,6 +7,12 @@ asr_with_pc:
       value: Improve transcription quality with structural detail
       verified: false
       task_type: ASR-PC
+      # Audio is carried in responses_create_params.metadata and must be translated by a vLLM-based Gym adapter.
+      allowed_model_types:
+      - vllm_model
+      - local_vllm_model
+      - local_vllm_model_proxy
+      - vllm_model_with_compaction
 asr_with_pc_simple_agent:
   responses_api_agents:
     simple_agent:

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -36,6 +36,7 @@ from nemo_gym.config_types import (
     ServerRefNotFoundError,
     UnsupportedAgentOverrideError,
     UnsupportedAgentPairingError,
+    UnsupportedModelPairingError,
     WANDBConfig,
 )
 from nemo_gym.global_config import (
@@ -1898,6 +1899,123 @@ class TestOpenAIVersionMatchesNemoGymConstraint:
 
         monkeypatch.setattr(importlib.metadata, "requires", raise_not_found)
         assert _openai_version_matches_nemo_gym_constraint("2.52.0") is True
+
+
+class TestModelServerPairing:
+    _ABSENT = object()
+
+    def _config(self, model_type: str = "openai_model", declared=_ABSENT) -> DictConfig:
+        resources_config = {"entrypoint": "app.py", "domain": "other"}
+        if declared is not self._ABSENT:
+            resources_config["allowed_model_types"] = declared
+        return DictConfig(
+            {
+                "audio_resources_server": {"resources_servers": {"audio": resources_config}},
+                "audio_simple_agent": {
+                    "responses_api_agents": {
+                        "simple_agent": {
+                            "entrypoint": "app.py",
+                            "resources_server": {"type": "resources_servers", "name": "audio_resources_server"},
+                            "model_server": {"type": "responses_api_models", "name": "policy_model"},
+                        }
+                    }
+                },
+                "policy_model": {"responses_api_models": {model_type: {"entrypoint": "app.py"}}},
+            }
+        )
+
+    def test_rejects_an_unsupported_model_adapter_with_an_actionable_error(self) -> None:
+        config = self._config(declared=["vllm_model", "local_vllm_model"])
+
+        with raises(UnsupportedModelPairingError) as error:
+            GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+        message = str(error.value)
+        assert "audio_simple_agent" in message
+        assert "policy_model" in message
+        assert "openai_model" in message
+        assert "audio_resources_server" in message
+        assert "--model-type vllm_model" in message
+        assert "Supported model types: vllm_model, local_vllm_model" in message
+        assert "--allow-unsupported-pairing" in message
+
+    def test_allows_a_declared_model_adapter(self) -> None:
+        config = self._config(model_type="vllm_model", declared=["vllm_model"])
+
+        GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+    @mark.parametrize("declared", [_ABSENT, None, []], ids=["key absent", "null", "empty list"])
+    def test_resources_server_without_a_restriction_remains_compatible(self, declared) -> None:
+        config = self._config(declared=declared)
+
+        GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+    def test_accepts_a_bare_model_type_string(self) -> None:
+        config = self._config(model_type="vllm_model", declared="vllm_model")
+
+        GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+    @mark.parametrize("declared", [5, {"vllm_model": True}], ids=["scalar", "mapping"])
+    def test_rejects_a_malformed_model_type_declaration(self, declared) -> None:
+        config = self._config(declared=declared)
+
+        with raises(ConfigError) as error:
+            GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+        message = str(error.value)
+        assert "audio_resources_server.resources_servers.audio.allowed_model_types" in message
+        assert "must be a list of model types" in message
+
+    def test_pairing_override_also_waives_model_compatibility(self) -> None:
+        config = self._config(declared=["vllm_model"])
+        config[ALLOW_UNSUPPORTED_PAIRING_KEY_NAME] = True
+
+        GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+    def test_dummy_model_does_not_break_model_free_parser_clients(self) -> None:
+        config = self._config(model_type="dummy_model", declared=["vllm_model"])
+
+        GlobalConfigDictParser().raise_on_unsupported_model_pairings(config)
+
+    @staticmethod
+    def _parse_librispeech(model_config_path: str) -> DictConfig:
+        initial = DictConfig(
+            {
+                "config_paths": [
+                    "benchmarks/librispeech_pc/config.yaml",
+                    model_config_path,
+                ],
+                "policy_base_url": "https://example.test/v1",
+                "policy_api_key": "test-key",
+                "policy_model_name": "test-model",
+            }
+        )
+        return GlobalConfigDictParser().parse(
+            GlobalConfigDictParserConfig(
+                initial_global_config_dict=initial,
+                skip_load_from_cli=True,
+                skip_load_from_dotenv=True,
+                offline=True,
+            )
+        )
+
+    def test_librispeech_config_fails_during_parse_with_openai_model(self) -> None:
+        model_config_path = "responses_api_models/openai_model/configs/openai_model.yaml"
+
+        with raises(UnsupportedModelPairingError) as error:
+            self._parse_librispeech(model_config_path)
+
+        message = str(error.value)
+        assert "librispeech_pc_asr_with_pc_simple_agent" in message
+        assert "type 'openai_model'" in message
+        assert "--model-type vllm_model" in message
+
+    def test_librispeech_config_resolves_with_vllm_model(self) -> None:
+        model_config_path = "responses_api_models/vllm_model/configs/vllm_model.yaml"
+
+        resolved = self._parse_librispeech(model_config_path)
+
+        assert "vllm_model" in resolved["policy_model"]["responses_api_models"]
 
 
 class TestComposeUnboundAgent:

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 from aiohttp import ClientOSError, ClientResponseError, RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
 from omegaconf import OmegaConf
-from pytest import MonkeyPatch, raises
+from pytest import CaptureFixture, MonkeyPatch, raises
 from yarl import URL
 
 import nemo_gym.global_config
@@ -38,6 +38,7 @@ from nemo_gym.server_utils import (
     HeadServer,
     ServerClient,
     SimpleServer,
+    _format_upstream_error_log,
     _make_keepalive_socket_factory,
     initialize_ray,
     raise_for_status,
@@ -541,6 +542,73 @@ class TestServerUtils:
             response = client.get("/session")
             assert response.json()["session_id"]
             assert 1 == len(response.headers.get_list("set-cookie"))
+
+    def test_upstream_error_log_has_bounded_body_and_redacted_url(self) -> None:
+        request_info = RequestInfo(
+            url=URL("http://policy.test/v1/responses?api_key=secret"),
+            method="POST",
+            headers=CIMultiDictProxy(CIMultiDict()),
+            real_url=URL("http://policy.test/v1/responses?api_key=secret"),
+        )
+        error = ClientResponseError(
+            request_info=request_info,
+            history=(),
+            status=500,
+            message="policy failed",
+        )
+        error.response_content = (
+            b"Traceback (most recent call last):\nValueError: actionable inner failure\n" + b"x" * 3000
+        )
+
+        message = _format_upstream_error_log("TestSimpleServer___my_server", error)
+
+        assert "[upstream_request_failed]" in message
+        assert "server=TestSimpleServer___my_server" in message
+        assert "method=POST url=http://policy.test/v1/responses status=500" in message
+        assert "ValueError: actionable inner failure" in message
+        assert "api_key=secret" not in message
+        assert message.endswith("…")
+        assert len(message) < 2200
+
+    async def test_exception_middleware_logs_upstream_error_without_debug(
+        self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+    ) -> None:
+        callbacks = []
+        app = MagicMock()
+
+        def register_middleware(middleware_type):
+            assert middleware_type == "http"
+
+            def register(callback):
+                callbacks.append(callback)
+                return callback
+
+            return register
+
+        app.middleware.side_effect = register_middleware
+        server = MagicMock()
+        server.get_session_middleware_key.return_value = "TestSimpleServer___my_server"
+        SimpleServer.setup_exception_middleware(server, app)
+
+        request_info = RequestInfo(
+            url=URL("http://policy.test/v1/responses"),
+            method="POST",
+            headers=CIMultiDictProxy(CIMultiDict()),
+            real_url=URL("http://policy.test/v1/responses"),
+        )
+        error = ClientResponseError(request_info=request_info, history=(), status=500, message="policy failed")
+        error.response_content = b"ValueError: actionable inner failure"
+
+        async def fail(_request):
+            raise error
+
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG", False)
+        response = await callbacks[0](MagicMock(), fail)
+
+        assert response.status_code == 500
+        captured = capsys.readouterr().out
+        assert "[upstream_request_failed]" in captured
+        assert "ValueError: actionable inner failure" in captured
 
     def _mock_global_client(self, monkeypatch: MonkeyPatch, connection_errors: int) -> MagicMock:
         """Global-client stand-in whose request() raises ClientOSError `connection_errors` times, then succeeds."""


### PR DESCRIPTION
## What does this PR do?

This fixes two failure modes found while running `librispeech_pc`.

### Surface nested HTTP errors

Previously, an inner model or resources server response body was only logged when `global_aiohttp_client_request_debug` was enabled. A normal run could therefore end with an outer `/run` HTTP 500 without showing the actionable inner traceback.

Nested HTTP failures now log the server, method, redacted URL, status, and up to 2,000 characters of the response body by default:

```text
🚨 [upstream_request_failed] server=TestSimpleServer___my_server method=POST url=http://policy.test/v1/responses status=500
Response content: ValueError: actionable inner failure
```

Query strings are removed from logged URLs, long bodies are truncated, and invalid UTF-8 is replaced safely. The HTTP status and response schema are unchanged.

Reproduce the middleware behavior:

```bash
uv run --extra dev pytest tests/unit_tests/test_server_utils.py \
  -q \
  -k "upstream_error_log_has_bounded_body_and_redacted_url or exception_middleware_logs_upstream_error_without_debug"
```

Expected result:

```text
2 passed, 24 deselected
```

### Reject the incompatible OpenAI adapter for LibriSpeech-PC

`librispeech_pc` carries audio in `responses_create_params.metadata.audio_data`. The vLLM-based Gym model adapters translate this side channel into an audio content block. `openai_model` does not perform that translation, so it cannot run this workload.

The ASR resources server now declares its supported model types through the optional `allowed_model_types` field. Config parsing validates the selected adapter before starting Ray or any server subprocess. Configs without this field remain unrestricted, and model-free commands such as benchmark preparation continue to use `dummy_model`.

Reproduce the rejected configuration:

```bash
uv run --extra dev gym env start \
  --benchmark librispeech_pc \
  --model-type openai_model \
  --model test-model \
  --model-url https://example.test/v1 \
  --model-api-key test-key
```

Expected result:

```text
Error: The selected Gym model-server adapter is not compatible with this workload:
  - agent 'librispeech_pc_asr_with_pc_simple_agent' uses model server
    'policy_model' (type 'openai_model'), but resources server
    'librispeech_pc_asr_with_pc_resources_server' accepts only: vllm_model,
    local_vllm_model, local_vllm_model_proxy, vllm_model_with_compaction

Select a compatible model adapter (for example, --model-type vllm_model).
```

The existing `--allow-unsupported-pairing` option remains available as an explicit bypass.

## Testing

```text
136 passed in tests/unit_tests/test_global_config.py
204 passed in tests/unit_tests/test_cli_main.py
2 focused server-utils regression tests passed
pre-commit run --all-files passed
```

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
