### PR TITLE
cp: fix(docker): drop --ldconfig arg from enroot NVIDIA hook into main

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,12 @@ curl -fSsL -o /tmp/enroot.deb \
 apt-get install -y /tmp/enroot.deb
 rm /tmp/enroot.deb
 
+# Drop the --ldconfig arg from enroot's NVIDIA hook so nvidia-container-cli
+# reuses the sandbox's existing ld.so.cache instead of regenerating it.
+sed -i 's/cli_args=("--no-cgroups" "--ldconfig=@$(command -v ldconfig.real || command -v ldconfig)")/cli_args=("--no-cgroups")/' \
+    /etc/enroot/hooks.d/98-nvidia.sh
+grep -q '^cli_args=("--no-cgroups")$' /etc/enroot/hooks.d/98-nvidia.sh
+
 # Install nvidia-container-toolkit so enroot's NVIDIA hook
 # (/etc/enroot/hooks.d/98-nvidia.sh) can find nvidia-container-cli to inject
 # GPUs into enroot sandboxes. Without this, enroot sandboxes that request a


### PR DESCRIPTION
## Summary
- Cherry-pick of #2781 from `r0.5.1` into `main`. **Stack position 5 of 5** — all prior positions merged. This is the last one, rebased directly onto `main`.
- Patches `/etc/enroot/hooks.d/98-nvidia.sh` at build time to drop the `--ldconfig=@...` arg passed to `nvidia-container-cli`, fixing nested enroot GPU sandboxes failing at the hook step under some GPU cgroup configurations.
