### PR TITLE
cp: docs(legal): PinchBench modified-component notice and NVIDIA disclaimer (#2629) into main

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -222,6 +222,14 @@ upstream copyright header and adds an NVIDIA modifications block.
 
 ---
 
+## Cloned and Modified Components
+
+| Component | License | Upstream | Notes |
+|-----------|---------|----------|-------|
+| PinchBench skill | MIT | https://github.com/pinchbench/skill | Cloned and patched at image build (modification). |
+
+---
+
 ## Full License Texts
 
 The complete license text for each Python package dependency follows.

--- a/README.md
+++ b/README.md
@@ -419,3 +419,7 @@ If you use NeMo Gym in your research, please cite it using the following BibTeX 
   note = {GitHub repository},
 }
 ```
+
+## ⚠️ Notice and Disclaimer
+
+This software automatically retrieves, accesses or interacts with external materials. Those retrieved materials are not distributed with this software and are governed solely by separate terms, conditions and licenses. You are solely responsible for finding, reviewing and complying with all applicable terms, conditions, and licenses, and for verifying the security, integrity and suitability of any retrieved materials for your specific use case. This software is provided "AS IS", without warranty of any kind. The author makes no representations or warranties regarding any retrieved materials, and assumes no liability for any losses, damages, liabilities or legal consequences from your use or inability to use this software or any retrieved materials. Use this software and the retrieved materials at your own risk.


### PR DESCRIPTION
## Summary
- Cherry-pick of #2629 from `r0.5.1` into `main`. **Stack position 2 of 5** — #2547 (position 1) merged as #2986. This is now next in line, rebased directly onto `main`.
- Adds a "Cloned and Modified Components" section to `ATTRIBUTIONS.md` covering PinchBench (cloned & patched at image build, MIT-licensed).
- Adds the NVIDIA retrieved-materials Notice and Disclaimer to `README.md`, required for containers that automatically retrieve external materials at runtime.
- Addresses OSRB guidance items 10 and 11.

Remaining stack (merge in this order): #2985 → #2984 → #2987 → #2983

## Test plan
- [ ] Confirm ATTRIBUTIONS.md and README.md render correctly