### PR TITLE
Serve filings from the local SEC corpus when edgar_search found them

### DIFF
--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -20,6 +20,7 @@ Caches ticker mappings and filing metadata locally to minimize SEC.gov calls.
 """
 
 import asyncio
+import atexit
 import contextlib
 import json
 import logging
@@ -29,7 +30,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
-from collections import deque
+from collections import Counter, deque
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
@@ -57,10 +58,16 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import SESSION_ID_KEY, get_response_json
-from resources_servers.finance_sec_search.local_edgar_search import LocalEdgarSearch
+from resources_servers.finance_sec_search.local_edgar_search import (
+    LocalEdgarSearch,
+    canonical_url_key,
+)
 
 
 logger = logging.getLogger(__name__)
+
+FILING_READ_SOURCES = ("cache", "sec-corpus", "live")
+FILING_READ_LOG_INTERVAL_SEC = 1800.0
 
 
 class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
@@ -415,6 +422,10 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
 
         self._tickers: Dict[str, Dict[str, str]] = {}  # ticker -> {"cik": ..., "name": ...}
         self._filings_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}  # cik -> {acc_nodash -> filing_meta}
+        # Filled in by edgar_search, read by filing fetches. Separate from
+        # _filings_cache, which is per-accession and mirrored to disk, because
+        # this is per-document (exhibits included) and process-local.
+        self._dump_paths: Dict[str, str] = {}  # canonical document key -> path below sec_dump_path
         self._session: Optional[aiohttp.ClientSession] = None
         self._session_lock = asyncio.Lock()
         self._filings_locks: Dict[str, asyncio.Lock] = {}
@@ -453,6 +464,9 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 )
         else:
             logger.info("No tavily_api_key configured — web_search will be unavailable")
+
+        self._filing_read_sources: Counter[str] = Counter()
+        self._filing_read_logged_at: Optional[float] = None
 
         self._local_edgar_search: Optional[LocalEdgarSearch] = None
         if self.config.local_edgar_index_path:
@@ -537,7 +551,17 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 )
             }
 
+        # Process-level hook: not every FastAPI version exposes a shutdown
+        # handler API.
+        atexit.register(self._log_filing_read_sources)
+
         return app
+
+    def _log_filing_read_sources(self) -> None:
+        logger.warning(
+            "SEC filing reads by source: %s",
+            " ".join(f"{source}={self._filing_read_sources[source]}" for source in FILING_READ_SOURCES),
+        )
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create the shared HTTP session."""
@@ -760,31 +784,75 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
     # Dump Fallback
     # ========================================================================
 
+    async def _read_dump_file(self, dump_path: Path) -> Optional[str]:
+        """Read and parse one file from the read-only dump, or None."""
+        if not dump_path.is_file():
+            return None
+
+        def _read_and_parse() -> str:
+            return self._parse_html_to_text(dump_path.read_text(encoding="utf-8"))
+
+        try:
+            return await asyncio.get_running_loop().run_in_executor(None, _read_and_parse)
+        except OSError:
+            logger.warning("Failed to read dump file %s", dump_path)
+            return None
+
+    async def _record_dump_paths(self, results: List[Dict[str, Any]]) -> None:
+        """Remember where edgar_search's hits live in the dump, for later reads.
+
+        Failures are non-fatal: the search result stands, reads just fall back.
+        """
+        if not self.config.sec_dump_path or self._local_edgar_search is None:
+            return
+        urls = [
+            url
+            for url in (str(result.get("filingUrl") or "") for result in results)
+            if url and canonical_url_key(url) not in self._dump_paths
+        ]
+        if not urls:
+            return
+        try:
+            self._dump_paths.update(await self._local_edgar_search.dump_paths_for_urls_async(urls))
+        except Exception:
+            logger.warning("Failed to resolve dump paths for %d search results", len(urls), exc_info=True)
+
     async def _lookup_dump(self, url: str) -> Optional[str]:
         """Try to read a filing from the pre-fetched SEC dump (read-only).
 
-        Derives the dump path from in-memory metadata cache:
-        {sec_dump_path}/{TICKER}/{FORM}/{YEAR}/{ACCESSION}/primary-document.html
-
-        Uses report_date for year and form.replace("/", "_") for the form folder,
-        matching the conventions of the download_filings.py script.
         Returns parsed plain text or None.
         """
         if not self.config.sec_dump_path:
             return None
+        root = Path(self.config.sec_dump_path)
 
+        # A path edgar_search recorded. The index holds a row per document, so
+        # this is the only route that can name an exhibit rather than a filing's
+        # primary document.
+        key = canonical_url_key(url)
+        relative_path = self._dump_paths.get(key) if key else None
+        if relative_path:
+            candidate = Path(relative_path)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                logger.warning("Rejected unsafe dump path %s", relative_path)
+            else:
+                text_content = await self._read_dump_file(root / candidate)
+                if text_content is not None:
+                    return text_content
+
+        # Otherwise rebuild the path from filing metadata that sec_filing_search
+        # left in memory. Uses report_date for the year and form.replace("/", "_")
+        # for the form folder, matching download_filings.py. That metadata is keyed
+        # per filing, so the filename can only ever be the primary document.
         parts = self._parse_sec_url(url)
         if not parts:
             return None
 
-        cik_padded = parts["cik"]
-        acc_nodash = parts["accession_number"].replace("-", "")
-
-        metadata = self._filings_cache.get(cik_padded)
+        metadata = self._filings_cache.get(parts["cik"])
         if not metadata:
             return None
 
-        filing_meta = metadata.get(acc_nodash)
+        filing_meta = metadata.get(parts["accession_number"].replace("-", ""))
         if not filing_meta:
             return None
 
@@ -797,18 +865,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         if not all([ticker, form, year, accession]):
             return None
 
-        dump_path = Path(self.config.sec_dump_path) / ticker / form / year / accession / "primary-document.html"
-        if not dump_path.exists():
-            return None
-
-        def _read_and_parse(p: Path) -> str:
-            return self._parse_html_to_text(p.read_text(encoding="utf-8"))
-
-        try:
-            return await asyncio.get_running_loop().run_in_executor(None, _read_and_parse, dump_path)
-        except OSError:
-            logger.warning("Failed to read dump file %s", dump_path)
-            return None
+        return await self._read_dump_file(root / ticker / form / year / accession / "primary-document.html")
 
     # ========================================================================
     # URL Parsing
@@ -950,6 +1007,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 form_types=body.form_types,
                 ciks=body.ciks,
             )
+            await self._record_dump_paths(results)
             return EdgarSearchResponse(results=json.dumps(results, default=str))
         except Exception as error:
             logger.warning("edgar_search failed: %s", error)
@@ -991,13 +1049,17 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             raise ValueError(f"Invalid SEC URL format: {url}")
 
         text_content = None
+        source = None
         if self.config.use_cache and file_path.exists():
             text_content = file_path.read_text(encoding="utf-8")
+            source = "cache"
 
-        if text_content is None and self.config.sec_dump_path:
+        if text_content is None:
             text_content = await self._lookup_dump(url)
-            if text_content and self.config.use_cache:
-                self._atomic_write(file_path, text_content)
+            if text_content is not None:
+                source = "sec-corpus"
+                if self.config.use_cache:
+                    self._atomic_write(file_path, text_content)
 
         if text_content is None:
             html_content = await self._fetch_with_retry(url)
@@ -1009,12 +1071,20 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             text_content = await asyncio.get_running_loop().run_in_executor(
                 None, self._parse_html_to_text, html_content
             )
+            source = "live"
             if self.config.use_cache:
                 self._atomic_write(file_path, text_content)
 
         if not text_content:
             raise ValueError("Filing content was empty after parsing.")
 
+        self._filing_read_sources[source] += 1
+        # Logs the first read, then at most one line per interval, so a count
+        # survives a server that is killed without a clean shutdown.
+        now = time.monotonic()
+        if self._filing_read_logged_at is None or now - self._filing_read_logged_at >= FILING_READ_LOG_INTERVAL_SEC:
+            self._filing_read_logged_at = now
+            self._log_filing_read_sources()
         return text_content
 
     async def _save_tool_output(self, output: str, key: str, state: dict[str, Any]) -> str:

--- a/resources_servers/finance_sec_search/local_edgar_search.py
+++ b/resources_servers/finance_sec_search/local_edgar_search.py
@@ -25,10 +25,12 @@ import re
 import sqlite3
 import threading
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import unquote
 
 
 logger = logging.getLogger(__name__)
@@ -65,9 +67,42 @@ METADATA_COLUMNS = (
     "url",
 )
 
+# Not mirrored into the sidecar, so dump path lookups always read documents.
+DUMP_PATH_COLUMNS = ("canonical_url_key", "source_path")
+
+# Keeps the IN clause below SQLite's bound-parameter limit on any build.
+DUMP_PATH_CHUNK_SIZE = 500
+
+SEC_ARCHIVES_URL_RE = re.compile(r"sec\.gov/Archives/edgar/data/(\d+)/(\d+)/([^?#]*)")
+
 
 def default_sidecar_path(index_path: str | Path) -> Path:
     return Path(str(index_path) + SIDECAR_SUFFIX)
+
+
+def canonical_url_key(url: str) -> str | None:
+    """Return the index's document key for an SEC Archives URL, or None.
+
+    Must stay byte-identical to the key the index builder writes: unpadded CIK,
+    dashless accession, lowercased filename.
+    """
+    match = SEC_ARCHIVES_URL_RE.search(url)
+    if not match:
+        return None
+    filename = unquote(match.group(3)).strip("/").rsplit("/", 1)[-1].lower()
+    if not filename:
+        return None
+    return f"{int(match.group(1))}:{match.group(2)}:{filename}"
+
+
+def _relative_source_path(source_path: str) -> str | None:
+    """Return the part of an indexed path below the download's data directory.
+
+    Indexed paths are container-absolute, so only the fragment below data/ is
+    portable to whatever the reader has mounted.
+    """
+    _, separator, relative = source_path.replace("\\", "/").partition("/data/")
+    return relative if separator and relative else None
 
 
 def fingerprint_source_index(connection: sqlite3.Connection) -> str:
@@ -476,6 +511,40 @@ class LocalEdgarSearch:
 
     async def search_async(self, **arguments: Any) -> list[dict[str, Any]]:
         return await asyncio.to_thread(self.search, **arguments)
+
+    @property
+    def supports_dump_paths(self) -> bool:
+        return all(column in self._document_columns for column in DUMP_PATH_COLUMNS)
+
+    def dump_paths_for_urls(self, urls: Iterable[str]) -> dict[str, str]:
+        """Map SEC URLs to where the index recorded each document on disk.
+
+        Returned keys are canonical document keys, so callers look up with
+        canonical_url_key() rather than the URL itself.
+        """
+        if not self.supports_dump_paths:
+            return {}
+        keys = sorted({key for key in (canonical_url_key(url) for url in urls) if key})
+        if not keys:
+            return {}
+
+        connection = self._session()
+        resolved: dict[str, str] = {}
+        for start in range(0, len(keys), DUMP_PATH_CHUNK_SIZE):
+            chunk = keys[start : start + DUMP_PATH_CHUNK_SIZE]
+            placeholders = ",".join("?" for _ in chunk)
+            rows = connection.execute(
+                f"SELECT canonical_url_key, source_path FROM documents WHERE canonical_url_key IN ({placeholders})",
+                chunk,
+            )
+            for row in rows:
+                relative = _relative_source_path(str(row["source_path"]))
+                if relative:
+                    resolved[str(row["canonical_url_key"])] = relative
+        return resolved
+
+    async def dump_paths_for_urls_async(self, urls: Iterable[str]) -> dict[str, str]:
+        return await asyncio.to_thread(self.dump_paths_for_urls, list(urls))
 
     @staticmethod
     def _assert_invariants(

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -15,6 +15,7 @@
 """Tests for Finance Agent Resource Server."""
 
 import json
+import logging
 import tempfile
 import urllib.error
 from pathlib import Path
@@ -30,6 +31,7 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.server_utils import ServerClient
 from resources_servers.finance_sec_search.app import (
+    EdgarSearchRequest,
     FinanceAgentResourcesServer,
     FinanceAgentResourcesServerConfig,
     FinanceAgentSearchRequest,
@@ -37,6 +39,7 @@ from resources_servers.finance_sec_search.app import (
     RateLimiter,
     RetrieveInformationRequest,
 )
+from resources_servers.finance_sec_search.tests.test_local_edgar_search import _index
 
 
 _TEST_SESSION_ID = "test-session"
@@ -712,6 +715,167 @@ class TestDumpFallback:
         result = await server._lookup_dump(url)
         assert result is not None
         assert "Revenue was $100B" in result
+
+
+class TestDumpFromSearch:
+    """edgar_search records where its hits live, so filing reads can skip sec.gov."""
+
+    _PRIMARY_URL = "https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/aapl.htm"
+    _EXHIBIT_URL = "https://www.sec.gov/Archives/edgar/data/789019/000078901925000001/msft-ex991.htm"
+
+    @pytest.fixture
+    def server(self, server_config, tmp_path):
+        server_config.local_edgar_index_path = str(_index(tmp_path / "index.sqlite"))
+        server_config.sec_dump_path = str(tmp_path / "dump")
+        # Past the fixture's newest filing, so the exhibit is not clamped away.
+        server_config.max_end_date = "2030-01-01"
+        return FinanceAgentResourcesServer(config=server_config, server_client=MagicMock(spec=ServerClient))
+
+    @staticmethod
+    def _write_dump(server, relative_path: str, html: str) -> None:
+        target = Path(server.config.sec_dump_path) / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(html)
+
+    async def _search(self, server) -> None:
+        await server.edgar_search(_mock_request(), EdgarSearchRequest(search_query="quantum pineapple"))
+
+    @pytest.mark.asyncio
+    async def test_search_records_paths_for_every_returned_document(self, server) -> None:
+        await self._search(server)
+
+        assert server._dump_paths == {
+            "320193:000032019324000001:aapl.htm": "AAPL/10-K/2024/0000320193-24-000001/primary-document.html",
+            "789019:000078901925000001:msft-ex991.htm": "MSFT/8-K/2025/0000789019-25-000001/exhibits/EX-99.1.html",
+        }
+
+    @pytest.mark.asyncio
+    async def test_exhibit_is_served_from_the_dump(self, server) -> None:
+        await self._search(server)
+        self._write_dump(
+            server,
+            "MSFT/8-K/2025/0000789019-25-000001/exhibits/EX-99.1.html",
+            "<html><body><p>Guidance raised to $5B</p></body></html>",
+        )
+
+        with patch.object(server, "_fetch_with_retry", new=AsyncMock()) as fetch:
+            text = await server._fetch_sec_filing_text(self._EXHIBIT_URL)
+
+        assert "Guidance raised to $5B" in text
+        fetch.assert_not_called()
+        assert server._filing_read_sources["sec-corpus"] == 1
+        assert server._filing_read_sources["live"] == 0
+
+    @pytest.mark.asyncio
+    async def test_recorded_path_wins_over_the_layout_convention(self, server) -> None:
+        """The cached filing metadata points elsewhere, so only precedence explains the result."""
+        await self._search(server)
+        server._filings_cache["0000320193"] = {
+            "000032019324000001": {
+                "ticker": "AAPL",
+                "form": "10-K",
+                "report_date": "2023-01-01",
+                "accession_number": "0000320193-24-000001",
+            },
+        }
+        self._write_dump(
+            server,
+            "AAPL/10-K/2024/0000320193-24-000001/primary-document.html",
+            "<html><body><p>Recorded copy</p></body></html>",
+        )
+        self._write_dump(
+            server,
+            "AAPL/10-K/2023/0000320193-24-000001/primary-document.html",
+            "<html><body><p>Convention copy</p></body></html>",
+        )
+
+        text_content = await server._lookup_dump(self._PRIMARY_URL)
+
+        assert text_content is not None
+        assert "Recorded copy" in text_content
+
+    @pytest.mark.asyncio
+    async def test_convention_still_serves_urls_that_were_never_searched(self, server) -> None:
+        """sec_filing_search's path stays live when edgar_search recorded nothing."""
+        url = "https://www.sec.gov/Archives/edgar/data/320193/000032019324000009/aapl-10q.htm"
+        server._filings_cache["0000320193"] = {
+            "000032019324000009": {
+                "ticker": "AAPL",
+                "form": "10-Q",
+                "report_date": "2024-06-30",
+                "accession_number": "0000320193-24-000009",
+            },
+        }
+        self._write_dump(
+            server,
+            "AAPL/10-Q/2024/0000320193-24-000009/primary-document.html",
+            "<html><body><p>Convention copy</p></body></html>",
+        )
+
+        text_content = await server._lookup_dump(url)
+
+        assert text_content is not None
+        assert "Convention copy" in text_content
+
+    @pytest.mark.asyncio
+    async def test_missing_dump_file_falls_through_to_live(self, server) -> None:
+        """A recorded path whose file is absent must not shadow the live fetch."""
+        await self._search(server)
+
+        with patch.object(server, "_fetch_with_retry", new=AsyncMock(return_value=MOCK_HTML)) as fetch:
+            await server._fetch_sec_filing_text(self._PRIMARY_URL)
+
+        fetch.assert_called_once()
+        assert server._filing_read_sources["live"] == 1
+        assert server._filing_read_sources["sec-corpus"] == 0
+
+    @pytest.mark.asyncio
+    async def test_url_that_was_never_searched_is_fetched_live(self, server) -> None:
+        url = "https://www.sec.gov/Archives/edgar/data/1234567/000123456725000001/other.htm"
+
+        with patch.object(server, "_fetch_with_retry", new=AsyncMock(return_value=MOCK_HTML)) as fetch:
+            await server._fetch_sec_filing_text(url)
+
+        fetch.assert_called_once()
+        assert server._dump_paths == {}
+        assert server._filing_read_sources["live"] == 1
+
+    @pytest.mark.asyncio
+    async def test_every_read_source_is_counted_and_summarized(self, server, caplog) -> None:
+        """The summary is the only read-source signal that reaches a default log level."""
+        await self._search(server)
+        self._write_dump(
+            server,
+            "MSFT/8-K/2025/0000789019-25-000001/exhibits/EX-99.1.html",
+            "<html><body><p>Guidance raised to $5B</p></body></html>",
+        )
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(server, "_fetch_with_retry", new=AsyncMock(return_value=MOCK_HTML)),
+        ):
+            await server._fetch_sec_filing_text(self._EXHIBIT_URL)
+            await server._fetch_sec_filing_text(self._PRIMARY_URL)
+
+        assert dict(server._filing_read_sources) == {"sec-corpus": 1, "live": 1}
+        # The first read logs; the second falls inside the interval and is quiet.
+        assert caplog.text.count("SEC filing reads by source:") == 1
+        assert "SEC filing reads by source: cache=0 sec-corpus=1 live=0" in caplog.text
+
+        caplog.clear()
+        server._log_filing_read_sources()
+        assert "SEC filing reads by source: cache=0 sec-corpus=1 live=1" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_dump_paths_are_not_collected_without_a_dump(self, server_config, tmp_path) -> None:
+        server_config.local_edgar_index_path = str(_index(tmp_path / "index.sqlite"))
+        server_config.sec_dump_path = None
+        server_config.max_end_date = "2030-01-01"
+        server = FinanceAgentResourcesServer(config=server_config, server_client=MagicMock(spec=ServerClient))
+
+        await self._search(server)
+
+        assert server._dump_paths == {}
 
 
 # ============================================================================

--- a/resources_servers/finance_sec_search/tests/test_local_edgar_search.py
+++ b/resources_servers/finance_sec_search/tests/test_local_edgar_search.py
@@ -31,6 +31,7 @@ from resources_servers.finance_sec_search.app import (
 )
 from resources_servers.finance_sec_search.local_edgar_search import (
     LocalEdgarSearch,
+    canonical_url_key,
     default_sidecar_path,
     normalize_request,
     translate_query,
@@ -41,6 +42,10 @@ from resources_servers.finance_sec_search.scripts.convert_questions import (
     PROMPT,
     convert_entry,
 )
+
+
+# Indexed paths are container-absolute; only the part below data/ is portable.
+DUMP_PREFIX = "/workspace/outputs/finance/demo/workflow-2-download-sec/step-0-download/data"
 
 
 def _index(path: Path) -> Path:
@@ -58,8 +63,11 @@ def _index(path: Path) -> Path:
             document_type TEXT NOT NULL,
             filing_date TEXT NOT NULL,
             url TEXT NOT NULL,
+            canonical_url_key TEXT NOT NULL,
+            source_path TEXT NOT NULL,
             body TEXT NOT NULL
         );
+        CREATE UNIQUE INDEX documents_url_key ON documents(canonical_url_key);
         CREATE VIRTUAL TABLE documents_fts USING fts5(
             body,
             content='documents',
@@ -79,6 +87,8 @@ def _index(path: Path) -> Path:
             "10-K",
             "2024-11-01",
             "https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/aapl.htm",
+            "320193:000032019324000001:aapl.htm",
+            f"{DUMP_PREFIX}/AAPL/10-K/2024/0000320193-24-000001/primary-document.html",
             "quantum pineapple net income",
         ),
         (
@@ -92,6 +102,8 @@ def _index(path: Path) -> Path:
             "EX-99.1",
             "2025-04-08",
             "https://www.sec.gov/Archives/edgar/data/789019/000078901925000001/msft-ex991.htm",
+            "789019:000078901925000001:msft-ex991.htm",
+            f"{DUMP_PREFIX}/MSFT/8-K/2025/0000789019-25-000001/exhibits/EX-99.1.html",
             "quantum pineapple guidance",
         ),
     ]
@@ -99,8 +111,9 @@ def _index(path: Path) -> Path:
         """
         INSERT INTO documents (
             id, accession_number, cik, company_name, ticker, description,
-            form_type, document_type, filing_date, url, body
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            form_type, document_type, filing_date, url, canonical_url_key,
+            source_path, body
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         rows,
     )
@@ -252,6 +265,50 @@ async def test_server_routes_edgar_search_to_local_index(tmp_path: Path) -> None
     metric = json.loads(metric_files[0].read_text(encoding="utf-8"))
     assert metric["result_count"] == 1
     assert "completed_at_unix_seconds" in metric
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "https://www.sec.gov/Archives/edgar/data/0000066740/000006674026000246/MMM-20260630.htm",
+            "66740:000006674026000246:mmm-20260630.htm",
+        ),
+        (
+            "https://www.sec.gov/Archives/edgar/data/66740/000006674026000246/ex%2010-1.htm",
+            "66740:000006674026000246:ex 10-1.htm",
+        ),
+        ("https://example.test/not-edgar.htm", None),
+        ("https://www.sec.gov/Archives/edgar/data/66740/000006674026000246/", None),
+    ],
+)
+def test_canonical_url_key_normalizes_cik_and_filename(url: str, expected: str | None) -> None:
+    assert canonical_url_key(url) == expected
+
+
+def test_dump_paths_cover_primary_documents_and_exhibits(tmp_path: Path) -> None:
+    search = LocalEdgarSearch(_index(tmp_path / "index.sqlite"))
+
+    resolved = search.dump_paths_for_urls(
+        [
+            "https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/aapl.htm",
+            "https://www.sec.gov/Archives/edgar/data/789019/000078901925000001/msft-ex991.htm",
+            "https://www.sec.gov/Archives/edgar/data/1/000000000000000001/absent.htm",
+        ]
+    )
+
+    assert resolved == {
+        "320193:000032019324000001:aapl.htm": "AAPL/10-K/2024/0000320193-24-000001/primary-document.html",
+        "789019:000078901925000001:msft-ex991.htm": "MSFT/8-K/2025/0000789019-25-000001/exhibits/EX-99.1.html",
+    }
+
+
+def test_dump_paths_are_unavailable_without_the_columns(tmp_path: Path) -> None:
+    """An index built before source_path existed degrades instead of erroring."""
+    search = LocalEdgarSearch(_varied_index(tmp_path / "legacy.sqlite", documents=4))
+
+    assert search.supports_dump_paths is False
+    assert search.dump_paths_for_urls(["https://www.sec.gov/Archives/edgar/data/1/2/a.htm"]) == {}
 
 
 def _varied_index(path: Path, documents: int = 400) -> Path:


### PR DESCRIPTION
## Serve filings from the local SEC corpus when edgar_search found them

`edgar_search` queries a local full-text index built from a downloaded SEC
corpus, but reads of its results did not come from that corpus. To turn a filing
URL into a file on disk, `_lookup_dump` rebuilt a path out of `_filings_cache`,
which only `sec_filing_search` populates. After an `edgar_search` hit there was
nothing to rebuild from, so the read went to sec.gov.

When `sec_filing_search` had run earlier in the same rollout, the rebuilt path
was worse than useless for exhibits — the separate documents filed alongside a
filing, such as an `EX-99.2` press release. A rebuilt path can only ever name a
filing's main document, so the read returned that instead of the exhibit, and
reported success.

### Changes

- `edgar_search` records each hit's `source_path` from the index, keyed by
  canonical URL, and filing reads consult it before falling back to the rebuilt
  path. The index holds a row per document, so this is the only route that can
  name an exhibit.
- Filing reads are counted by source (`cache`, `sec-corpus`, `live`). The totals
  are logged on the first read, then at most once every 30 minutes, and on
  shutdown, at warning level so they appear in job logs with no logging
  configuration.

### Metrics

The fix changes how a filing URL is turned into a file path. There are two ways
to do that, and the table compares them on the same documents:

- **the exact path the index recorded** for the document the search returned
- **a path rebuilt from filing metadata**, which can only name a filing's main
  document

8 queries against a 3-year, 5-ticker demo index returned 138 distinct documents
(62 exhibits, 76 main documents). Each was read both ways, and the bytes that
came back were compared against the document the search had actually returned:

| how the file path is chosen | right document | wrong document | no file found |
| --- | --- | --- | --- |
| exact path from the index — after this change | 138 (100%) | 0 | 0 |
| rebuilt from filing metadata — before this change | 64 (46%) | 56 (41%) | 18 (13%) |

All 56 wrong reads were requests for an exhibit, where we previously returned the filing's primary document instead of the exhibit itself. None of the 76 primary-document reads is wrong, which is the shape the mechanism predicts: a rebuilt path can only ever name primary-document.html, so it is right for a filing's own document and wrong for every exhibit in that filing.
