### PR TITLE
fix(scicode): forward generation parameters to sub-steps

### DIFF
--- a/resources_servers/scicode/requirements.txt
+++ b/resources_servers/scicode/requirements.txt
@@ -6,3 +6,4 @@ numpy
 matplotlib
 h5py
 sympy
+networkx==3.5

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -153,7 +153,7 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
             url_path="/v1/responses",
-            json=body,
+            json=body.model_dump(exclude_unset=True, exclude_none=True),
             cookies=request.cookies,
         )
         await raise_for_status(model_response)
@@ -173,6 +173,8 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         solutions: Dict[str, str] = {}
         out_of_context = False
         last_response_json = None
+        response_create_params = body.responses_create_params.model_dump(exclude_unset=True, exclude_none=True)
+        response_create_params.pop("input", None)
 
         for cur_step in range(total):
             # Prefilled steps provide context for later steps but are not scored (no solution entry).
@@ -196,7 +198,10 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
                 gen_response = await self.server_client.post(
                     server_name=self.config.name,
                     url_path="/v1/responses",
-                    json={"input": [{"role": "user", "content": user_content}]},
+                    json={
+                        **response_create_params,
+                        "input": [{"role": "user", "content": user_content}],
+                    },
                     cookies=cookies,
                 )
                 await raise_for_status(gen_response)

--- a/responses_api_agents/scicode_agent/tests/test_app.py
+++ b/responses_api_agents/scicode_agent/tests/test_app.py
@@ -170,27 +170,46 @@ class TestApp:
     async def test_responses_forwards_to_model(self):
         agent = _agent()
         agent.server_client.post = AsyncMock(return_value=_Resp(_model_json("x = 1"), cookies={"sid": "abc"}))
-        body = NeMoGymResponseCreateParamsNonStreaming(input="hi")
+        body = NeMoGymResponseCreateParamsNonStreaming(input="hi", temperature=0.25)
         with patch.object(app, "raise_for_status", AsyncMock()):
             result = await agent.responses(_FakeRequest(), Response(), body)
         assert result.output_text == "```python\nx = 1\n```"
+        request_json = agent.server_client.post.await_args.kwargs["json"]
+        assert isinstance(request_json, dict)
+        assert request_json["temperature"] == 0.25
+        assert request_json["input"][0]["content"] == "hi"
 
     @pytest.mark.asyncio
     async def test_run_builds_solutions_and_calls_verify(self):
         agent = _agent()
-        captured = {}
+        captured = {"model": []}
 
         def _post(server_name, url_path, json, cookies):
             if url_path == "/v1/responses":
+                captured["model"].append(json)
                 return _Resp(_model_json("x = 1"))
             captured["verify"] = json
             return _Resp({"reward": 1.0})
 
         agent.server_client.post = AsyncMock(side_effect=_post)
+        body = _run_request(problem_id="1", n_steps=2)
+        body.responses_create_params = NeMoGymResponseCreateParamsNonStreaming(
+            input=[],
+            max_output_tokens=4096,
+            temperature=0.25,
+            top_p=0.9,
+        )
         with patch.object(app, "raise_for_status", AsyncMock()):
-            result = await agent.run(_FakeRequest(), _run_request(problem_id="1", n_steps=2))
+            result = await agent.run(_FakeRequest(), body)
 
         assert result == {"reward": 1.0}
+        assert len(captured["model"]) == 2
+        for request_json in captured["model"]:
+            assert request_json["max_output_tokens"] == 4096
+            assert request_json["temperature"] == 0.25
+            assert request_json["top_p"] == 0.9
+            assert request_json["input"][0]["role"] == "user"
+            assert request_json["input"][0]["content"]
         verify = captured["verify"]
         assert "response" in verify  # /verify requires a response field
         solutions = verify["solutions"]


### PR DESCRIPTION
## Summary

- serialize SciCode Responses API payloads before forwarding them to the model server
- propagate caller-supplied generation parameters to every SciCode sub-step while replacing only the per-step input
- add the validated `networkx==3.5` runtime dependency for generated SciCode solutions

## Context

The Super 3.5 SciCode integration was applying these fixes dynamically from the pipeline launcher. This PR moves the reusable runtime changes into Gym source. The ARG_MAX fix is not duplicated because it is already present from #2804.

Related pipeline MR: https://gitlab-master.nvidia.com/post-training/pipeline/-/merge_requests/36

## Testing

- `uv run --frozen ruff check responses_api_agents/scicode_agent/app.py responses_api_agents/scicode_agent/tests/test_app.py`
- `PYTHONPATH=.:responses_api_agents/scicode_agent:resources_servers/scicode uv run --frozen --extra dev python -m pytest -q responses_api_agents/scicode_agent/tests/test_app.py resources_servers/scicode/tests/test_app.py`
- 37 tests passed