### PR TITLE
feat(swebench,opencode): set EXECD_API_GRACE_SHUTDOWN=50ms in the sandbox env; initial poll 0.5s

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -238,3 +238,5 @@ Command failures return `SandboxExecResult` with the command's exit code. If Ope
 The provider's `create.image_pull_policy` defaults to `IfNotPresent`. Valid values are `Always`, `IfNotPresent`, and `Never`. The resolved policy is written into OpenSandbox create extensions as both `imagePullPolicy` and `opensandbox.extensions.image-pull-policy` unless those keys are already present in `provider_options.extensions`.
 
 Create retries handle transient allocation, connection, image pull, and server-side errors. Command retries are controlled separately by `operations.command_retries`.
+
+execd, the exec daemon inside each sandbox, holds every command response open for `EXECD_API_GRACE_SHUTDOWN` (default 1s) after the command's last event, which is fixed latency on each command and on the readiness probe. Set it in the sandbox spec's `env` to shorten it; the shipped SWE-bench and OpenCode configs use `50ms`, and the provider's `operations.background_poll_initial_s` (0.5) is sized to that.

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -68,7 +68,9 @@ sandbox:
       # Poll interval backs off from initial to interval.
       # @bxyu-nvidia: Too frequent of a poll interval can quickly reduce server performance.
       # e.g. on SWE Bench Verified 500 samples with 3 repeats = 1500 concurrent samples, we would do polling every `background_poll_interval_s` seconds
-      background_poll_initial_s: 1.0
+      # Assumes a short execd response grace (EXECD_API_GRACE_SHUTDOWN in the sandbox env; the
+      # shipped swebench and opencode configs set 50ms).
+      background_poll_initial_s: 0.5
       background_poll_interval_s: 30.0
       # Per-request budget for status polls, which are small idempotent GETs:
       # without their own short budget, each poll against an unreachable

--- a/resources_servers/swebench/configs/swebench.yaml
+++ b/resources_servers/swebench/configs/swebench.yaml
@@ -20,6 +20,10 @@ swebench_resources_server:          # instance name — how agents/CLI refer to 
         ttl_s: 18000
         ready_timeout_s: 1200
         derive_cpu_env: true
+        env:
+          # execd holds each finished command's response open for this long (default 1s);
+          # a short grace keeps every command and the readiness probe from paying that tail.
+          EXECD_API_GRACE_SHUTDOWN: "50ms"
         resources:
           cpu: 2
           memory_mib: 16384

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -476,6 +476,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         resources = SandboxResources.from_mapping(self.config.sandbox_config.get("resources", {}))
         # TODO @bxyu-nvidia: Refactor this after swapping to PTY as this should be set on the SWE Bench resources server side
         env = cpu_cap_env(resources.cpu) if self.config.sandbox_config.get("derive_cpu_env", True) else {}
+        env |= dict(self.config.sandbox_config.get("env", {}))  # explicit keys win over the derived caps
 
         # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
         sandbox_spec = SandboxSpec(

--- a/responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
+++ b/responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
@@ -147,6 +147,10 @@ opencode_sandboxed_agent:
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200
+        env:
+          # execd holds each finished command's response open for this long (default 1s);
+          # a short grace keeps every command and the readiness probe from paying that tail.
+          EXECD_API_GRACE_SHUTDOWN: "50ms"
         resources:
           cpu: 0.25
           memory_mib: 512

--- a/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
@@ -107,6 +107,14 @@ class TestOpenCodeSandboxedAgent:
         assert (await created_spec({"resources": {"cpu": 2}, "derive_cpu_env": False})).env == {}
         assert (await created_spec({"resources": {"memory_mib": 8192}})).env == {}
 
+        # Explicit sandbox_config.env is passed through and wins over the derived caps.
+        spec = await created_spec(
+            {"resources": {"cpu": 2}, "env": {"EXECD_API_GRACE_SHUTDOWN": "50ms", "OMP_NUM_THREADS": "4"}}
+        )
+        assert spec.env["EXECD_API_GRACE_SHUTDOWN"] == "50ms"
+        assert spec.env["OMP_NUM_THREADS"] == "4"
+        assert all(spec.env[name] == "2" for name in CPU_CAP_ENV_VARS if name != "OMP_NUM_THREADS")
+
     @fixture
     def opencode_export_test_data(self) -> Dict[str, Any]:
         test_data_path = Path(__file__).parent / "opencode_export_test_data.json"


### PR DESCRIPTION
## Summary

Set `EXECD_API_GRACE_SHUTDOWN=50ms` in the sandbox env of the shipped SWE-bench resources server and OpenCode agent configs, and lower the OpenSandbox provider's `operations.background_poll_initial_s` from 1.0 to 0.5 to match. Config-first: the only code change is one line so the OpenCode agent passes `sandbox_config.env` through to its `SandboxSpec` (explicit keys win over the derived CPU caps), the same rule the SWE-bench server already applies.

execd's `/command` handler holds each response open for `ApiGracefulShutdownTimeout` (default 1 s) **after** the terminal SSE frame has been written and flushed, then returns. With Gym's background-exec path that is a fixed ~1 s of dead time on every command submit; the same tail sits on foreground commands and on the create-time readiness probe. The knob is env-overridable per sandbox. The 1.0 s initial poll was tuned around the 1 s tail; 0.5 s matches the shorter tail without raising the steady-state poll rate (`background_poll_interval_s` stays 30 s).

## Why it is safe

In execd (`components/execd/pkg/web/controller/command.go`) the runtime fires the completion hook synchronously before `Execute` returns, every SSE frame (stdout, stderr, `execution_complete`/`error`) is written and flushed under a lock as it is produced, and only then does the handler `time.Sleep(ApiGracefulShutdownTimeout)`. Output, exit status and background command status are final before the sleep, so shortening it changes when the stream ends, not what it carries. The delay's only other stated purpose is to give execd's optional egress sidecar time to observe state changes, which Gym deployments do not use. The env var is harmless on providers without execd.

## Measurements (cell-3 through the server proxy, `python:3.11-slim`, `true`)

| path | grace 1 s (before) | grace 50 ms (after) |
| --- | --- | --- |
| SDK foreground exec p50 | 1.088 s | 0.128 s |
| Gym background exec p50 (submit + poll + status + logs) | 1.493 s | 0.542 s |

At eval scale (SWE-bench Verified, 1500 rollouts, 1024 concurrency, p2d2 vLLM on hsg) 2 h runs with this grace and poll setting completed 1458 rows (reward 0.7181) and 1453 rows (reward 0.7219). A same-tree run with poll 0.2 s and the default 1 s grace tracked within ~1.5 % at 30 min; throughput there is dominated by the model side, and the change removes about 1 s of client-side latency per sandbox command.

## Test plan

- [x] `pytest responses_api_agents/opencode_sandboxed_agent/tests/test_app.py` in a fresh worktree venv (11 passed): extended `test_start_sandbox_derives_cpu_cap_env_from_cpu_limit` to assert that `sandbox_config.env` is passed through and wins over the derived caps.
- [x] `pytest tests/unit_tests/test_opensandbox_provider.py` (54 passed; provider code unchanged, yaml only).
- [x] `pre-commit run --files ...` on the changed files.
- [ ] SWE-bench resources server tests not run here (they need the server's own venv with `swebench`); the change to that server is yaml-only and it already reads `sandbox_config.env`.
- [x] Real rollouts: SWE-bench Verified runs on hsg + OpenSandbox cell-3 with this exact grace and poll configuration (jobs 6830263, 6850730), agent and verifier behavior inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
