### PR TITLE
feat(finance_sec_search): Decline the layout convention for URLs it cannot name

### DIFF
--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -839,6 +839,10 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 text_content = await self._read_dump_file(root / candidate)
                 if text_content is not None:
                     return text_content
+                logger.warning("Index recorded %s but the corpus has no readable file there", relative_path)
+            # The index named this URL's own document, so the rebuild below could
+            # only answer with a different one.
+            return None
 
         # Otherwise rebuild the path from filing metadata that sec_filing_search
         # left in memory. Uses report_date for the year and form.replace("/", "_")
@@ -854,6 +858,13 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
 
         filing_meta = metadata.get(parts["accession_number"].replace("-", ""))
         if not filing_meta:
+            return None
+
+        # Reading primary-document.html for an exhibit URL returns the wrong text
+        # and reports success, so decline whenever the URL names another document.
+        document = parts.get("document", "").strip()
+        primary_document = str(filing_meta.get("primary_document", "")).strip()
+        if document and primary_document and document.lower() != primary_document.lower():
             return None
 
         ticker = filing_meta.get("ticker", "")

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -830,6 +830,79 @@ class TestDumpFromSearch:
         assert server._filing_read_sources["sec-corpus"] == 0
 
     @pytest.mark.asyncio
+    async def test_missing_exhibit_is_not_answered_with_the_primary_document(self, server) -> None:
+        """A recorded path with no file must not reach the convention: it names another document."""
+        await self._search(server)
+        server._filings_cache["0000789019"] = {
+            "000078901925000001": {
+                "ticker": "MSFT",
+                "form": "8-K",
+                "report_date": "2025-01-01",
+                "accession_number": "0000789019-25-000001",
+                "primary_document": "msft-8k.htm",
+            },
+        }
+        # The exhibit is absent from the corpus; its filing's own document is not.
+        self._write_dump(
+            server,
+            "MSFT/8-K/2025/0000789019-25-000001/primary-document.html",
+            "<html><body><p>Convention copy</p></body></html>",
+        )
+
+        with patch.object(server, "_fetch_with_retry", new=AsyncMock(return_value=MOCK_HTML)) as fetch:
+            text_content = await server._fetch_sec_filing_text(self._EXHIBIT_URL)
+
+        assert "Convention copy" not in text_content
+        assert "Company Financial Report" in text_content
+        fetch.assert_called_once()
+        assert server._filing_read_sources["live"] == 1
+        assert server._filing_read_sources["sec-corpus"] == 0
+
+    @pytest.mark.asyncio
+    async def test_convention_declines_a_url_naming_another_document(self, server) -> None:
+        """Reached without any search, as sec_filing_search leaves it."""
+        server._filings_cache["0000320193"] = {
+            "000032019324000009": {
+                "ticker": "AAPL",
+                "form": "10-Q",
+                "report_date": "2024-06-30",
+                "accession_number": "0000320193-24-000009",
+                "primary_document": "aapl-10q.htm",
+            },
+        }
+        self._write_dump(
+            server,
+            "AAPL/10-Q/2024/0000320193-24-000009/primary-document.html",
+            "<html><body><p>Convention copy</p></body></html>",
+        )
+
+        exhibit_url = "https://www.sec.gov/Archives/edgar/data/320193/000032019324000009/aapl-ex101.htm"
+        assert await server._lookup_dump(exhibit_url) is None
+
+    @pytest.mark.asyncio
+    async def test_convention_still_serves_the_filings_own_document(self, server) -> None:
+        server._filings_cache["0000320193"] = {
+            "000032019324000009": {
+                "ticker": "AAPL",
+                "form": "10-Q",
+                "report_date": "2024-06-30",
+                "accession_number": "0000320193-24-000009",
+                "primary_document": "aapl-10q.htm",
+            },
+        }
+        self._write_dump(
+            server,
+            "AAPL/10-Q/2024/0000320193-24-000009/primary-document.html",
+            "<html><body><p>Convention copy</p></body></html>",
+        )
+
+        primary_url = "https://www.sec.gov/Archives/edgar/data/320193/000032019324000009/aapl-10q.htm"
+        text_content = await server._lookup_dump(primary_url)
+
+        assert text_content is not None
+        assert "Convention copy" in text_content
+
+    @pytest.mark.asyncio
     async def test_url_that_was_never_searched_is_fetched_live(self, server) -> None:
         url = "https://www.sec.gov/Archives/edgar/data/1234567/000123456725000001/other.htm"
 


### PR DESCRIPTION
Follow-up to #2990. Thanks @cmunley1 for catching this in review — the answer
is yes, and the same gap turns out to be reachable without any recorded path
at all.

### The two ways a URL becomes a file

A filing on EDGAR is a folder of documents: one primary document, plus
exhibits such as an `EX-99.1` press release, each with its own URL. To serve a
read from the local corpus, `_lookup_dump` has two mechanisms.

The **recorded path** comes from the index, which holds a row per document, so
it can name an exhibit. #2990 added it and gave it precedence.

The **layout convention** rebuilds `ticker/form/year/accession/primary-document.html`
from filing-level metadata. Because that metadata is per filing rather than per
document, this path can only ever name the primary document — but it cannot tell
whether the URL it was handed is that document, so it returns text and reports
success either way.

The convention predates the index by three months (#1304, May) and was written
when `sec_filing_search` was the only search. Every URL that tool emits is built
from the submissions API's `primaryDocument`, so the convention was correct by
construction: a filing-level search feeding filing-level URLs into a filing-level
path rebuild. `edgar_search` (#2722) widened the input domain from filings to
documents, and the fallback kept the old assumption.

### Why the fallback cannot just check where the URL came from

`_lookup_dump` receives a URL and nothing else. Holding a recorded path for it is
the only provenance signal available, and it is a proxy that goes missing while
the URL really did come from `edgar_search`:

- `_record_dump_paths` is deliberately non-fatal, so results reach the model
  while the paths silently go unrecorded
- an index built before the `source_path` / `canonical_url_key` columns returns
  `{}` for every lookup
- `canonical_url_key` drifting from the builder's normalization misses silently
- nothing constrains the read tool's input to a URL that appeared in a search
  result

In each case the URL is indistinguishable from one that was never searched, and
the convention resolves if `sec_filing_search` ran for that CIK earlier. Note
`_filings_cache` is process-level and disk-backed, so "earlier" spans rollouts,
not just the current one.

### Changes

- Decline the convention when the URL names a document other than the filing's
  `primary_document`. This reasons about the URL rather than its provenance, so
  it holds in all four cases above.
- Stop falling through when a recorded path exists but no readable file does,
  and warn: the index and the corpus have drifted apart.
- Both return `None`, which routes to the live fetch — the correct document, one
  request slower. Neither guard fails a read.

One deliberate limit: when the metadata carries no primary-document name, the
first guard does not fire. The URL's document cannot be classified then, and
declining on a guess would push reads back to sec.gov, which is what the corpus
exists to avoid.

### Evidence

Three tests, run against `main` with only `app.py` reverted:

| test | on c50eb20 | with this change |
| --- | --- | --- |
| exhibit whose recorded file is missing | fails — returns the filing's primary document, counted `sec-corpus=1 live=0` | passes — live fetch, `sec-corpus=0 live=1` |
| exhibit URL with no recorded path | fails — returns the filing's primary document | passes — declines, live fetch |
| the filing's own document via the convention | passes | passes |

The third is the no-regression case, and it passing on both sides is what shows
the other two are testing behaviour rather than restating the new code. Full
component suite: 106 passed.