### PR TITLE
fix(model-server): preserve aliases in ORJSON responses

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -181,7 +181,7 @@ def _orjson_dispatch_response(content: Any) -> Any:
     if isinstance(content, Response):
         return content
     if isinstance(content, BaseModel):
-        content = content.model_dump(mode="json")
+        content = content.model_dump(mode="json", by_alias=True)
     return Response(content=orjson.dumps(content), media_type="application/json")
 
 

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -90,6 +90,32 @@ def test_orjson_dispatch_response_serializes_json(content, expected):
     assert response.headers["content-type"] == "application/json"
 
 
+def test_orjson_dispatch_response_preserves_pydantic_aliases():
+    content = NeMoGymResponse(
+        id="resp_1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": "answer",
+                "schema": {"type": "object", "properties": {"answer": {"type": "string"}}},
+            }
+        },
+    )
+
+    body = orjson.loads(_orjson_dispatch_response(content).body)
+    wire_format = body["text"]["format"]
+
+    assert "schema" in wire_format
+    assert "schema_" not in wire_format
+
+
 def test_orjson_dispatch_response_preserves_existing_response():
     existing_response = Response(content=b"already encoded", media_type="application/octet-stream", status_code=202)
 


### PR DESCRIPTION
## Summary
- serialize Pydantic model responses with their declared aliases in the non-streaming ORJSON fast path
- preserve the `text.format.schema` wire contract used by structured-output requests
- add regression coverage using the real `NeMoGymResponse` schema

## Performance
A local in-process benchmark alternated the previous and corrected `model_dump` calls before `orjson.dumps`, with 100 warmups and nine repeats. The corrected path was unchanged for a 1.2 KB response (6.560 vs 6.556 microseconds per operation) and 1.77% slower for a synthetic 71.8 KB response (30.669 vs 31.211 microseconds). The change affects key selection during the existing dump and does not add another traversal.

## Test plan
- [x] `uv run --extra dev pytest -q tests/unit_tests/test_base_responses_api_model.py`
- [x] scoped pre-commit checks for changed files

Closes #3041.
Parent roadmap: #2998.