### PR TITLE
feat(code_gen): accept any capitalisation of Yes/No in stdout comparison

### DIFF
--- a/resources_servers/code_gen/lcb_integration/testing_util.py
+++ b/resources_servers/code_gen/lcb_integration/testing_util.py
@@ -297,6 +297,16 @@ def decimal_lines_match(
     )
 
 
+CASE_INSENSITIVE_VERDICTS = ("yes", "no")
+
+
+def is_case_insensitive_verdict(expected_line: str, predicted_line: str) -> bool:
+    predicted = predicted_line.strip().lower()
+    if predicted not in CASE_INSENSITIVE_VERDICTS:
+        return False
+    return predicted == expected_line.strip().lower()
+
+
 def get_stripped_lines(val: str):
     ## you don't want empty lines to add empty list after splitlines!
     val = val.strip()
@@ -501,6 +511,9 @@ def grade_stdio(
 
             ## CASE 1: exact match
             if stripped_prediction_line == stripped_gt_out_line:
+                continue
+
+            if is_case_insensitive_verdict(stripped_gt_out_line, stripped_prediction_line):
                 continue
 
             ## CASE 2: element-wise comparision

--- a/resources_servers/code_gen/tests/test_case_insensitive_verdict.py
+++ b/resources_servers/code_gen/tests/test_case_insensitive_verdict.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for case-insensitive Yes/No verdicts in stdout comparison."""
+
+from __future__ import annotations
+
+import pytest
+from lcb_integration.testing_util import is_case_insensitive_verdict
+
+
+class TestYesNoIsCaseInsensitive:
+    """Codeforces-style statements accept any capitalisation of Yes/No."""
+
+    @pytest.mark.parametrize(
+        "expected,predicted",
+        [
+            ("Yes", "YES"),
+            ("YES", "yes"),
+            ("yes", "Yes"),
+            ("No", "NO"),
+            ("NO", "no"),
+            ("no", "nO"),
+        ],
+    )
+    def test_capitalisation_variants_match(self, expected, predicted):
+        assert is_case_insensitive_verdict(expected, predicted)
+
+    def test_identical_verdicts_match(self):
+        assert is_case_insensitive_verdict("Yes", "Yes")
+
+
+class TestOnlyYesNoAreCaseInsensitive:
+    """No other answer may become case-insensitive as a side effect."""
+
+    @pytest.mark.parametrize(
+        "expected,predicted",
+        [
+            ("Snuke", "SNUKE"),
+            ("Alice", "alice"),
+            ("First", "FIRST"),
+            ("Fennec", "fennec"),
+        ],
+    )
+    def test_other_words_stay_case_sensitive(self, expected, predicted):
+        assert not is_case_insensitive_verdict(expected, predicted)
+
+    def test_yes_does_not_match_no(self):
+        assert not is_case_insensitive_verdict("No", "YES")
+        assert not is_case_insensitive_verdict("Yes", "NO")
+
+    def test_verdict_does_not_match_unrelated_answer(self):
+        assert not is_case_insensitive_verdict("42", "yes")
+        assert not is_case_insensitive_verdict("Yes", "42")
+
+    def test_multi_token_line_is_not_a_verdict(self):
+        assert not is_case_insensitive_verdict("Yes 1", "YES 1")


### PR DESCRIPTION
## What does this PR do?

Accepts any capitalisation of a `Yes`/`No` verdict in the LiveCodeBench stdout comparison, and only for those two words.

Codeforces-style statements print a Yes/No verdict and explicitly accept any capitalisation, so a solution answering `YES` against a reference of `Yes` is correct on the platform but was scored Wrong Answer here.

## Scope

Deliberately narrow. Tolerance for capitalisation applies only when the predicted line is exactly `yes` or `no` (in any case) and both sides agree case-insensitively. Every other answer stays case-sensitive, so problems whose answer is a name or a word are unaffected, and a line with more than one token is not treated as a verdict at all.

Verified end-to-end through the grader:

| submitted | expected | verdict |
|---|---|---|
| `YES` | `Yes` | accepted |
| `no` | `No` | accepted |
| `NO` | `Yes` | rejected |
| `SNUKE` | `Snuke` | rejected (stays case-sensitive) |
| `FIRST` | `First` | rejected (stays case-sensitive) |
| `alice` | `Alice` | rejected (stays case-sensitive) |
| `YES 1` | `Yes 1` | rejected (multi-token, not a verdict) |

## Why this is separate from #2956

The four changes in #2956 fixed grader faults: correct solutions being scored wrong because of a defect (exact float equality, `StringIO` having no `.buffer`, the int→str digit cap, missing list tolerance). This one is different in kind — it changes accept/reject semantics to match a platform convention, so it deserves its own review rather than riding along.

## Effect on LiveCodeBench scores

**None measured on v6.** Across a 1362-rollout DeepSeek-V4-Flash LCB v6 run, none of the 66 wrong-answer failures differ from their reference by capitalisation alone, so the score is unchanged (the run's projected accuracy stays at 94.93%). The behaviour matters for Codeforces-sourced problems rather than the AtCoder/LeetCode mix in v6.

## Test plan

- New `resources_servers/code_gen/tests/test_case_insensitive_verdict.py` (14 tests): all capitalisation variants of Yes and No, `yes` not matching `no`, verdicts not matching unrelated answers, other words staying case-sensitive, and multi-token lines rejected.
- Full code_gen suite green: 52 passed.
- End-to-end through `run_test` on the 7 cases in the table above, all behaving as intended in both directions.
- Ruff lint, import order and format clean on both changed files (pinned v0.9.9, matching `.pre-commit-config.yaml`).

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
