### PR TITLE
fix(openai_utils): strip redundant outer tool-call names

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -931,22 +931,20 @@ class NeMoGymChatCompletionMessageToolCallFunctionParam(TypedDict, total=False):
     name: Required[str]
 
 
-# `NeMoGymChatCompletionCreateParamsNonStreaming` sets `extra="forbid"`, and
-# pydantic propagates that config into every nested `TypedDict`. Tool calls are
-# echoed back by agents from whatever the provider returned, so they routinely
-# carry provider-specific keys that are not in the OpenAI schema. Opt the tool
-# call shapes out so those keys are dropped rather than rejected; the request
-# model itself stays strict.
-_TOOL_CALL_CONFIG = ConfigDict(extra="ignore")
-
-
+# Clients label a tool call with the tool's name alongside the nested
+# `function.name`, and servers accept it, but the field is absent from OpenAI's
+# own type. Since the request schema forbids extras, and pydantic propagates
+# that into nested `TypedDict`s, its presence rejects the whole conversation.
+# Declared rather than ignored so it round-trips: an unknown field here is
+# still an error, because tool calls carry provider state that a client must
+# echo back verbatim and silently dropping it would corrupt the trajectory.
 class NeMoGymChatCompletionMessageToolCallParam(ChatCompletionMessageToolCallParam):
-    __pydantic_config__ = _TOOL_CALL_CONFIG
     function: NeMoGymChatCompletionMessageToolCallFunctionParam
+    name: NotRequired[str]
 
 
 class NeMoGymChatCompletionMessageCustomToolCallParam(ChatCompletionMessageCustomToolCallParam):
-    __pydantic_config__ = _TOOL_CALL_CONFIG
+    name: NotRequired[str]
 
 
 NeMoGymChatCompletionMessageToolCallUnionParam = Annotated[

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -931,12 +931,22 @@ class NeMoGymChatCompletionMessageToolCallFunctionParam(TypedDict, total=False):
     name: Required[str]
 
 
+# `NeMoGymChatCompletionCreateParamsNonStreaming` sets `extra="forbid"`, and
+# pydantic propagates that config into every nested `TypedDict`. Tool calls are
+# echoed back by agents from whatever the provider returned, so they routinely
+# carry provider-specific keys that are not in the OpenAI schema. Opt the tool
+# call shapes out so those keys are dropped rather than rejected; the request
+# model itself stays strict.
+_TOOL_CALL_CONFIG = ConfigDict(extra="ignore")
+
+
 class NeMoGymChatCompletionMessageToolCallParam(ChatCompletionMessageToolCallParam):
+    __pydantic_config__ = _TOOL_CALL_CONFIG
     function: NeMoGymChatCompletionMessageToolCallFunctionParam
 
 
 class NeMoGymChatCompletionMessageCustomToolCallParam(ChatCompletionMessageCustomToolCallParam):
-    pass
+    __pydantic_config__ = _TOOL_CALL_CONFIG
 
 
 NeMoGymChatCompletionMessageToolCallUnionParam = Annotated[

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -931,20 +931,12 @@ class NeMoGymChatCompletionMessageToolCallFunctionParam(TypedDict, total=False):
     name: Required[str]
 
 
-# Clients label a tool call with the tool's name alongside the nested
-# `function.name`, and servers accept it, but the field is absent from OpenAI's
-# own type. Since the request schema forbids extras, and pydantic propagates
-# that into nested `TypedDict`s, its presence rejects the whole conversation.
-# Declared rather than ignored so it round-trips: an unknown field here is
-# still an error, because tool calls carry provider state that a client must
-# echo back verbatim and silently dropping it would corrupt the trajectory.
 class NeMoGymChatCompletionMessageToolCallParam(ChatCompletionMessageToolCallParam):
     function: NeMoGymChatCompletionMessageToolCallFunctionParam
-    name: NotRequired[str]
 
 
 class NeMoGymChatCompletionMessageCustomToolCallParam(ChatCompletionMessageCustomToolCallParam):
-    name: NotRequired[str]
+    pass
 
 
 NeMoGymChatCompletionMessageToolCallUnionParam = Annotated[
@@ -956,10 +948,34 @@ NeMoGymChatCompletionMessageToolCallUnionParam = Annotated[
 ]
 
 
+def _strip_outer_tool_call_names(value: Any) -> Any:
+    """Copy tool calls carrying a redundant outer name and remove only that field."""
+    if not isinstance(value, list):
+        return value
+
+    normalized = None
+    for index, tool_call in enumerate(value):
+        if not isinstance(tool_call, dict) or "name" not in tool_call:
+            continue
+        if normalized is None:
+            normalized = list(value)
+        normalized_tool_call = dict(tool_call)
+        del normalized_tool_call["name"]
+        normalized[index] = normalized_tool_call
+
+    return value if normalized is None else normalized
+
+
+NeMoGymChatCompletionMessageToolCallsParam: TypeAlias = Annotated[
+    List[NeMoGymChatCompletionMessageToolCallUnionParam],
+    BeforeValidator(_strip_outer_tool_call_names),
+]
+
+
 class NeMoGymChatCompletionAssistantMessageParam(ChatCompletionAssistantMessageParam, total=False):
     # Override the iterable which is annoying to work with.
     content: Union[str, List[ContentArrayOfContentPart], None]
-    tool_calls: Optional[List[NeMoGymChatCompletionMessageToolCallUnionParam]] = None
+    tool_calls: Optional[NeMoGymChatCompletionMessageToolCallsParam] = None
 
 
 class NeMoGymChatCompletionAssistantMessageForTrainingParam(

--- a/tests/unit_tests/test_chat_completions_streaming.py
+++ b/tests/unit_tests/test_chat_completions_streaming.py
@@ -280,6 +280,33 @@ class TestChatDispatchRoute:
         assert resp.status_code == 422
         assert resp.json()["detail"][0]["loc"][0] == "body"
 
+    def test_non_streaming_request_does_not_forward_outer_tool_call_name(self) -> None:
+        client, server = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "name": "get_weather",
+                                "function": {"name": "get_weather", "arguments": "{}"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        forwarded = server.last_params.model_dump(exclude_unset=True)["messages"][0]["tool_calls"][0]
+        assert "name" not in forwarded
+        assert forwarded["function"]["name"] == "get_weather"
+
     def test_streaming_request_returns_synthesized_sse(self) -> None:
         client, server = _client(_EchoChatModel)
         resp = client.post(

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -288,12 +288,11 @@ class TestNeMoGymChatCompletionSchemas:
         assert params.messages[0]["tool_calls"][0]["type"] == "custom"
         assert params.messages[0]["generation_token_ids"] == [2]
 
-    def test_tool_call_keeps_unknown_keys_out_of_the_way(self) -> None:
-        """Agents echo tool calls back verbatim, so they carry provider-specific keys.
+    def test_tool_call_accepts_the_name_field(self) -> None:
+        """Clients label a tool call with the tool's name and servers accept it.
 
-        The request model is `extra="forbid"` and pydantic propagates that into
-        nested TypedDicts, which would otherwise turn a harmless extra key into a
-        hard validation error for every tool-calling agent.
+        The field is absent from OpenAI's type, so a request schema that forbids
+        extras rejects the whole conversation.
         """
         payload = {
             "messages": [
@@ -321,9 +320,12 @@ class TestNeMoGymChatCompletionSchemas:
         tool_call = params.messages[0]["tool_calls"][0]
         assert tool_call["type"] == "function"
         assert tool_call["function"] == {"name": "KB_search", "arguments": '{"query": "hello"}'}
-        assert "name" not in tool_call
+        # Round-trips rather than being dropped.
+        assert tool_call["name"] == "KB_search"
+        dumped = params.model_dump()["messages"][0]["tool_calls"][0]
+        assert dumped["name"] == "KB_search"
 
-    def test_custom_tool_call_keeps_unknown_keys_out_of_the_way(self) -> None:
+    def test_custom_tool_call_accepts_the_name_field(self) -> None:
         payload = {
             "messages": [
                 {
@@ -347,10 +349,37 @@ class TestNeMoGymChatCompletionSchemas:
         tool_call = params.messages[0]["tool_calls"][0]
         assert tool_call["type"] == "custom"
         assert tool_call["custom"] == {"name": "shell", "input": "echo hello"}
-        assert "name" not in tool_call
+        assert tool_call["name"] == "shell"
+
+    def test_tool_call_still_rejects_unknown_fields(self) -> None:
+        """Tool calls carry provider state a client must echo back verbatim.
+
+        Accepting and silently dropping an unknown field would corrupt an
+        otherwise valid trajectory, so it must stay an error.
+        """
+        payload = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                            "not_a_real_field": 1,
+                        }
+                    ],
+                }
+            ],
+            "model": "gpt-test",
+        }
+
+        with pytest.raises(ValidationError):
+            NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
     def test_unknown_top_level_request_key_is_still_rejected(self) -> None:
-        """Tolerating extras on tool calls must not loosen the request model."""
+        """Accepting the tool-call name must not loosen the request model."""
         with pytest.raises(ValidationError):
             NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
                 {

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from copy import deepcopy
 from types import UnionType
 from typing import (
     Annotated,
@@ -288,12 +289,7 @@ class TestNeMoGymChatCompletionSchemas:
         assert params.messages[0]["tool_calls"][0]["type"] == "custom"
         assert params.messages[0]["generation_token_ids"] == [2]
 
-    def test_tool_call_accepts_the_name_field(self) -> None:
-        """Clients label a tool call with the tool's name and servers accept it.
-
-        The field is absent from OpenAI's type, so a request schema that forbids
-        extras rejects the whole conversation.
-        """
+    def test_tool_call_strips_only_the_outer_name_without_mutating_input(self) -> None:
         payload = {
             "messages": [
                 {
@@ -314,18 +310,20 @@ class TestNeMoGymChatCompletionSchemas:
             ],
             "model": "gpt-test",
         }
+        original = deepcopy(payload)
 
         params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
         tool_call = params.messages[0]["tool_calls"][0]
         assert tool_call["type"] == "function"
         assert tool_call["function"] == {"name": "KB_search", "arguments": '{"query": "hello"}'}
-        # Round-trips rather than being dropped.
-        assert tool_call["name"] == "KB_search"
+        assert "name" not in tool_call
         dumped = params.model_dump()["messages"][0]["tool_calls"][0]
-        assert dumped["name"] == "KB_search"
+        assert "name" not in dumped
+        assert dumped["function"]["name"] == "KB_search"
+        assert payload == original
 
-    def test_custom_tool_call_accepts_the_name_field(self) -> None:
+    def test_custom_tool_call_strips_only_the_outer_name_without_mutating_input(self) -> None:
         payload = {
             "messages": [
                 {
@@ -343,33 +341,51 @@ class TestNeMoGymChatCompletionSchemas:
             ],
             "model": "gpt-test",
         }
+        original = deepcopy(payload)
 
         params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
         tool_call = params.messages[0]["tool_calls"][0]
         assert tool_call["type"] == "custom"
         assert tool_call["custom"] == {"name": "shell", "input": "echo hello"}
-        assert tool_call["name"] == "shell"
+        assert "name" not in tool_call
+        assert tool_call["custom"]["name"] == "shell"
+        assert payload == original
 
-    def test_tool_call_still_rejects_unknown_fields(self) -> None:
-        """Tool calls carry provider state a client must echo back verbatim.
-
-        Accepting and silently dropping an unknown field would corrupt an
-        otherwise valid trajectory, so it must stay an error.
-        """
+    @pytest.mark.parametrize(
+        "tool_call",
+        [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+                "not_a_real_field": 1,
+            },
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}", "not_a_real_field": 1},
+            },
+            {
+                "id": "call-1",
+                "type": "custom",
+                "custom": {"name": "shell", "input": "echo hello"},
+                "not_a_real_field": 1,
+            },
+            {
+                "id": "call-1",
+                "type": "custom",
+                "custom": {"name": "shell", "input": "echo hello", "not_a_real_field": 1},
+            },
+        ],
+    )
+    def test_tool_calls_still_reject_other_unknown_fields(self, tool_call: dict[str, Any]) -> None:
         payload = {
             "messages": [
                 {
                     "role": "assistant",
                     "content": "",
-                    "tool_calls": [
-                        {
-                            "id": "call-1",
-                            "type": "function",
-                            "function": {"name": "f", "arguments": "{}"},
-                            "not_a_real_field": 1,
-                        }
-                    ],
+                    "tool_calls": [tool_call],
                 }
             ],
             "model": "gpt-test",
@@ -379,7 +395,7 @@ class TestNeMoGymChatCompletionSchemas:
             NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
     def test_unknown_top_level_request_key_is_still_rejected(self) -> None:
-        """Accepting the tool-call name must not loosen the request model."""
+        """Normalizing the tool-call name must not loosen the request model."""
         with pytest.raises(ValidationError):
             NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
                 {

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -288,6 +288,78 @@ class TestNeMoGymChatCompletionSchemas:
         assert params.messages[0]["tool_calls"][0]["type"] == "custom"
         assert params.messages[0]["generation_token_ids"] == [2]
 
+    def test_tool_call_keeps_unknown_keys_out_of_the_way(self) -> None:
+        """Agents echo tool calls back verbatim, so they carry provider-specific keys.
+
+        The request model is `extra="forbid"` and pydantic propagates that into
+        nested TypedDicts, which would otherwise turn a harmless extra key into a
+        hard validation error for every tool-calling agent.
+        """
+        payload = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "name": "KB_search",
+                            "function": {
+                                "name": "KB_search",
+                                "arguments": '{"query": "hello"}',
+                            },
+                            "type": "function",
+                        }
+                    ],
+                }
+            ],
+            "model": "gpt-test",
+        }
+
+        params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
+
+        tool_call = params.messages[0]["tool_calls"][0]
+        assert tool_call["type"] == "function"
+        assert tool_call["function"] == {"name": "KB_search", "arguments": '{"query": "hello"}'}
+        assert "name" not in tool_call
+
+    def test_custom_tool_call_keeps_unknown_keys_out_of_the_way(self) -> None:
+        payload = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "custom",
+                            "custom": {"name": "shell", "input": "echo hello"},
+                            "name": "shell",
+                        }
+                    ],
+                }
+            ],
+            "model": "gpt-test",
+        }
+
+        params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
+
+        tool_call = params.messages[0]["tool_calls"][0]
+        assert tool_call["type"] == "custom"
+        assert tool_call["custom"] == {"name": "shell", "input": "echo hello"}
+        assert "name" not in tool_call
+
+    def test_unknown_top_level_request_key_is_still_rejected(self) -> None:
+        """Tolerating extras on tool calls must not loosen the request model."""
+        with pytest.raises(ValidationError):
+            NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
+                {
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "model": "gpt-test",
+                    "not_a_real_request_field": True,
+                }
+            )
+
     def test_custom_response_tool_call_round_trip(self) -> None:
         payload = {
             "id": "chatcmpl-1",


### PR DESCRIPTION
## Problem

Some external chat-completions agents replay assistant tool calls with a redundant outer `name` alongside the standard nested `function.name` or `custom.name`. OpenAI's tool-call schema does not define the outer field.

PR #2456 configured `NeMoGymChatCompletionCreateParamsNonStreaming` to reject unknown fields. Pydantic applies that policy to its nested `TypedDict` models, so Gym now rejects the entire request with HTTP 422 when `tool_calls[].name` is present. Before that strict configuration was added, Gym accepted the request and omitted the redundant field before sending it to the model provider.

## Fix

The tool-call list now removes only the redundant outer `tool_calls[].name` before strict schema validation. The normalization is copy-on-write, so it does not mutate the caller's request object.

The nested `function.name` or `custom.name` remains unchanged and continues to identify the tool. Every other unknown request or tool-call field remains a validation error. This avoids silently discarding provider state that may be required when an agent replays a tool call.

## Relationship to #2963

This change and #2963 handle different fields:

- This PR normalizes the redundant `name` inside an assistant message's `tool_calls[]` entry.
- #2963 accepts `name` in the subsequent `role: "tool"` result message.

Neither change replaces the other, and they can merge independently.

## Validation

Regression coverage verifies function and custom tool calls, preservation of their nested names, rejection of unrelated unknown fields, caller-input immutability, and the payload received by the model server. The original Tau3 benchmark failure was reproduced with the same request shape, and removing the redundant outer field prevents the validation failure.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated changes are tracked separately.
- [x] Tests were added or updated for the changed behavior.
- [x] Pre-commit checks pass locally.
- [ ] All commits include DCO sign-off.
