### PR TITLE
docs(sandbox): OpenSandbox best-practices and debugging guides

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -30,6 +30,12 @@ Requests vs limits, timeouts, retries, and the failure signatures that look like
 <Badge minimal outlined>guide</Badge> <Badge minimal outlined>opensandbox</Badge>
 </Card>
 
+<Card title="Debugging OpenSandbox Sandboxes" href="/infrastructure/sandbox/opensandbox-debugging">
+See what CPU and memory a sandbox is getting and using, and detect OOM kills from the client.
+
+<Badge minimal outlined>guide</Badge> <Badge minimal outlined>opensandbox</Badge>
+</Card>
+
 <Card title="E2B Provider" href="/infrastructure/sandbox/e2b">
 Run isolated cloud sandboxes through E2B or an E2B-compatible gateway.
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -24,6 +24,12 @@ Run sandboxes through an OpenSandbox server and SDK.
 <Badge minimal outlined>provider</Badge> <Badge minimal outlined>opensandbox</Badge>
 </Card>
 
+<Card title="OpenSandbox Best Practices" href="/infrastructure/sandbox/opensandbox-best-practices">
+Requests vs limits, timeouts, retries, and the failure signatures that look like bugs but are not — lessons from running thousands of sandboxes.
+
+<Badge minimal outlined>guide</Badge> <Badge minimal outlined>opensandbox</Badge>
+</Card>
+
 <Card title="E2B Provider" href="/infrastructure/sandbox/e2b">
 Run isolated cloud sandboxes through E2B or an E2B-compatible gateway.
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -107,7 +107,11 @@ timeouts do not help a full cluster.
 
 ## Retries: creates yes, commands no
 
-`create.retries` is safe: a failed create leaves nothing behind. `operations.command_retries`
+`create.retries` is safe: a failed create leaves nothing behind. `operations.retries` (shipped:
+`5`, exponential backoff from `retry_delay_s` to `retry_max_delay_s`) covers the SDK calls after
+create — status and endpoint lookups, file transfer, close — plus a command submit that failed at
+TCP connect before the body reached the exec daemon. All of those are idempotent or provably never
+started, so retrying them is safe. `operations.command_retries`
 defaults to `0` and should stay there for agent commands, because a proxy `502` on
 `POST /command` does not mean the command never started — the server maps every transport error
 to 502, including a dropped read *after* the body reached the exec daemon, which runs commands on

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -122,13 +122,6 @@ command and survives any idle timeout.
 
 `connection.request_timeout_s` still governs the submit and the final output fetch.
 
-<Warning>
-Creates failing every ~20 minutes with `Timeout on reading data from socket` is
-`create.request_timeout_s` (1200 s) echoing back: the cluster has no capacity, each create hangs
-for the full budget, and each retry adds another. Check cluster load; more retries or longer
-timeouts do not help a full cluster.
-</Warning>
-
 ### Which timeout you are waiting on
 
 Create is synchronous on the server: schedule the pod, lazy-load the image, start the exec daemon.
@@ -138,6 +131,13 @@ On a healthy cluster that is p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min. On a full
 - `create.timeout_s` must exceed `ready_timeout_s`; it bounds the whole create including the
   readiness wait (the shipped config: 1500 s over 1200 s).
 - `ttl_s` is the server-side backstop if your client dies. Set it above your longest rollout.
+
+<Warning>
+Creates failing every ~20 minutes with `Timeout on reading data from socket` is
+`create.request_timeout_s` (1200 s) echoing back: the cluster has no capacity, each create hangs
+for the full budget, and each retry adds another. Check cluster load; more retries or longer
+timeouts do not help a full cluster.
+</Warning>
 
 ## Retries: creates yes, commands no
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -90,13 +90,25 @@ On a healthy cluster that is p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min. On a full
 
 - `create.timeout_s` must exceed `ready_timeout_s`; it bounds the whole create including the
   readiness wait (the shipped config: 1500 s over 1200 s).
-- `operations.status_poll_timeout_s` (default 10 s) gives status polls their own short budget.
-  Without it, each poll against an unreachable sandbox hangs for the full
-  `connection.request_timeout_s` per retry.
 - `ttl_s` is the server-side backstop if your client dies. Set it above your longest rollout.
-- Keep `operations.background_exec: true`: short polls instead of one long stream, so multi-minute
-  commands survive load balancers with fixed idle timeouts. Keep `background_poll_interval_s` in
-  the tens of seconds — at 1,500 sandboxes a 1 s poll is 1,500 requests/s on the shared server.
+
+### How background execution works
+
+With `operations.background_exec: false`, `exec()` holds one streaming response open for the
+whole command; any load balancer with a fixed idle timeout drops that stream mid-command and the
+client hangs. With `background_exec: true` (the shipped setting) the provider instead submits the
+command with `background=true`, gets an execution id back, polls its status with short GETs, and
+fetches the output once when the status reports finished. It costs a few extra round trips per
+command and survives any idle timeout.
+
+| Knob | Shipped | What it does |
+| --- | --- | --- |
+| `background_poll_initial_s` | `1.0` | Delay before the first status poll. Short, so the many sub-second commands an agent issues are detected promptly. |
+| `background_poll_interval_s` | `30.0` | Ceiling for the poll delay. Each idle poll multiplies the delay by 1.5 until it reaches this, so a long-running command settles at one poll per interval. Steady-state load on the shared server is roughly *running commands ÷ interval*: 1,500 sandboxes at 30 s is ~50 requests/s; at 1 s it would be 1,500. |
+| `status_poll_timeout_s` | `10.0` | Per-poll budget. A status poll is an idempotent GET, so a timed-out poll is retried under `operations.retries` instead of failing the command. Without this knob each poll against an unreachable sandbox hangs for the full `connection.request_timeout_s`, which is sized for long submits. |
+| `exec(timeout_s=...)` | per call | The command timeout is enforced by the server. The client keeps polling until the status reports finished or `timeout_s` + 60 s headroom passes, then raises `TimeoutError`. |
+
+`connection.request_timeout_s` still governs the submit and the final output fetch.
 
 <Warning>
 Creates failing every ~20 minutes with `Timeout on reading data from socket` is

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -110,6 +110,49 @@ provably idempotent workloads.
 Keep `create.skip_health_check: false`. Skipping it lets your first command race a pod whose exec
 daemon is not listening yet, and the resulting 502 kills the rollout.
 
+## Egress controls are off by default
+
+Without a network policy the server creates **no egress sidecar**, and the sandbox has
+unrestricted internet access. For benchmarks that means an agent can `pip install` its way around
+a task, fetch the upstream fix from GitHub, or exfiltrate the test set. Harness-level deny lists
+(such as opencode's `git fetch` / `curl github.com` permission rules) are advisory; the network
+policy is the enforced layer.
+
+Enable it per sandbox with `provider_options.network_policy`. Rules are evaluated in order, match
+FQDNs or wildcard domains, and fall through to `default_action`:
+
+```yaml
+sandbox_config:
+  provider_options:
+    network_policy:
+      default_action: deny
+      egress:
+        - action: allow
+          target: pypi.org
+        - action: allow
+          target: "*.pythonhosted.org"
+        - action: allow
+          target: "*.internal.example.com"   # the hosts the harness itself must reach
+```
+
+What happens on create: the server injects the egress sidecar, drops `NET_ADMIN` from the sandbox
+container so only the sidecar can touch the network stack, and routes DNS through the sidecar.
+Things to know:
+
+- **`dns` vs `dns+nft` is a server setting, not yours.** In `dns` mode only name resolution is
+  filtered — a hard-coded IP bypasses it. `dns+nft` also enforces at the IP layer with nftables
+  (resolved IPs of allowed domains are admitted with a TTL), which is what a real default-deny
+  needs. Ask which mode your cluster runs before relying on the policy for anti-cheating.
+- **Allow what the harness needs, then test with one rollout.** Under `default_action: deny`,
+  anything the agent process calls out to — the Gym model server, a package index, an internal
+  artifact host — must be listed, or the first model call fails inside the sandbox with a
+  connection error that looks like an infrastructure outage.
+- A create with `network_policy` is rejected if the server has no egress image configured; that
+  is a cluster setup gap, not a config typo.
+- `OPENSANDBOX_EGRESS_*` variables in the sandbox `env` configure the sidecar (proxy behavior,
+  nameserver exemptions). Without a `network_policy` they are silently dropped, because there is
+  no sidecar to read them.
+
 ## Failure signatures that are not what they look like
 
 | What you see | What it is | What to do |

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -15,8 +15,9 @@ See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the
    `--config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml` and override only
    the keys you need. Its connection settings are the ones that are hard to get right
    ([connection fields](#connection-fields-that-must-be-right)).
-2. **Set requests separately from limits** — small `resource_requests`, generous `resources`
-   ([requests are not limits](#requests-are-not-limits)).
+2. **Start with low requests and set limits to the max CPU/memory you need** — small
+   `resource_requests` so you pack densely, `resources` sized to your real peaks; never the same
+   map for both ([requests are not limits](#requests-are-not-limits)).
 3. **Leave `derive_cpu_env` on and give agents a bash timeout** — the sandbox sees the host's core
    count, not your limit ([host-core fan-out](#the-host-core-fan-out-trap)).
 4. **Use background execution** — the shipped default; keep the poll interval in the tens of

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -9,6 +9,20 @@ cluster you occupy, your **limits** decide what your commands may use, and both 
 everyone else's runs. Most "OpenSandbox is flaky" reports trace back to one of the traps below.
 See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the config schema.
 
+## Connection fields that must be right
+
+The shipped `nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml` has these set
+correctly; if you copy or override it, keep them.
+
+| Field | Set it to | Why |
+| --- | --- | --- |
+| `connection.domain` | the server's external address, via `OPENSANDBOX_DOMAIN` | The default is the in-cluster service DNS name, which resolves only from pods inside the cluster. From Slurm or a laptop every call fails to connect. |
+| `connection.use_server_proxy` | `true` | With `false`, exec, file and PTY calls dial the sandbox **pod's IP directly**. That only works from inside the cluster; from anywhere else the sandbox is created but every command hangs. Proxy mode routes everything through the server. |
+| `connection.transport_backend` | `aiohttp` | httpx's connection pool degrades badly at high concurrency; the aiohttp bridge (`httpx-aiohttp`, in the `sandbox` extra) does not. If the bridge is missing the provider falls back to httpx with a warning — treat that warning as a setup error. |
+| `connection.max_connections` | `null` | The pool is shared, so this also caps in-flight sandbox operations per process. The httpx default of 100 silently serializes a 1,000-sandbox run. |
+| `connection.keepalive_expiry_s` | below the server's idle timeout (shipped: `3.0`) | A pooled socket reused after the server closed it hangs the SDK. If a load balancer reaps idle connections anyway, set `disable_connection_pooling: true` and pay a handshake per request. |
+| `connection.protocol` | `http` unless you need TLS | TLS load-balancer listeners often have a fixed, short idle timeout that resets multi-minute streams. If you must use `https`, `background_exec: true` (below) is what keeps long commands alive. |
+
 ## Requests are not limits
 
 `resources` becomes the pod's **limits**. Scheduling **requests** are a separate map under

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -30,7 +30,9 @@ See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the
 7. **Clean up zombie sandboxes** — reap an interrupted run by its `run` id, set `ttl_s` as the
    backstop, and keep attribution on so the run is findable ([be a good tenant](#be-a-good-tenant)).
 8. **Check the failure table before filing a bug** — most alarming errors at scale are known and
-   benign ([failure signatures](#failure-signatures-that-are-not-what-they-look-like)).
+   benign ([failure signatures](#failure-signatures-that-are-not-what-they-look-like)). To see what
+   a sandbox is actually getting and using, and to tell an OOM from a timeout, see
+   [Debugging OpenSandbox Sandboxes](/infrastructure/sandbox/opensandbox-debugging).
 
 ## Connection fields that must be right
 
@@ -234,7 +236,7 @@ Things to know:
 | Status poll → `404 unknown execution` on a live sandbox | Stale sandbox→IP routing during create/delete storms. | Treat as a lost execution and recreate; do not tear down other sandboxes. |
 | `Server disconnected` / `Connection reset by peer` on a long stream | Load-balancer idle timeout or a server worker restart. | `background_exec: true`; keep `keepalive_expiry_s` below the server's idle timeout. |
 | `SandboxPtyError: PTY session already has an attached client` on every retry | The sandbox's backend died while the proxy still records the old attachment. | Report the death. Environments must catch `SandboxPtyError` in `verify()`; one unhandled 500 on `/run` can abort the whole eval. |
-| Whole sandbox dies with `137` after one heavy command | Group OOM kill (fan-out above). | Cap parallelism, bash timeout; more memory alone rarely fixes it. |
+| Whole sandbox dies with `137` after one heavy command | Group OOM kill (fan-out above). | Cap parallelism, bash timeout; more memory alone rarely fixes it. See [detecting OOM from the client](/infrastructure/sandbox/opensandbox-debugging#detecting-oom-from-the-client). |
 
 Sandboxes run with the default capability set — no `SYS_PTRACE`, no `SYS_ADMIN`. `strace`/`gdb`
 attach and mount namespaces fail for that reason, not because of your config.

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -21,7 +21,7 @@ See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the
 3. **Leave `derive_cpu_env` on and give agents a bash timeout** — the sandbox sees the host's core
    count, not your limit ([host-core fan-out](#the-host-core-fan-out-trap)).
 4. **Use background execution** — the shipped default; keep the poll interval in the tens of
-   seconds ([background execution](#how-background-execution-works)).
+   seconds ([background execution and timeouts](#background-execution-and-timeouts)).
 5. **Retry creates, never commands** — a retried command can run twice
    ([retries](#retries-creates-yes-commands-no)).
 6. **Turn on egress controls** for any benchmark where the agent must not reach the internet —
@@ -104,17 +104,7 @@ Two things it cannot fix:
   is the validated default; 8 minutes measured quality-negative) so runaway commands fail fast and
   the agent recovers.
 
-## Know which timeout you are waiting on
-
-Create is synchronous on the server: schedule the pod, lazy-load the image, start the exec daemon.
-On a healthy cluster that is p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min. On a full cluster, pods sit
-`Pending` for as long as your timeout allows.
-
-- `create.timeout_s` must exceed `ready_timeout_s`; it bounds the whole create including the
-  readiness wait (the shipped config: 1500 s over 1200 s).
-- `ttl_s` is the server-side backstop if your client dies. Set it above your longest rollout.
-
-### How background execution works
+## Background execution and timeouts
 
 With `operations.background_exec: false`, `exec()` holds one streaming response open for the
 whole command; any load balancer with a fixed idle timeout drops that stream mid-command and the
@@ -138,6 +128,16 @@ Creates failing every ~20 minutes with `Timeout on reading data from socket` is
 for the full budget, and each retry adds another. Check cluster load; more retries or longer
 timeouts do not help a full cluster.
 </Warning>
+
+### Which timeout you are waiting on
+
+Create is synchronous on the server: schedule the pod, lazy-load the image, start the exec daemon.
+On a healthy cluster that is p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min. On a full cluster, pods sit
+`Pending` for as long as your timeout allows.
+
+- `create.timeout_s` must exceed `ready_timeout_s`; it bounds the whole create including the
+  readiness wait (the shipped config: 1500 s over 1200 s).
+- `ttl_s` is the server-side backstop if your client dies. Set it above your longest rollout.
 
 ## Retries: creates yes, commands no
 
@@ -198,21 +198,6 @@ Things to know:
   nameserver exemptions). Without a `network_policy` they are silently dropped, because there is
   no sidecar to read them.
 
-## Failure signatures that are not what they look like
-
-| What you see | What it is | What to do |
-| --- | --- | --- |
-| `No such file or directory` for a file that is in the image (`/testbed`, `/tests/test.sh`, exit 127 on a present binary) during a large create burst | Lazy-loading image flake; the negative lookup got cached. The image is fine. | Retry after ≥60 s; if it fails twice, recreate the sandbox. |
-| Bursts of `502` on `/proxy/.../ping` right after create | Exec daemon not listening yet in a new pod. Self-healing. | Nothing. If it persists for minutes, the cluster is overloaded. |
-| `DELETE` → `404` / "Failed to terminate sandbox" | Already gone (TTL or earlier stop). | Nothing; the provider treats it as success. |
-| Status poll → `404 unknown execution` on a live sandbox | Stale sandbox→IP routing during create/delete storms. | Treat as a lost execution and recreate; do not tear down other sandboxes. |
-| `Server disconnected` / `Connection reset by peer` on a long stream | Load-balancer idle timeout or a server worker restart. | `background_exec: true`; keep `keepalive_expiry_s` below the server's idle timeout. |
-| `SandboxPtyError: PTY session already has an attached client` on every retry | The sandbox's backend died while the proxy still records the old attachment. | Report the death. Environments must catch `SandboxPtyError` in `verify()`; one unhandled 500 on `/run` can abort the whole eval. |
-| Whole sandbox dies with `137` after one heavy command | Group OOM kill (fan-out above). | Cap parallelism, bash timeout; more memory alone rarely fixes it. |
-
-Sandboxes run with the default capability set — no `SYS_PTRACE`, no `SYS_ADMIN`. `strace`/`gdb`
-attach and mount namespaces fail for that reason, not because of your config.
-
 ## Be a good tenant
 
 - **Keep attribution on.** Inside Kubernetes (no Slurm variables, OS user `root`) set
@@ -232,3 +217,18 @@ attach and mount namespaces fail for that reason, not because of your config.
   instead of downloading it.
 - **Stop sandboxes in the background.** Teardown is a provider round-trip you never need to wait
   for; `ttl_s` reaps anything a background stop misses.
+
+## Failure signatures that are not what they look like
+
+| What you see | What it is | What to do |
+| --- | --- | --- |
+| `No such file or directory` for a file that is in the image (`/testbed`, `/tests/test.sh`, exit 127 on a present binary) during a large create burst | Lazy-loading image flake; the negative lookup got cached. The image is fine. | Retry after ≥60 s; if it fails twice, recreate the sandbox. |
+| Bursts of `502` on `/proxy/.../ping` right after create | Exec daemon not listening yet in a new pod. Self-healing. | Nothing. If it persists for minutes, the cluster is overloaded. |
+| `DELETE` → `404` / "Failed to terminate sandbox" | Already gone (TTL or earlier stop). | Nothing; the provider treats it as success. |
+| Status poll → `404 unknown execution` on a live sandbox | Stale sandbox→IP routing during create/delete storms. | Treat as a lost execution and recreate; do not tear down other sandboxes. |
+| `Server disconnected` / `Connection reset by peer` on a long stream | Load-balancer idle timeout or a server worker restart. | `background_exec: true`; keep `keepalive_expiry_s` below the server's idle timeout. |
+| `SandboxPtyError: PTY session already has an attached client` on every retry | The sandbox's backend died while the proxy still records the old attachment. | Report the death. Environments must catch `SandboxPtyError` in `verify()`; one unhandled 500 on `/run` can abort the whole eval. |
+| Whole sandbox dies with `137` after one heavy command | Group OOM kill (fan-out above). | Cap parallelism, bash timeout; more memory alone rarely fixes it. |
+
+Sandboxes run with the default capability set — no `SYS_PTRACE`, no `SYS_ADMIN`. `strace`/`gdb`
+attach and mount namespaces fail for that reason, not because of your config.

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -170,8 +170,6 @@ attach and mount namespaces fail for that reason, not because of your config.
 
 ## Be a good tenant
 
-- **Check load before a large launch**: `GET /v1/sandboxes?pageSize=1` and read `totalItems`.
-  Near the cluster's ceiling, every create becomes a 20-minute wait for everyone. Stagger runs.
 - **Keep attribution on.** Inside Kubernetes (no Slurm variables, OS user `root`) set
   `NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD` on the pod, or nobody can tell whose run
   is filling the cluster.

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -27,6 +27,9 @@ correctly; if you copy or override it, keep them.
 
 `resources` becomes the pod's **limits**. Scheduling **requests** are a separate map under
 `provider_options.resource_requests`. If you set only `resources`, the server uses it as both.
+These are Kubernetes
+[requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits)
+applied to the sandbox container.
 
 ```yaml
 sandbox_config:

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -1,0 +1,194 @@
+---
+title: "OpenSandbox Best Practices"
+description: "Field-tested guidance for running Gym environments on OpenSandbox at scale: resource requests vs limits, timeouts, retries, and the failure signatures that look like bugs but are not."
+position: 2
+---
+
+This page collects what we learned running thousands of concurrent OpenSandbox sandboxes for
+agentic benchmarks (SWE-bench, Terminal-Bench, DeepSWE). Every recommendation here came from a
+real incident or a measured A/B, and each section starts with the trap it prevents. Read the
+[OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page first for the config schema.
+
+<Note>
+The single most important idea: **one sandbox is one Kubernetes pod on a shared cluster.** Your
+resource requests decide how much of the cluster you occupy, your limits decide what your commands
+may use, and both are shared with everyone else's runs. Most "OpenSandbox is flaky" reports trace
+back to one of the misconfigurations below.
+</Note>
+
+## Resources: requests are not limits
+
+`SandboxSpec.resources` (the `resources:` block in an agent or resources-server `sandbox_config`)
+becomes the pod's **limits** — the ceiling a command may consume before it is throttled or
+OOM-killed. Scheduling **requests** — the capacity the cluster reserves for you — are a separate
+map under `provider_options.resource_requests`. If you set only `resources`, the server applies
+that single map as *both* requests and limits.
+
+```yaml
+sandbox_config:
+  resources:                # LIMITS: what a command may burst to
+    cpu: 4
+    memory_mib: 16384
+    disk_gib: 30
+  provider_options:
+    resource_requests:      # REQUESTS: what the scheduler reserves; keep these small
+      cpu: 0.5
+      memory_mib: 512
+      disk_gib: 30
+```
+
+<Warning>
+**Trap: requests == limits.** A sandbox requesting `4` CPU / `32Gi` occupies the same node
+capacity as roughly thirty sandboxes requesting `0.5` CPU / `512Mi`. On a shared cluster one such
+run can hold ~70% of all reserved memory with under 10% of the pods, pushing everyone else's
+creates into `Pending`. The symptom others see is "sandbox create timed out", not "someone
+over-requested".
+</Warning>
+
+Why low requests are safe: sandbox workloads are bursty (an agent thinks, runs a test, thinks
+again), so dense packing with generous limits was measured contention-free — median memory use
+~1.2–1.9 GB against a 16 GiB limit, with occasional 7–16 GB peaks during test/build phases. The
+limits protect you during the peaks; the small requests keep the cluster usable for everyone.
+
+Guidance:
+
+| Knob | Recommended | Why |
+| --- | --- | --- |
+| `resources.cpu` (limit) | `4` | Best reward/failure profile measured on SWE-bench Verified; `2` raised sandbox-fatal exec errors ~15×. |
+| `resources.memory_mib` (limit) | `16384` | Covers observed build/test peaks; raising it further mostly treats symptoms (see fan-out below). |
+| `resource_requests.cpu` | `0.5` | Dense packing measured contention-free for agentic workloads. |
+| `resource_requests.memory_mib` | `512` | Same. |
+| `disk_gib` | `30` | Works on every provider; keep requests and limits identical for disk. |
+
+## The host-core fan-out trap
+
+Inside a sandbox, `nproc`, `os.cpu_count()`, `os.cpus()` and friends report the **host's** core
+count (often 128–192), not your CPU limit. Any tool that sizes a worker pool from that number —
+old `jest` (`maxWorkers = cores-1`), Python `multiprocessing`/`ProcessPool`, `pytest-xdist -n auto`,
+`make -j$(nproc)`, Rust test threads, OpenBLAS — will fan out to 100+ processes inside a 4-CPU,
+16 GiB box. The result is either a container OOM kill or a near-miss that thrashes at the memory
+ceiling and runs 10× slower under CFS throttling. Because it depends on the repo's tooling, it
+looks random and task-specific.
+
+Gym mitigates this with `derive_cpu_env` (default `true` in the SWE-bench configs): the provider
+derives a set of cap variables from `resources.cpu` and injects them into the sandbox
+environment — `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `PYTHON_CPU_COUNT`,
+`PYTEST_XDIST_AUTO_NUM_WORKERS`, `DJANGO_TEST_PROCESSES`, `GOMAXPROCS`, `CARGO_BUILD_JOBS`,
+`RAYON_NUM_THREADS`, `UV_THREADPOOL_SIZE`, `CMAKE_BUILD_PARALLEL_LEVEL`, and others (see
+`CPU_CAP_ENV_VARS` in `nemo_gym/sandbox/utils.py`). Explicit `sandbox_config.env` keys always win.
+
+Two things the caps do **not** cover, so plan for them:
+
+- **Runners that ignore the environment**: old `jest`, plain `make`, `ninja`, and Python
+  `multiprocessing.cpu_count()` before 3.13 (`PYTHON_CPU_COUNT` only helps on 3.13+; `taskset`
+  does not help either — it counts configured CPUs, not affinity). If your tasks hit these, add a
+  repo-specific cap in the task's setup command or bake it into the image.
+- **Agent-written runaway code** (unbounded recursion, giant allocations in intermediate
+  attempts). These are the majority of OOMs on coding benchmarks and no limit fixes them; note
+  that Kubernetes group-OOM kills the *whole* sandbox, so one runaway command ends the rollout.
+  Give agents a bash timeout (the validated default is 2 minutes; 8 minutes measured
+  quality-negative) so runaway commands fail fast and the agent can recover.
+
+## Timeouts: know which one you are waiting on
+
+Sandbox create is synchronous on the server: it waits for the pod to be scheduled, the image to
+lazy-load, and the exec daemon to start. Server-side create latency on a healthy cluster is
+p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min — but when the cluster is at its capacity ceiling, pods sit
+`Pending` for as long as your timeout allows.
+
+- `create.timeout_s` must **exceed** `SandboxSpec.ready_timeout_s`; it bounds the whole create
+  call including the readiness wait (the shipped config uses 1500 s over a 1200 s readiness wait).
+- `connection.request_timeout_s` is the per-request budget for long submits. Status polls are
+  small idempotent GETs and get their own short budget via `operations.status_poll_timeout_s`
+  (default 10 s) — without it, every poll against an unreachable sandbox hangs for the full
+  request timeout per retry.
+- `ttl_s` is the server-side backstop that reaps a sandbox if your client dies. Set it above your
+  longest rollout, not to "infinite".
+
+<Warning>
+**Trap: failures on an exact N-minute cadence.** If creates fail every ~20 minutes with
+`Timeout on reading data from socket`, that is your `create.request_timeout_s` (1200 s) echoing
+back: creates are hanging for the full budget server-side because the cluster has no capacity, and
+each retry adds another full period. Check cluster load before adding retries or raising timeouts;
+neither helps a full cluster.
+</Warning>
+
+Also keep long-lived streams off load balancers with short idle timeouts. The default
+`operations.background_exec: true` polls status instead of holding one SSE stream open per
+command, precisely so multi-minute commands survive TLS listeners with fixed idle limits; keep it
+on, and keep `background_poll_interval_s` in the tens of seconds — at 1,500 concurrent sandboxes a
+1 s poll interval is 1,500 requests per second against the shared server.
+
+## Retries: creates yes, commands no
+
+`create.retries` (default 10) is safe: a failed create leaves nothing behind you care about.
+`operations.command_retries` defaults to `0` and should stay there for agent commands.
+
+A proxy `502` on `POST /command` does **not** mean the command never started. The server maps
+every transport error to 502, including a dropped read *after* the body reached the exec daemon,
+and the daemon runs commands on a detached context that a dropped connection never cancels. A
+retried `git apply` or `pip install` therefore runs twice. In production tracking of >100k
+requests this race never actually fired — but the cost of being wrong is a corrupted rollout, and
+the harness already surfaces the error for you to handle. Raise `command_retries` only for
+provably idempotent workloads.
+
+Keep `create.skip_health_check: false`. Skipping it lets your first command race a pod whose exec
+daemon is not listening yet; the resulting 502 kills the rollout.
+
+## Failure signatures that are not what they look like
+
+| What you see | What it usually is | What to do |
+| --- | --- | --- |
+| `No such file or directory` for a file that is definitely in the image (`/tests/test.sh`, `/testbed`, `command -v` failing on a present binary, exit 127) during a large create burst | Lazy-loading image flake: an in-flight read was aborted and the negative lookup got cached. The image is fine. | Retry after ≥60 s (an immediate retry often fails again); if it fails twice, recreate the sandbox. Reduce same-image create/delete churn where you can. |
+| Bursts of `502` on `/proxy/.../ping` right after create | The exec daemon is not listening yet in a just-started pod. Normal startup latency, self-healing. | Nothing; the provider's readiness probe absorbs it. If it persists for minutes, the cluster is overloaded. |
+| `DELETE` returns `404` / "Failed to terminate sandbox ... not found" | The sandbox already went away (TTL or a previous stop). | Nothing. The provider treats this as success. |
+| A command's status poll returns `404 unknown execution` on a sandbox that is alive | Stale sandbox→IP routing in the server under create/delete storms; the poll reached a reused pod IP. | Treat as a lost execution and recreate; do not tear down other healthy sandboxes over it. |
+| `Server disconnected` / `Connection reset by peer` on a long stream | Load-balancer idle timeout, or a server worker restart. | Use `background_exec: true` and short polls; keep `keepalive_expiry_s` below the server's idle timeout. |
+| `SandboxPtyError: PTY session already has an attached client` on every takeover retry | The sandbox's backend died while the proxy still records the old attachment. | Check sandbox status and report the death. Environments must catch `SandboxPtyError` in `verify()` — one unhandled 500 on `/run` can abort an entire eval. |
+| Sandbox-wide death with `137` after one heavy command | Group OOM kill (see fan-out above). | Cap parallelism, add a bash timeout; raising memory alone rarely fixes it. |
+
+Sandboxes also run with the default runtime capability set — no `SYS_PTRACE`, no `SYS_ADMIN`.
+Tasks that need `strace`/`gdb` attach or mount namespaces will fail for that reason, not because
+of your config.
+
+## Be a good tenant
+
+- **Check load before a large launch.** List the server's sandboxes (`GET /v1/sandboxes` with a
+  small page size and read `totalItems`) and look at how many of your own are still creating. A
+  cluster near its pod or request ceiling turns every create into a 20-minute wait for everyone.
+  Stagger large runs instead of starting several at once.
+- **Keep attribution on.** The provider's `attribution` block labels every sandbox with
+  `team`/`user`/`workload`/`run`. When Gym runs inside Kubernetes (no Slurm variables, OS user is
+  `root`), set `NEMO_GYM_TEAM`/`NEMO_GYM_USER`/`NEMO_GYM_WORKLOAD` on the pod, or your sandboxes
+  are invisible to per-team accounting and nobody can tell whose run is filling the cluster.
+- **Clean up interrupted runs.** Note the `run` id logged at the first create and reap exactly that
+  run's sandboxes:
+
+  ```bash
+  python -m nemo_gym.sandbox.providers.opensandbox.cleanup_sandboxes \
+    --domain "$OPENSANDBOX_DOMAIN" --api-key "$OPENSANDBOX_API_KEY" \
+    --run-id <run-id> --user <user>          # audit
+  python -m nemo_gym.sandbox.providers.opensandbox.cleanup_sandboxes ... --reap   # delete
+  ```
+
+  Rely on `ttl_s` only as the backstop.
+- **Do not `apt-get` inside every sandbox.** Installing a tool per rollout costs 10–40 s of network
+  time, multiplied by thousands of rollouts, and any registry hiccup fails the step. Bake tools into
+  the task image, or mount a prebuilt binary and run it from there. The same goes for downloading
+  the agent binary: mount it.
+- **Keep teardown off your critical path.** Stopping a sandbox is a provider round-trip you never
+  need to wait for; schedule it in the background (bounded by a timeout) so the rollout's
+  concurrency slot frees as soon as verification returns. The provider's TTL reaps anything a
+  background stop misses.
+
+## Sizing quick reference
+
+| Environment shape | cpu / memory limit | requests | bash timeout |
+| --- | --- | --- | --- |
+| Python-heavy repos (SWE-bench Verified) | `4` / `16 GiB` | `0.5` / `512 MiB` | 2 min |
+| Polyglot repos (SWE-bench Multilingual) | `4` / `16 GiB` | `0.5` / `512 MiB` | 2 min |
+| Terminal / build-heavy tasks | `4` / `16 GiB`, consider `8` only after measuring throttling | `0.5` / `512 MiB` | 2 min |
+
+If you believe a task class needs more, measure first: sandbox cgroup `memory.peak` and
+`cpu.stat` throttled time are readable inside the sandbox, and Gym's opencode agent can record
+them per rollout. Raise limits based on peaks you observed, not on the failure message.

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -18,8 +18,9 @@ See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the
 2. **Start with low requests and set limits to the max CPU/memory you need** — small
    `resource_requests` so you pack densely, `resources` sized to your real peaks; never the same
    map for both ([requests are not limits](#requests-are-not-limits)).
-3. **Leave `derive_cpu_env` on and give agents a bash timeout** — the sandbox sees the host's core
-   count, not your limit ([host-core fan-out](#the-host-core-fan-out-trap)).
+3. **Check what CPU count your sandbox actually sees** — on many clusters it is the host's cores,
+   not your limit, and that varies cluster to cluster. Be mindful of it: leave `derive_cpu_env`
+   on and give agents a bash timeout ([host-core fan-out](#the-host-core-fan-out-trap)).
 4. **Use background execution** — the shipped default; keep the poll interval in the tens of
    seconds ([background execution and timeouts](#background-execution-and-timeouts)).
 5. **Retry creates, never commands** — a retried command can run twice
@@ -80,25 +81,30 @@ inside the sandbox — not from a failure message.
 
 ## The host-core fan-out trap
 
-Inside a sandbox, `nproc`, `os.cpu_count()` and `os.cpus()` report the **host's** cores (often
-128–192), not your limit. Tools that size worker pools from that number — old `jest`, Python
+What a sandbox reports as its CPU count **varies cluster to cluster**. On a plain Kubernetes node,
+`nproc`, `os.cpu_count()` and `os.cpus()` report the **host's** cores (often 128–192), not your
+limit. Clusters that run [LXCFS](https://linuxcontainers.org/lxcfs/introduction/) overlay
+`/proc/cpuinfo`, `/proc/meminfo` and `/sys/devices/system/cpu/online` with cgroup-aware values, so
+the same tools report your limit instead. Check before assuming either — run `nproc` and
+`python -c 'import os; print(os.cpu_count())'` in one sandbox on the cluster you are about to use.
+
+Where the host count leaks through, tools that size worker pools from it — old `jest`, Python
 `multiprocessing`, `pytest -n auto`, `make -j$(nproc)`, OpenBLAS — fan out to 100+ processes in a
 4-CPU, 16 GiB box. The result is an OOM kill, or a near-miss that thrashes at the memory ceiling
 and runs 10× slower. It depends on each repo's tooling, so it looks random.
 
-`derive_cpu_env` (default `true` in the SWE-bench configs) injects cap variables derived from
-`resources.cpu` — `OMP_NUM_THREADS`, `PYTHON_CPU_COUNT`, `PYTEST_XDIST_AUTO_NUM_WORKERS`,
-`GOMAXPROCS`, `CARGO_BUILD_JOBS`, `UV_THREADPOOL_SIZE`, and others; see `CPU_CAP_ENV_VARS` in
-`nemo_gym/sandbox/utils.py`. Explicit `sandbox_config.env` keys win.
+`derive_cpu_env` (default `true` in the SWE-bench configs) is the portable mitigation: it injects
+cap variables derived from `resources.cpu` — `OMP_NUM_THREADS`, `PYTHON_CPU_COUNT`,
+`PYTEST_XDIST_AUTO_NUM_WORKERS`, `GOMAXPROCS`, `CARGO_BUILD_JOBS`, `UV_THREADPOOL_SIZE`, and
+others; see `CPU_CAP_ENV_VARS` in `nemo_gym/sandbox/utils.py`. Explicit `sandbox_config.env` keys
+win. Leave it on even where LXCFS is present; it is harmless there and protects you when the same
+config moves to a cluster without it.
 
 Two things it cannot fix:
 
 - Runners that ignore the environment: old `jest`, plain `make`, `ninja`, and Python
-  `multiprocessing` before 3.13. Cap these in the task's setup command or the image. Some
-  clusters run [LXCFS](https://linuxcontainers.org/lxcfs/introduction/), which overlays
-  `/proc/cpuinfo`, `/proc/meminfo`, and `/sys/devices/system/cpu/online` with cgroup-aware
-  values so these tools see the limit instead of the host — check `nproc` inside a sandbox to
-  find out; where it is present, this class of fan-out disappears.
+  `multiprocessing` before 3.13. On clusters without LXCFS, cap these in the task's setup command
+  or the image.
 - Agent-written runaway code. This is the majority of OOMs on coding benchmarks, and Kubernetes
   group-OOM kills the **whole sandbox**, ending the rollout. Give agents a bash timeout (2 minutes
   is the validated default; 8 minutes measured quality-negative) so runaway commands fail fast and

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -1,194 +1,134 @@
 ---
 title: "OpenSandbox Best Practices"
-description: "Field-tested guidance for running Gym environments on OpenSandbox at scale: resource requests vs limits, timeouts, retries, and the failure signatures that look like bugs but are not."
+description: "Resource requests vs limits, timeouts, retries, and the failure signatures that look like bugs but are not — lessons from running thousands of concurrent sandboxes."
 position: 2
 ---
 
-This page collects what we learned running thousands of concurrent OpenSandbox sandboxes for
-agentic benchmarks (SWE-bench, Terminal-Bench, DeepSWE). Every recommendation here came from a
-real incident or a measured A/B, and each section starts with the trap it prevents. Read the
-[OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page first for the config schema.
+One sandbox is one Kubernetes pod on a shared cluster. Your **requests** decide how much of the
+cluster you occupy, your **limits** decide what your commands may use, and both are shared with
+everyone else's runs. Most "OpenSandbox is flaky" reports trace back to one of the traps below.
+See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the config schema.
 
-<Note>
-The single most important idea: **one sandbox is one Kubernetes pod on a shared cluster.** Your
-resource requests decide how much of the cluster you occupy, your limits decide what your commands
-may use, and both are shared with everyone else's runs. Most "OpenSandbox is flaky" reports trace
-back to one of the misconfigurations below.
-</Note>
+## Requests are not limits
 
-## Resources: requests are not limits
-
-`SandboxSpec.resources` (the `resources:` block in an agent or resources-server `sandbox_config`)
-becomes the pod's **limits** — the ceiling a command may consume before it is throttled or
-OOM-killed. Scheduling **requests** — the capacity the cluster reserves for you — are a separate
-map under `provider_options.resource_requests`. If you set only `resources`, the server applies
-that single map as *both* requests and limits.
+`resources` becomes the pod's **limits**. Scheduling **requests** are a separate map under
+`provider_options.resource_requests`. If you set only `resources`, the server uses it as both.
 
 ```yaml
 sandbox_config:
-  resources:                # LIMITS: what a command may burst to
+  resources:                # limits: what a command may burst to
     cpu: 4
     memory_mib: 16384
     disk_gib: 30
   provider_options:
-    resource_requests:      # REQUESTS: what the scheduler reserves; keep these small
+    resource_requests:      # requests: what the scheduler reserves for you
       cpu: 0.5
       memory_mib: 512
       disk_gib: 30
 ```
 
 <Warning>
-**Trap: requests == limits.** A sandbox requesting `4` CPU / `32Gi` occupies the same node
-capacity as roughly thirty sandboxes requesting `0.5` CPU / `512Mi`. On a shared cluster one such
-run can hold ~70% of all reserved memory with under 10% of the pods, pushing everyone else's
-creates into `Pending`. The symptom others see is "sandbox create timed out", not "someone
-over-requested".
+A sandbox requesting `4` CPU / `32Gi` occupies the cluster capacity of ~30 sandboxes requesting
+`0.5` / `512Mi`. One run configured that way pushes everyone else's creates into `Pending`, and
+what they see is "sandbox create timed out".
 </Warning>
 
-Why low requests are safe: sandbox workloads are bursty (an agent thinks, runs a test, thinks
-again), so dense packing with generous limits was measured contention-free — median memory use
-~1.2–1.9 GB against a 16 GiB limit, with occasional 7–16 GB peaks during test/build phases. The
-limits protect you during the peaks; the small requests keep the cluster usable for everyone.
-
-Guidance:
-
-| Knob | Recommended | Why |
-| --- | --- | --- |
-| `resources.cpu` (limit) | `4` | Best reward/failure profile measured on SWE-bench Verified; `2` raised sandbox-fatal exec errors ~15×. |
-| `resources.memory_mib` (limit) | `16384` | Covers observed build/test peaks; raising it further mostly treats symptoms (see fan-out below). |
-| `resource_requests.cpu` | `0.5` | Dense packing measured contention-free for agentic workloads. |
-| `resource_requests.memory_mib` | `512` | Same. |
-| `disk_gib` | `30` | Works on every provider; keep requests and limits identical for disk. |
+Low requests are safe because agent workloads are bursty: median memory use is ~1–2 GB against a
+16 GiB limit, with occasional 7–16 GB peaks during builds and tests. The limits cover the peaks;
+the small requests keep the cluster usable. The values above are the validated defaults for
+SWE-bench-style environments; raise a limit only after measuring `memory.peak` or CPU throttling
+inside the sandbox — not from a failure message.
 
 ## The host-core fan-out trap
 
-Inside a sandbox, `nproc`, `os.cpu_count()`, `os.cpus()` and friends report the **host's** core
-count (often 128–192), not your CPU limit. Any tool that sizes a worker pool from that number —
-old `jest` (`maxWorkers = cores-1`), Python `multiprocessing`/`ProcessPool`, `pytest-xdist -n auto`,
-`make -j$(nproc)`, Rust test threads, OpenBLAS — will fan out to 100+ processes inside a 4-CPU,
-16 GiB box. The result is either a container OOM kill or a near-miss that thrashes at the memory
-ceiling and runs 10× slower under CFS throttling. Because it depends on the repo's tooling, it
-looks random and task-specific.
+Inside a sandbox, `nproc`, `os.cpu_count()` and `os.cpus()` report the **host's** cores (often
+128–192), not your limit. Tools that size worker pools from that number — old `jest`, Python
+`multiprocessing`, `pytest -n auto`, `make -j$(nproc)`, OpenBLAS — fan out to 100+ processes in a
+4-CPU, 16 GiB box. The result is an OOM kill, or a near-miss that thrashes at the memory ceiling
+and runs 10× slower. It depends on each repo's tooling, so it looks random.
 
-Gym mitigates this with `derive_cpu_env` (default `true` in the SWE-bench configs): the provider
-derives a set of cap variables from `resources.cpu` and injects them into the sandbox
-environment — `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `PYTHON_CPU_COUNT`,
-`PYTEST_XDIST_AUTO_NUM_WORKERS`, `DJANGO_TEST_PROCESSES`, `GOMAXPROCS`, `CARGO_BUILD_JOBS`,
-`RAYON_NUM_THREADS`, `UV_THREADPOOL_SIZE`, `CMAKE_BUILD_PARALLEL_LEVEL`, and others (see
-`CPU_CAP_ENV_VARS` in `nemo_gym/sandbox/utils.py`). Explicit `sandbox_config.env` keys always win.
+`derive_cpu_env` (default `true` in the SWE-bench configs) injects cap variables derived from
+`resources.cpu` — `OMP_NUM_THREADS`, `PYTHON_CPU_COUNT`, `PYTEST_XDIST_AUTO_NUM_WORKERS`,
+`GOMAXPROCS`, `CARGO_BUILD_JOBS`, `UV_THREADPOOL_SIZE`, and others; see `CPU_CAP_ENV_VARS` in
+`nemo_gym/sandbox/utils.py`. Explicit `sandbox_config.env` keys win.
 
-Two things the caps do **not** cover, so plan for them:
+Two things it cannot fix:
 
-- **Runners that ignore the environment**: old `jest`, plain `make`, `ninja`, and Python
-  `multiprocessing.cpu_count()` before 3.13 (`PYTHON_CPU_COUNT` only helps on 3.13+; `taskset`
-  does not help either — it counts configured CPUs, not affinity). If your tasks hit these, add a
-  repo-specific cap in the task's setup command or bake it into the image.
-- **Agent-written runaway code** (unbounded recursion, giant allocations in intermediate
-  attempts). These are the majority of OOMs on coding benchmarks and no limit fixes them; note
-  that Kubernetes group-OOM kills the *whole* sandbox, so one runaway command ends the rollout.
-  Give agents a bash timeout (the validated default is 2 minutes; 8 minutes measured
-  quality-negative) so runaway commands fail fast and the agent can recover.
+- Runners that ignore the environment: old `jest`, plain `make`, `ninja`, and Python
+  `multiprocessing` before 3.13. Cap these in the task's setup command or the image.
+- Agent-written runaway code. This is the majority of OOMs on coding benchmarks, and Kubernetes
+  group-OOM kills the **whole sandbox**, ending the rollout. Give agents a bash timeout (2 minutes
+  is the validated default; 8 minutes measured quality-negative) so runaway commands fail fast and
+  the agent recovers.
 
-## Timeouts: know which one you are waiting on
+## Know which timeout you are waiting on
 
-Sandbox create is synchronous on the server: it waits for the pod to be scheduled, the image to
-lazy-load, and the exec daemon to start. Server-side create latency on a healthy cluster is
-p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min — but when the cluster is at its capacity ceiling, pods sit
+Create is synchronous on the server: schedule the pod, lazy-load the image, start the exec daemon.
+On a healthy cluster that is p50 ≈ 7 s, p90 ≈ 20 s, p99 ≈ 2 min. On a full cluster, pods sit
 `Pending` for as long as your timeout allows.
 
-- `create.timeout_s` must **exceed** `SandboxSpec.ready_timeout_s`; it bounds the whole create
-  call including the readiness wait (the shipped config uses 1500 s over a 1200 s readiness wait).
-- `connection.request_timeout_s` is the per-request budget for long submits. Status polls are
-  small idempotent GETs and get their own short budget via `operations.status_poll_timeout_s`
-  (default 10 s) — without it, every poll against an unreachable sandbox hangs for the full
-  request timeout per retry.
-- `ttl_s` is the server-side backstop that reaps a sandbox if your client dies. Set it above your
-  longest rollout, not to "infinite".
+- `create.timeout_s` must exceed `ready_timeout_s`; it bounds the whole create including the
+  readiness wait (the shipped config: 1500 s over 1200 s).
+- `operations.status_poll_timeout_s` (default 10 s) gives status polls their own short budget.
+  Without it, each poll against an unreachable sandbox hangs for the full
+  `connection.request_timeout_s` per retry.
+- `ttl_s` is the server-side backstop if your client dies. Set it above your longest rollout.
+- Keep `operations.background_exec: true`: short polls instead of one long stream, so multi-minute
+  commands survive load balancers with fixed idle timeouts. Keep `background_poll_interval_s` in
+  the tens of seconds — at 1,500 sandboxes a 1 s poll is 1,500 requests/s on the shared server.
 
 <Warning>
-**Trap: failures on an exact N-minute cadence.** If creates fail every ~20 minutes with
-`Timeout on reading data from socket`, that is your `create.request_timeout_s` (1200 s) echoing
-back: creates are hanging for the full budget server-side because the cluster has no capacity, and
-each retry adds another full period. Check cluster load before adding retries or raising timeouts;
-neither helps a full cluster.
+Creates failing every ~20 minutes with `Timeout on reading data from socket` is
+`create.request_timeout_s` (1200 s) echoing back: the cluster has no capacity, each create hangs
+for the full budget, and each retry adds another. Check cluster load; more retries or longer
+timeouts do not help a full cluster.
 </Warning>
-
-Also keep long-lived streams off load balancers with short idle timeouts. The default
-`operations.background_exec: true` polls status instead of holding one SSE stream open per
-command, precisely so multi-minute commands survive TLS listeners with fixed idle limits; keep it
-on, and keep `background_poll_interval_s` in the tens of seconds — at 1,500 concurrent sandboxes a
-1 s poll interval is 1,500 requests per second against the shared server.
 
 ## Retries: creates yes, commands no
 
-`create.retries` (default 10) is safe: a failed create leaves nothing behind you care about.
-`operations.command_retries` defaults to `0` and should stay there for agent commands.
-
-A proxy `502` on `POST /command` does **not** mean the command never started. The server maps
-every transport error to 502, including a dropped read *after* the body reached the exec daemon,
-and the daemon runs commands on a detached context that a dropped connection never cancels. A
-retried `git apply` or `pip install` therefore runs twice. In production tracking of >100k
-requests this race never actually fired — but the cost of being wrong is a corrupted rollout, and
-the harness already surfaces the error for you to handle. Raise `command_retries` only for
+`create.retries` is safe: a failed create leaves nothing behind. `operations.command_retries`
+defaults to `0` and should stay there for agent commands, because a proxy `502` on
+`POST /command` does not mean the command never started — the server maps every transport error
+to 502, including a dropped read *after* the body reached the exec daemon, which runs commands on
+a context a dropped connection never cancels. A retried `git apply` runs twice. Raise it only for
 provably idempotent workloads.
 
 Keep `create.skip_health_check: false`. Skipping it lets your first command race a pod whose exec
-daemon is not listening yet; the resulting 502 kills the rollout.
+daemon is not listening yet, and the resulting 502 kills the rollout.
 
 ## Failure signatures that are not what they look like
 
-| What you see | What it usually is | What to do |
+| What you see | What it is | What to do |
 | --- | --- | --- |
-| `No such file or directory` for a file that is definitely in the image (`/tests/test.sh`, `/testbed`, `command -v` failing on a present binary, exit 127) during a large create burst | Lazy-loading image flake: an in-flight read was aborted and the negative lookup got cached. The image is fine. | Retry after ≥60 s (an immediate retry often fails again); if it fails twice, recreate the sandbox. Reduce same-image create/delete churn where you can. |
-| Bursts of `502` on `/proxy/.../ping` right after create | The exec daemon is not listening yet in a just-started pod. Normal startup latency, self-healing. | Nothing; the provider's readiness probe absorbs it. If it persists for minutes, the cluster is overloaded. |
-| `DELETE` returns `404` / "Failed to terminate sandbox ... not found" | The sandbox already went away (TTL or a previous stop). | Nothing. The provider treats this as success. |
-| A command's status poll returns `404 unknown execution` on a sandbox that is alive | Stale sandbox→IP routing in the server under create/delete storms; the poll reached a reused pod IP. | Treat as a lost execution and recreate; do not tear down other healthy sandboxes over it. |
-| `Server disconnected` / `Connection reset by peer` on a long stream | Load-balancer idle timeout, or a server worker restart. | Use `background_exec: true` and short polls; keep `keepalive_expiry_s` below the server's idle timeout. |
-| `SandboxPtyError: PTY session already has an attached client` on every takeover retry | The sandbox's backend died while the proxy still records the old attachment. | Check sandbox status and report the death. Environments must catch `SandboxPtyError` in `verify()` — one unhandled 500 on `/run` can abort an entire eval. |
-| Sandbox-wide death with `137` after one heavy command | Group OOM kill (see fan-out above). | Cap parallelism, add a bash timeout; raising memory alone rarely fixes it. |
+| `No such file or directory` for a file that is in the image (`/testbed`, `/tests/test.sh`, exit 127 on a present binary) during a large create burst | Lazy-loading image flake; the negative lookup got cached. The image is fine. | Retry after ≥60 s; if it fails twice, recreate the sandbox. |
+| Bursts of `502` on `/proxy/.../ping` right after create | Exec daemon not listening yet in a new pod. Self-healing. | Nothing. If it persists for minutes, the cluster is overloaded. |
+| `DELETE` → `404` / "Failed to terminate sandbox" | Already gone (TTL or earlier stop). | Nothing; the provider treats it as success. |
+| Status poll → `404 unknown execution` on a live sandbox | Stale sandbox→IP routing during create/delete storms. | Treat as a lost execution and recreate; do not tear down other sandboxes. |
+| `Server disconnected` / `Connection reset by peer` on a long stream | Load-balancer idle timeout or a server worker restart. | `background_exec: true`; keep `keepalive_expiry_s` below the server's idle timeout. |
+| `SandboxPtyError: PTY session already has an attached client` on every retry | The sandbox's backend died while the proxy still records the old attachment. | Report the death. Environments must catch `SandboxPtyError` in `verify()`; one unhandled 500 on `/run` can abort the whole eval. |
+| Whole sandbox dies with `137` after one heavy command | Group OOM kill (fan-out above). | Cap parallelism, bash timeout; more memory alone rarely fixes it. |
 
-Sandboxes also run with the default runtime capability set — no `SYS_PTRACE`, no `SYS_ADMIN`.
-Tasks that need `strace`/`gdb` attach or mount namespaces will fail for that reason, not because
-of your config.
+Sandboxes run with the default capability set — no `SYS_PTRACE`, no `SYS_ADMIN`. `strace`/`gdb`
+attach and mount namespaces fail for that reason, not because of your config.
 
 ## Be a good tenant
 
-- **Check load before a large launch.** List the server's sandboxes (`GET /v1/sandboxes` with a
-  small page size and read `totalItems`) and look at how many of your own are still creating. A
-  cluster near its pod or request ceiling turns every create into a 20-minute wait for everyone.
-  Stagger large runs instead of starting several at once.
-- **Keep attribution on.** The provider's `attribution` block labels every sandbox with
-  `team`/`user`/`workload`/`run`. When Gym runs inside Kubernetes (no Slurm variables, OS user is
-  `root`), set `NEMO_GYM_TEAM`/`NEMO_GYM_USER`/`NEMO_GYM_WORKLOAD` on the pod, or your sandboxes
-  are invisible to per-team accounting and nobody can tell whose run is filling the cluster.
-- **Clean up interrupted runs.** Note the `run` id logged at the first create and reap exactly that
-  run's sandboxes:
+- **Check load before a large launch**: `GET /v1/sandboxes?pageSize=1` and read `totalItems`.
+  Near the cluster's ceiling, every create becomes a 20-minute wait for everyone. Stagger runs.
+- **Keep attribution on.** Inside Kubernetes (no Slurm variables, OS user `root`) set
+  `NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD` on the pod, or nobody can tell whose run
+  is filling the cluster.
+- **Clean up interrupted runs** by the `run` id logged at the first create (`--reap` to delete,
+  omit to audit):
 
   ```bash
   python -m nemo_gym.sandbox.providers.opensandbox.cleanup_sandboxes \
     --domain "$OPENSANDBOX_DOMAIN" --api-key "$OPENSANDBOX_API_KEY" \
-    --run-id <run-id> --user <user>          # audit
-  python -m nemo_gym.sandbox.providers.opensandbox.cleanup_sandboxes ... --reap   # delete
+    --run-id <run-id> --user <user> --reap
   ```
 
-  Rely on `ttl_s` only as the backstop.
-- **Do not `apt-get` inside every sandbox.** Installing a tool per rollout costs 10–40 s of network
-  time, multiplied by thousands of rollouts, and any registry hiccup fails the step. Bake tools into
-  the task image, or mount a prebuilt binary and run it from there. The same goes for downloading
-  the agent binary: mount it.
-- **Keep teardown off your critical path.** Stopping a sandbox is a provider round-trip you never
-  need to wait for; schedule it in the background (bounded by a timeout) so the rollout's
-  concurrency slot frees as soon as verification returns. The provider's TTL reaps anything a
-  background stop misses.
-
-## Sizing quick reference
-
-| Environment shape | cpu / memory limit | requests | bash timeout |
-| --- | --- | --- | --- |
-| Python-heavy repos (SWE-bench Verified) | `4` / `16 GiB` | `0.5` / `512 MiB` | 2 min |
-| Polyglot repos (SWE-bench Multilingual) | `4` / `16 GiB` | `0.5` / `512 MiB` | 2 min |
-| Terminal / build-heavy tasks | `4` / `16 GiB`, consider `8` only after measuring throttling | `0.5` / `512 MiB` | 2 min |
-
-If you believe a task class needs more, measure first: sandbox cgroup `memory.peak` and
-`cpu.stat` throttled time are readable inside the sandbox, and Gym's opencode agent can record
-them per rollout. Raise limits based on peaks you observed, not on the failure message.
+- **No `apt-get` per sandbox.** A tool install per rollout is 10–40 s of network time times
+  thousands of rollouts, plus a failure point. Bake tools into the image; mount the agent binary
+  instead of downloading it.
+- **Stop sandboxes in the background.** Teardown is a provider round-trip you never need to wait
+  for; `ttl_s` reaps anything a background stop misses.

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -69,7 +69,11 @@ and runs 10× slower. It depends on each repo's tooling, so it looks random.
 Two things it cannot fix:
 
 - Runners that ignore the environment: old `jest`, plain `make`, `ninja`, and Python
-  `multiprocessing` before 3.13. Cap these in the task's setup command or the image.
+  `multiprocessing` before 3.13. Cap these in the task's setup command or the image. Some
+  clusters run [LXCFS](https://linuxcontainers.org/lxcfs/introduction/), which overlays
+  `/proc/cpuinfo`, `/proc/meminfo`, and `/sys/devices/system/cpu/online` with cgroup-aware
+  values so these tools see the limit instead of the host — check `nproc` inside a sandbox to
+  find out; where it is present, this class of fan-out disappears.
 - Agent-written runaway code. This is the majority of OOMs on coding benchmarks, and Kubernetes
   group-OOM kills the **whole sandbox**, ending the rollout. Give agents a bash timeout (2 minutes
   is the validated default; 8 minutes measured quality-negative) so runaway commands fail fast and

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -21,7 +21,7 @@ See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the
 3. **Check what CPU count your sandbox actually sees** — on many clusters it is the host's cores,
    not your limit, and that varies cluster to cluster. Be mindful of it: leave `derive_cpu_env`
    on and give agents a bash timeout ([host-core fan-out](#the-host-core-fan-out-trap)).
-4. **Use background execution** — the shipped default; keep the poll interval in the tens of
+4. **Use background execution** — the shipped default; keep the max poll interval in the tens of
    seconds ([background execution and timeouts](#background-execution-and-timeouts)).
 5. **Retry creates, never commands** — a retried command can run twice
    ([retries](#retries-creates-yes-commands-no)).

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -9,6 +9,27 @@ cluster you occupy, your **limits** decide what your commands may use, and both 
 everyone else's runs. Most "OpenSandbox is flaky" reports trace back to one of the traps below.
 See the [OpenSandbox Provider](/infrastructure/sandbox/opensandbox) page for the config schema.
 
+## The short list
+
+1. **Start from the shipped config** — pass
+   `--config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml` and override only
+   the keys you need. Its connection settings are the ones that are hard to get right
+   ([connection fields](#connection-fields-that-must-be-right)).
+2. **Set requests separately from limits** — small `resource_requests`, generous `resources`
+   ([requests are not limits](#requests-are-not-limits)).
+3. **Leave `derive_cpu_env` on and give agents a bash timeout** — the sandbox sees the host's core
+   count, not your limit ([host-core fan-out](#the-host-core-fan-out-trap)).
+4. **Use background execution** — the shipped default; keep the poll interval in the tens of
+   seconds ([background execution](#how-background-execution-works)).
+5. **Retry creates, never commands** — a retried command can run twice
+   ([retries](#retries-creates-yes-commands-no)).
+6. **Turn on egress controls** for any benchmark where the agent must not reach the internet —
+   they are off by default ([egress controls](#egress-controls-are-off-by-default)).
+7. **Clean up zombie sandboxes** — reap an interrupted run by its `run` id, set `ttl_s` as the
+   backstop, and keep attribution on so the run is findable ([be a good tenant](#be-a-good-tenant)).
+8. **Check the failure table before filing a bug** — most alarming errors at scale are known and
+   benign ([failure signatures](#failure-signatures-that-are-not-what-they-look-like)).
+
 ## Connection fields that must be right
 
 The shipped `nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml` has these set

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-debugging.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-debugging.mdx
@@ -1,0 +1,142 @@
+---
+title: "Debugging OpenSandbox Sandboxes"
+description: "How to see what CPU and memory a sandbox is getting and using, and how to detect OOM kills from the client."
+position: 3
+---
+
+Companion to [OpenSandbox Best Practices](/infrastructure/sandbox/opensandbox-best-practices). That
+page says what to configure; this one says how to check what you actually got. Everything in the
+first two sections runs **inside** the sandbox through `sandbox.exec()` (or a bash tool call in the
+agent) — no cluster access needed. Sandboxes run on cgroup v2 with `/sys/fs/cgroup` mounted
+read-only, so the files below are always readable.
+
+## What am I getting? The enforced limits
+
+```bash
+cat /sys/fs/cgroup/cpu.max      # "400000 100000" = 4 CPUs (quota µs / period µs); "max" = unlimited
+cat /sys/fs/cgroup/memory.max   # bytes; "max" = unlimited
+nproc; python3 -c 'import os; print(os.cpu_count())'   # what tools will SEE — compare to cpu.max
+```
+
+If `cpu.max` says 4 CPUs but `nproc` says 192, this cluster does not overlay CPU counts and the
+[host-core fan-out trap](/infrastructure/sandbox/opensandbox-best-practices#the-host-core-fan-out-trap)
+applies.
+
+## How much am I using?
+
+```bash
+cat /sys/fs/cgroup/memory.current   # bytes in use now
+cat /sys/fs/cgroup/memory.peak      # high-water mark since start — the number to size limits from
+grep -E '^(anon|file) ' /sys/fs/cgroup/memory.stat   # anon = process memory, file = page cache (reclaimable)
+cat /sys/fs/cgroup/cpu.stat
+#   usage_usec      CPU time consumed
+#   nr_throttled    periods in which the quota ran out
+#   throttled_usec  time processes sat waiting for quota — the throttling signal
+```
+
+Throttling ratio = `throttled_usec / (usage_usec + throttled_usec)`. A few percent means the CPU
+limit is binding; above ~30% your commands are running dramatically slower than they look.
+
+### Did I hit the ceiling?
+
+```bash
+cat /sys/fs/cgroup/memory.events
+#   max        usage hit memory.max and the kernel had to reclaim — near-misses, i.e. thrashing
+#   oom        OOM events
+#   oom_kill   processes killed
+```
+
+`memory.peak == memory.max` with a large `max` count means you are living at the ceiling even if
+nothing has died yet. `oom_kill > 0` with the sandbox still alive means a child process was killed.
+If the whole sandbox died you will not get to read this file — see
+[detecting OOM from the client](#detecting-oom-from-the-client).
+
+### One-shot snapshot for the end of a rollout
+
+```bash
+sh -c 'echo "cpu.max=$(cat /sys/fs/cgroup/cpu.max)"; echo "mem.max=$(cat /sys/fs/cgroup/memory.max)"; \
+echo "mem.peak=$(cat /sys/fs/cgroup/memory.peak)"; \
+grep -E "^(usage_usec|nr_throttled|throttled_usec)" /sys/fs/cgroup/cpu.stat; \
+grep -E "^(max|oom|oom_kill)" /sys/fs/cgroup/memory.events; echo "nproc=$(nproc)"'
+```
+
+Capture this into your rollout record and you can size limits from real peaks across a whole run
+instead of from one failure message.
+
+## Detecting OOM from the client
+
+An OOM has one of two shapes, depending on what the kernel killed.
+
+### A child process died, the sandbox survived
+
+From the client this is an ordinary command failure:
+
+- `exec()` returns normally with `return_code == 137` (or `-9`), usually `Killed` in stderr and
+  truncated output.
+- Confirm from inside: `memory.events` shows `oom_kill > 0`, and `memory.peak` is at or near
+  `memory.max`.
+- The sandbox is fine to keep using; the agent can retry a smaller step.
+
+### The whole sandbox died
+
+Kubernetes group-OOM kills the entire cgroup, so the next operation cannot reach the exec daemon.
+The provider recognises this, polls the sandbox status for up to 5 seconds to learn *why*, and
+raises a typed error with the reason attached:
+
+```python
+from nemo_gym.sandbox.providers.opensandbox.provider import SandboxBackendUnreachableError
+
+try:
+    result = await sandbox.exec(cmd, timeout_s=120)
+except SandboxBackendUnreachableError as e:
+    if "OOM-killed" in str(e):
+        # message quotes the server's record: state=..., reason='OOMKilled', message=..., sandbox_id=...
+        ...  # record as OOM; recreate the sandbox or fail the rollout
+    else:
+        ...  # backend gone for another reason (node loss, TTL); same handling, different tag
+```
+
+Afterwards `await sandbox.status()` returns `SandboxStatus.ERROR` or `SandboxStatus.STOPPED` — that
+is the provider-neutral check if you do not want to import the provider's exception type. The same
+notice surfaces on the PTY path as
+`SandboxPtyError("PTY attach takeover kept being refused: Sandbox was OOM-killed. ...")`.
+
+<Note>
+Do not confuse OOM with a timeout. A command that exceeds its `timeout_s` raises `TimeoutError`; a
+wedged command raises `TimeoutError` mentioning the hard cap. Neither is an OOM — when in doubt,
+read `memory.events` before deciding.
+</Note>
+
+### Counting OOMs across a run
+
+Rollout records carry sandbox observations under `ng_agent_observations`: each record has
+`outcome` (`completed`, `failed`, `timeout`, `sandbox_error`), `exit_code`, and `error_type`.
+`outcome: sandbox_error` with `error_type: SandboxBackendUnreachableError`, or `exit_code: 137`, is
+your OOM census. Join it on the task id: OOMs clustered on a few tasks mean fan-out or runaway code
+in those repos; OOMs spread evenly mean the limit is genuinely too small.
+
+## Cluster-side checks
+
+If you have `kubectl` access to the sandbox namespace. The pod name is the sandbox id the SDK
+returned with `-0` appended; sandboxes also carry the `opensandbox.io/id` label.
+
+```bash
+kubectl top pod <sandbox-id>-0 -n <namespace>          # live CPU/memory as the node sees it
+kubectl get pod <sandbox-id>-0 -n <namespace> \
+  -o jsonpath='{.spec.containers[0].resources}'        # requests AND limits actually applied
+kubectl describe pod <sandbox-id>-0 -n <namespace> | grep -A3 'Last State'
+#   "Reason: OOMKilled, Exit Code: 137" = whole-sandbox OOM
+```
+
+The `resources` jsonpath is the fastest way to confirm you did not accidentally set the same map
+for requests and limits.
+
+## Reading the signals together
+
+| Observation | Meaning | Action |
+| --- | --- | --- |
+| `throttled_usec` ≫ 0, memory fine | CPU limit binding — usually fan-out | Fix parallelism caps before raising the limit. |
+| `memory.peak` near `memory.max`, many `max` events | Memory ceiling, thrashing | Find the fan-out or runaway code; raise the limit only if the peak is legitimate. |
+| `oom_kill > 0`, sandbox alive | A child process was killed | Command output is probably truncated; safe to retry a smaller step. |
+| Pod `OOMKilled` / `137`, no in-sandbox data | Group OOM kill | Same causes; add a bash timeout so the agent fails fast. |
+| `nproc` ≠ CPUs in `cpu.max` | This cluster does not overlay CPU counts | Rely on `derive_cpu_env`; cap environment-blind runners in the image. |

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -6,6 +6,11 @@ position: 1
 
 The `opensandbox` provider creates sandboxes through the OpenSandbox SDK and server API. It is the Kubernetes-backed provider used by agentic software engineering environments such as `mini_swe_agent_2`.
 
+<Tip>
+Running at scale? Read [OpenSandbox Best Practices](/infrastructure/sandbox/opensandbox-best-practices)
+for resource requests vs limits, timeout and retry guidance, and the failure signatures that are not bugs.
+</Tip>
+
 ## Setup
 
 Install the sandbox extra in the runtime image or virtual environment that creates sandboxes:


### PR DESCRIPTION
## Summary

Two new docs pages under `infrastructure/sandbox/`, distilled from several weeks of running thousands of concurrent OpenSandbox sandboxes for SWE-bench / Terminal-Bench / DeepSWE evals. Every recommendation traces to a real incident or a measured A/B.

### `opensandbox-best-practices`
Opens with an eight-item short list (each linking to its section), then in that order:
- **Connection fields that must be right** — `use_server_proxy: true` (direct mode dials pod IPs; unreachable from outside the cluster), `domain` via `OPENSANDBOX_DOMAIN`, `transport_backend: aiohttp`, `max_connections: null`, `keepalive_expiry_s`, `protocol`.
- **Requests are not limits** — `resources` becomes the pod limits; requests live under `provider_options.resource_requests`; setting only `resources` applies it as both, so a `4 CPU / 32Gi` run occupies ~30× the capacity of a `0.5 / 512Mi` one and pushes everyone's creates into `Pending`.
- **Host-core fan-out** — framed as cluster-dependent (host cores vs LXCFS-overlaid limits, how to check), what `derive_cpu_env` covers and cannot, why group-OOM kills the whole sandbox, bash timeout as the recovery mechanism.
- **Background execution and timeouts** — how submit/poll/fetch works, what each poll knob controls (with request-rate math), `create.timeout_s` vs `ready_timeout_s`, `ttl_s`, and the "failures every N minutes" create-timeout echo.
- **Retries** — `create.retries` and `operations.retries` (idempotent / provably-never-started ops) vs `command_retries: 0`: a 502 on `POST /command` does not mean the command never started.
- **Egress controls** — off by default (no sidecar without a `network_policy`); the per-sandbox policy shape; `dns` vs `dns+nft` enforcement; allow what the harness needs and test with one rollout.
- **Be a good tenant** — attribution labels (and `NEMO_GYM_*` inside k8s), reaping a run by id with `cleanup_sandboxes.py`, no `apt-get` per sandbox, teardown off the critical path.
- **Failure signatures that are not bugs** — lazy-load phantom `ENOENT`, startup `502` pings, terminate `404`s, stale-IP `404 unknown execution`, PTY zombie attachments, group-OOM `137`.

### `opensandbox-debugging`
- Reading the sandbox's own cgroup from inside: enforced limits (`cpu.max`, `memory.max`, and what `nproc` sees), live usage and peak (`memory.current`, `memory.peak`, `cpu.stat` throttling ratio), ceiling events (`memory.events`), and a one-shot end-of-rollout snapshot.
- Detecting OOM from the client: child-process kill (`return_code 137`, sandbox alive) vs whole-sandbox kill (`SandboxBackendUnreachableError` carrying the server's `OOMKilled` reason; `sandbox.status()` → `ERROR`/`STOPPED`; the PTY variant), not confusing it with `TimeoutError`, and counting OOMs across a run from `ng_agent_observations`.
- `kubectl` checks for those with cluster access, and a signals-to-action table.

Both pages are linked from the sandbox index (`<Card>`) and from each other; the provider page gets a `<Tip>` pointing at the best-practices guide. Pages in this folder are auto-discovered, so no nav change.

## Test plan

- [x] Docs-only; `pre-commit run --files` on the changed pages (no applicable hooks fail)
- [ ] CI `fern check` + preview link (verify in-page anchors resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)