### PR TITLE
fix(openai_utils): strip outer tool call name before validation

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -931,20 +931,12 @@ class NeMoGymChatCompletionMessageToolCallFunctionParam(TypedDict, total=False):
     name: Required[str]
 
 
-# Clients label a tool call with the tool's name alongside the nested
-# `function.name`, and servers accept it, but the field is absent from OpenAI's
-# own type. Since the request schema forbids extras, and pydantic propagates
-# that into nested `TypedDict`s, its presence rejects the whole conversation.
-# Declared rather than ignored so it round-trips: an unknown field here is
-# still an error, because tool calls carry provider state that a client must
-# echo back verbatim and silently dropping it would corrupt the trajectory.
 class NeMoGymChatCompletionMessageToolCallParam(ChatCompletionMessageToolCallParam):
     function: NeMoGymChatCompletionMessageToolCallFunctionParam
-    name: NotRequired[str]
 
 
 class NeMoGymChatCompletionMessageCustomToolCallParam(ChatCompletionMessageCustomToolCallParam):
-    name: NotRequired[str]
+    pass
 
 
 NeMoGymChatCompletionMessageToolCallUnionParam = Annotated[
@@ -956,10 +948,34 @@ NeMoGymChatCompletionMessageToolCallUnionParam = Annotated[
 ]
 
 
+def _strip_outer_tool_call_names(value: Any) -> Any:
+    """Copy tool calls carrying a redundant outer name and remove only that field."""
+    if not isinstance(value, list):
+        return value
+
+    normalized = None
+    for index, tool_call in enumerate(value):
+        if not isinstance(tool_call, dict) or "name" not in tool_call:
+            continue
+        if normalized is None:
+            normalized = list(value)
+        normalized_tool_call = dict(tool_call)
+        del normalized_tool_call["name"]
+        normalized[index] = normalized_tool_call
+
+    return value if normalized is None else normalized
+
+
+NeMoGymChatCompletionMessageToolCallsParam: TypeAlias = Annotated[
+    List[NeMoGymChatCompletionMessageToolCallUnionParam],
+    BeforeValidator(_strip_outer_tool_call_names),
+]
+
+
 class NeMoGymChatCompletionAssistantMessageParam(ChatCompletionAssistantMessageParam, total=False):
     # Override the iterable which is annoying to work with.
     content: Union[str, List[ContentArrayOfContentPart], None]
-    tool_calls: Optional[List[NeMoGymChatCompletionMessageToolCallUnionParam]] = None
+    tool_calls: Optional[NeMoGymChatCompletionMessageToolCallsParam] = None
 
 
 class NeMoGymChatCompletionAssistantMessageForTrainingParam(

--- a/tests/unit_tests/test_chat_completions_streaming.py
+++ b/tests/unit_tests/test_chat_completions_streaming.py
@@ -280,6 +280,33 @@ class TestChatDispatchRoute:
         assert resp.status_code == 422
         assert resp.json()["detail"][0]["loc"][0] == "body"
 
+    def test_non_streaming_request_does_not_forward_outer_tool_call_name(self) -> None:
+        client, server = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "name": "get_weather",
+                                "function": {"name": "get_weather", "arguments": "{}"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        forwarded = server.last_params.model_dump(exclude_unset=True)["messages"][0]["tool_calls"][0]
+        assert "name" not in forwarded
+        assert forwarded["function"]["name"] == "get_weather"
+
     def test_streaming_request_returns_synthesized_sse(self) -> None:
         client, server = _client(_EchoChatModel)
         resp = client.post(

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from copy import deepcopy
 from types import UnionType
 from typing import (
     Annotated,
@@ -288,12 +289,7 @@ class TestNeMoGymChatCompletionSchemas:
         assert params.messages[0]["tool_calls"][0]["type"] == "custom"
         assert params.messages[0]["generation_token_ids"] == [2]
 
-    def test_tool_call_accepts_the_name_field(self) -> None:
-        """Clients label a tool call with the tool's name and servers accept it.
-
-        The field is absent from OpenAI's type, so a request schema that forbids
-        extras rejects the whole conversation.
-        """
+    def test_tool_call_strips_only_the_outer_name_without_mutating_input(self) -> None:
         payload = {
             "messages": [
                 {
@@ -314,18 +310,20 @@ class TestNeMoGymChatCompletionSchemas:
             ],
             "model": "gpt-test",
         }
+        original = deepcopy(payload)
 
         params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
         tool_call = params.messages[0]["tool_calls"][0]
         assert tool_call["type"] == "function"
         assert tool_call["function"] == {"name": "KB_search", "arguments": '{"query": "hello"}'}
-        # Round-trips rather than being dropped.
-        assert tool_call["name"] == "KB_search"
+        assert "name" not in tool_call
         dumped = params.model_dump()["messages"][0]["tool_calls"][0]
-        assert dumped["name"] == "KB_search"
+        assert "name" not in dumped
+        assert dumped["function"]["name"] == "KB_search"
+        assert payload == original
 
-    def test_custom_tool_call_accepts_the_name_field(self) -> None:
+    def test_custom_tool_call_strips_only_the_outer_name_without_mutating_input(self) -> None:
         payload = {
             "messages": [
                 {
@@ -343,33 +341,51 @@ class TestNeMoGymChatCompletionSchemas:
             ],
             "model": "gpt-test",
         }
+        original = deepcopy(payload)
 
         params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
         tool_call = params.messages[0]["tool_calls"][0]
         assert tool_call["type"] == "custom"
         assert tool_call["custom"] == {"name": "shell", "input": "echo hello"}
-        assert tool_call["name"] == "shell"
+        assert "name" not in tool_call
+        assert tool_call["custom"]["name"] == "shell"
+        assert payload == original
 
-    def test_tool_call_still_rejects_unknown_fields(self) -> None:
-        """Tool calls carry provider state a client must echo back verbatim.
-
-        Accepting and silently dropping an unknown field would corrupt an
-        otherwise valid trajectory, so it must stay an error.
-        """
+    @pytest.mark.parametrize(
+        "tool_call",
+        [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+                "not_a_real_field": 1,
+            },
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}", "not_a_real_field": 1},
+            },
+            {
+                "id": "call-1",
+                "type": "custom",
+                "custom": {"name": "shell", "input": "echo hello"},
+                "not_a_real_field": 1,
+            },
+            {
+                "id": "call-1",
+                "type": "custom",
+                "custom": {"name": "shell", "input": "echo hello", "not_a_real_field": 1},
+            },
+        ],
+    )
+    def test_tool_calls_still_reject_other_unknown_fields(self, tool_call: dict[str, Any]) -> None:
         payload = {
             "messages": [
                 {
                     "role": "assistant",
                     "content": "",
-                    "tool_calls": [
-                        {
-                            "id": "call-1",
-                            "type": "function",
-                            "function": {"name": "f", "arguments": "{}"},
-                            "not_a_real_field": 1,
-                        }
-                    ],
+                    "tool_calls": [tool_call],
                 }
             ],
             "model": "gpt-test",
@@ -379,7 +395,7 @@ class TestNeMoGymChatCompletionSchemas:
             NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(payload)
 
     def test_unknown_top_level_request_key_is_still_rejected(self) -> None:
-        """Accepting the tool-call name must not loosen the request model."""
+        """Normalizing the tool-call name must not loosen the request model."""
         with pytest.raises(ValidationError):
             NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
                 {


### PR DESCRIPTION
Follow-up to #3061.

Strips the non-standard outer `tool_calls[].name` field before strict validation while preserving nested function/custom-call names and all other strict unknown-field checks. The sanitizer is copy-on-write so caller input is not mutated.

Tests cover function and custom calls, preservation of nested names, rejection of unrelated extra fields, and the provider-boundary payload.