### PR TITLE
[Super 3.5 evals] Terminus2 Model call timeout parity; Servers cancel requests when client cancels requests

### DIFF
--- a/nemo_gym/mcp_auto_exposure.py
+++ b/nemo_gym/mcp_auto_exposure.py
@@ -440,6 +440,8 @@ def harvest_tools(app: FastAPI, server: Any) -> dict[str, MCPTool]:
             continue  # Gym's SessionMiddleware — replaced by a materialized session on direct dispatch
         if f"{cls.__module__}.{cls.__name__}" == "nemo_gym.rollout_correlation.RolloutContextMiddleware":
             continue  # Correlation prefixes are handled before resource routes; direct MCP dispatch has no prefix.
+        if f"{cls.__module__}.{cls.__name__}" == ("nemo_gym.server_utils.ClientDisconnectCancellationMiddleware"):
+            continue  # Direct MCP dispatch has no client connection to monitor.
         dispatch = m.kwargs.get("dispatch")
         if dispatch is not None and getattr(dispatch, "__module__", None) in _GYM_MIDDLEWARE_MODULES:
             continue  # Gym's add_session_id / exception middleware

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -44,6 +44,7 @@ from aiohttp import (
     TCPConnector,
 )
 from aiohttp.client import _RequestOptions
+from anyio import create_task_group
 from fastapi import FastAPI, Request, Response
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
@@ -53,6 +54,7 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from requests.exceptions import ConnectionError
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from nemo_gym import WORKING_DIR
 from nemo_gym.config_types import (
@@ -730,6 +732,62 @@ def _telemetry_server_type(server_cls: Type) -> Optional[str]:
     return None
 
 
+class ClientDisconnectCancellationMiddleware:
+    """Cancel an in-flight HTTP request when its client disconnects."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self.num_cancelled = 0
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        received_messages: asyncio.Queue[Message] = asyncio.Queue()
+        client_disconnected = asyncio.Event()
+
+        async def receive_message() -> Message:
+            return await received_messages.get()
+
+        async def send_message(message: Message) -> None:
+            if not client_disconnected.is_set():
+                await send(message)
+
+        # The listener is the sole reader of the original ASGI receive channel.
+        # Forwarding request messages keeps the body available to the app while
+        # also allowing disconnects to cancel handlers that no longer call receive.
+        async with create_task_group() as task_group:
+
+            async def run_app() -> None:
+                try:
+                    await self.app(scope, receive_message, send_message)
+                finally:
+                    task_group.cancel_scope.cancel()
+
+            async def listen_for_disconnect() -> None:
+                while True:
+                    message = await receive()
+                    await received_messages.put(message)
+                    if message["type"] != "http.disconnect":
+                        continue
+
+                    client_disconnected.set()
+                    self.num_cancelled += 1
+                    if is_global_aiohttp_client_request_debug_enabled() or self.num_cancelled % 100 == 0:
+                        client = scope.get("client")
+                        client_address = f"{client[0]}:{client[1]}" if client else "-:-"
+                        print(
+                            f'{client_address} - "{scope["method"]} {scope["path"]}" '
+                            f"499 CLIENT DISCONNECTED ({self.num_cancelled} total for this server worker)"
+                        )
+                    task_group.cancel_scope.cancel()
+                    return
+
+            task_group.start_soon(run_app)
+            task_group.start_soon(listen_for_disconnect)
+
+
 class SimpleServer(BaseServer):
     server_client: ServerClient
 
@@ -817,7 +875,7 @@ class SimpleServer(BaseServer):
 
                 return JSONResponse(content=response_content, status_code=500)
             except CancelledError:
-                return JSONResponse(content="An unknown error occurred", status_code=500)
+                return JSONResponse(content="Request was cancelled", status_code=500)
             except Exception as e:
                 print(
                     f"""🚨 Caught an exception printed above in {self.config.name} ({self.__class__.__name__}). If you expect this to be fed back into this model, the exception repr i.e. `repr(e)` is returned to the model. However, please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception
@@ -831,6 +889,9 @@ repr(e): {repr(e)}"""
                     f"""🚨 Caught an unknown exception printed above in {self.config.name} ({self.__class__.__name__}). If you expect this to be fed back into this model, nothing meaningful is returned to the model. Please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception"""
                 )
                 return JSONResponse(content="An unknown error occurred", status_code=500)
+
+    def setup_cancellation_middleware(self, app: FastAPI) -> None:
+        app.add_middleware(ClientDisconnectCancellationMiddleware)
 
     def setup_profiling(self, app: FastAPI, profiling_config: ProfilingMiddlewareConfig) -> None:  # pragma: no cover
         base_profile_dir = WORKING_DIR / profiling_config.profiling_results_dirpath / self.get_session_middleware_key()
@@ -944,6 +1005,8 @@ repr(e): {repr(e)}"""
         server.set_ulimit()
         server.prefix_server_logs()
         server.setup_exception_middleware(app)
+        # Register last so cancellation wraps the complete request stack.
+        server.setup_cancellation_middleware(app)
         # Must precede uvicorn.run: Starlette refuses add_middleware once the app has
         # started. This is the ingress half of cross-process propagation — the instrumentor
         # extracts an inbound `traceparent` and parents this server's SERVER span to the

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -185,6 +185,10 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
         eval_sandbox = AsyncSandbox(resolved_sandbox_provider)
         await eval_sandbox.start(eval_sandbox_spec)
 
+        result = await eval_sandbox.exec("apt-get update", timeout_s=self.config.evaluation_timeout)
+        if result.return_code != 0:
+            print(f"Failed to apt-get update: {result}")
+
         return eval_sandbox
 
     async def seed_session(

--- a/responses_api_agents/terminus_2_sandboxed_agent/app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/app.py
@@ -7,10 +7,10 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from time import time
+from time import perf_counter, time
 from traceback import format_exc
 from types import SimpleNamespace
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 from fastapi import Request
@@ -81,6 +81,17 @@ class Terminus2AgentVerifyResponse(BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     terminus2_completed: bool
+    command_exec_times: List[float]
+    model_call_times: List[float]
+    average_command_exec_time: float
+    average_model_call_time: float
+    total_command_exec_time: float
+    total_model_call_time: float
+    command_exec_time_pct: float
+    model_call_time_pct: float
+    terminus2_time_taken: float
+    model_calls_gt_10min: int
+    num_compactions: int
 
 
 class NeMoGymSandboxEnvironment:
@@ -149,6 +160,9 @@ class NeMoGymLLM(BaseLLM):
         self._model_context_limit = model_context_limit
         self._model_output_limit = model_output_limit
         self.trajectory: list[NeMoGymResponseOutputItem] = []
+        self._times_spent = []
+        self._last_input_items = []
+        self._model_calls_gt_10min = 0
 
     @staticmethod
     def _input_items(message_history: list[dict[str, Any]], prompt: str) -> list[NeMoGymEasyInputMessage]:
@@ -177,13 +191,36 @@ class NeMoGymLLM(BaseLLM):
             raise NotImplementedError(f"NeMoGymLLM does not support call options: {sorted(kwargs)}")
 
         input_items = self._input_items(message_history, prompt)
-        response = NeMoGymResponse.model_validate(
-            await self._client.create_response(
-                model=self._model_name,
-                input=[item.model_dump(mode="json", exclude_none=True) for item in input_items],
-            )
-        )
-        self.trajectory.extend([*input_items, *response.output])
+        response = None
+        start_time = perf_counter()
+        max_attempts = 3  # Hardcode 3 attempts for now
+        for attempt in range(max_attempts):
+            try:
+                async with asyncio.timeout(delay=60 * 10):  # Hardcoded to match litellm default timeout
+                    response = NeMoGymResponse.model_validate(
+                        await self._client.create_response(
+                            model=self._model_name,
+                            input=[item.model_dump(mode="json", exclude_none=True) for item in input_items],
+                        )
+                    )
+                    break
+            except TimeoutError:
+                self._model_calls_gt_10min += 1
+                print(
+                    f"Hit LiteLLM default 10min timeout on model call, attempt {attempt + 1} / {max_attempts}",
+                    file=sys.stderr,
+                )
+        self._times_spent.append(perf_counter() - start_time)
+        if not response:
+            raise TimeoutError(f"Failed to query model endpoint due to timeouts after {max_attempts} attempts!")
+
+        if len(self._last_input_items) >= len(input_items):
+            # Compacted
+            self.trajectory.extend([*input_items, *response.output])
+        else:
+            self.trajectory.extend([input_items[-1], *response.output])
+        self._last_input_items = input_items.copy()
+
         usage = response.usage
         usage_info = None
         if usage is not None:
@@ -215,6 +252,8 @@ class NeMoGymTerminus2(Terminus2):
     def __init__(self, *args: Any, llm: NeMoGymLLM, dump_trajectory: bool, **kwargs: Any):
         self._nemo_gym_llm = llm
         self._dump_trajectory_enabled = dump_trajectory
+        self._times_spent = []
+        self._num_compactions = 0
         super().__init__(*args, **kwargs)
 
     def _init_llm(self, *args: Any, **kwargs: Any) -> BaseLLM:
@@ -226,6 +265,19 @@ class NeMoGymTerminus2(Terminus2):
     def _dump_trajectory_with_continuation_index(self, continuation_index: int) -> None:
         if self._dump_trajectory_enabled:
             super()._dump_trajectory_with_continuation_index(continuation_index)
+
+    async def _execute_commands(self, *args, **kwargs):
+        start_time = perf_counter()
+        res = await super()._execute_commands(*args, **kwargs)
+        self._times_spent.append(perf_counter() - start_time)
+
+        return res
+
+    async def _check_proactive_summarization(self, *args, **kwargs):
+        res = await super()._check_proactive_summarization(*args, **kwargs)
+        if res:
+            self._num_compactions += 1
+        return res
 
 
 class Terminus2Agent(SimpleResponsesAPIAgent):
@@ -248,7 +300,8 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming,
         sandbox: AsyncSandbox,
-    ) -> Tuple[NeMoGymResponse, bool]:
+    ) -> Tuple[NeMoGymResponse, Dict[str, Any]]:
+        start_time = perf_counter()
         instruction = _instruction(body.input)
 
         model_base_url = (
@@ -307,7 +360,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
                 terminus2_completed = False
                 print(f"Hit exception while running Terminus2: {format_exc()}", file=sys.stderr)
             finally:
-                await agent._session.stop()
+                pass
 
         usage = NeMoGymResponseUsage(
             input_tokens=context.n_input_tokens or 0,
@@ -316,7 +369,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
             total_tokens=(context.n_input_tokens or 0) + (context.n_output_tokens or 0),
         )
-        return NeMoGymResponse(
+        response = NeMoGymResponse(
             id=f"resp_{uuid4().hex}",
             created_at=int(time()),
             model=self.config.model_server.name,
@@ -326,7 +379,26 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             tools=body.tools,
             parallel_tool_calls=body.parallel_tool_calls,
             usage=usage,
-        ), terminus2_completed
+        )
+
+        total_time = perf_counter() - start_time
+        total_command_exec_time = sum(agent._times_spent)
+        total_model_call_time = sum(llm._times_spent)
+        metrics = {
+            "terminus2_completed": terminus2_completed,
+            "command_exec_times": agent._times_spent,
+            "model_call_times": llm._times_spent,
+            "average_command_exec_time": total_command_exec_time / max(len(agent._times_spent), 1),
+            "average_model_call_time": total_model_call_time / max(len(llm._times_spent), 1),
+            "total_command_exec_time": total_command_exec_time,
+            "total_model_call_time": total_model_call_time,
+            "command_exec_time_pct": 100 * total_command_exec_time / total_time,
+            "model_call_time_pct": 100 * total_model_call_time / total_time,
+            "terminus2_time_taken": total_time,
+            "model_calls_gt_10min": llm._model_calls_gt_10min,
+            "num_compactions": agent._num_compactions,
+        }
+        return response, metrics
 
     async def responses(self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
         session_key = request.session[SESSION_ID_KEY]
@@ -352,7 +424,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         session_key = request.session[SESSION_ID_KEY]
         self._session_sandboxes[session_key] = sandbox
 
-        response, terminus2_completed = await self._execute(request, body.responses_create_params, sandbox)
+        response, metrics = await self._execute(request, body.responses_create_params, sandbox)
 
         verification = await self.server_client.post(
             server_name=self.config.resources_server.name,
@@ -369,7 +441,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             print("Failed to stop sandbox", format_exc(), file=sys.stderr)
 
         result = await get_response_json(verification)
-        result["terminus2_completed"] = terminus2_completed
+        result.update(metrics)
         return Terminus2AgentVerifyResponse.model_validate(result)
 
 

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -122,10 +122,16 @@ async def test_nemo_gym_llm_records_every_responses_request_and_output():
         message_history=[{"role": "user", "content": "first"}, {"role": "assistant", "content": "answer 1"}],
         previous_response_id="resp_1",
     )
+    third = await llm.call(
+        "third",
+        message_history=[{"role": "user", "content": "compacted summary"}],
+        previous_response_id="resp_2",
+    )
 
     assert first.content == "answer 1"
     assert first.usage.prompt_tokens == 10
     assert second.content == "answer 2"
+    assert third.content == "answer 3"
     assert client.requests == [
         {"model": "policy_model", "input": [{"content": "first", "role": "user", "type": "message"}]},
         {
@@ -136,12 +142,19 @@ async def test_nemo_gym_llm_records_every_responses_request_and_output():
                 {"content": "second", "role": "user", "type": "message"},
             ],
         },
+        {
+            "model": "policy_model",
+            "input": [
+                {"content": "compacted summary", "role": "user", "type": "message"},
+                {"content": "third", "role": "user", "type": "message"},
+            ],
+        },
     ]
     assert [item.content for item in llm.trajectory if isinstance(item, NeMoGymEasyInputMessage)] == [
         "first",
-        "first",
-        "answer 1",
         "second",
+        "compacted summary",
+        "third",
     ]
 
 
@@ -184,6 +197,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         def __init__(self, **kwargs):
             self.kwargs = kwargs
             self._session = SimpleNamespace(stop=self.stop)
+            self._times_spent = [1.0, 3.0]
 
         async def stop(self):
             return None
@@ -195,6 +209,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
             assert instruction == "solve this"
             assert self.kwargs["dump_trajectory"] is dump_trajectory
             await environment.exec("tmux run")
+            self.kwargs["llm"]._times_spent.extend([2.0, 4.0])
             context.n_input_tokens = 4
             context.n_output_tokens = 3
             self.kwargs["llm"].trajectory.append(
@@ -217,18 +232,31 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
     monkeypatch.setattr(app_module, "AgentContext", FakeContext)
     monkeypatch.setattr(Terminus2Agent, "base_url_for_run", lambda *_args, **_kwargs: "http://model")
     monkeypatch.setattr(app_module, "get_server_url", lambda _: "http://model")
+    elapsed_times = iter([10.0, 20.0])
+    monkeypatch.setattr(app_module, "perf_counter", lambda: next(elapsed_times))
 
     async def request_json():
         return {"task_id": "task"}
 
     request = SimpleNamespace(json=request_json, session={app_module.SESSION_ID_KEY: "session-1"})
-    response, terminus2_completed = await server._execute(
+    response, metrics = await server._execute(
         request,
         NeMoGymResponseCreateParamsNonStreaming(input="solve this"),
         sandbox,
     )
 
-    assert terminus2_completed is True
+    assert metrics == {
+        "terminus2_completed": True,
+        "command_exec_times": [1.0, 3.0],
+        "model_call_times": [2.0, 4.0],
+        "average_command_exec_time": 2.0,
+        "average_model_call_time": 3.0,
+        "total_command_exec_time": 4.0,
+        "total_model_call_time": 6.0,
+        "command_exec_time_pct": 40.0,
+        "model_call_time_pct": 60.0,
+        "terminus2_time_taken": 10.0,
+    }
     assert response.output[-1].content[0].text == "done"
     assert response.usage.input_tokens == 4
     assert response.usage.output_tokens == 3

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -198,6 +198,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
             self.kwargs = kwargs
             self._session = SimpleNamespace(stop=self.stop)
             self._times_spent = [1.0, 3.0]
+            self._num_compactions = 2
 
         async def stop(self):
             return None
@@ -256,6 +257,8 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         "command_exec_time_pct": 40.0,
         "model_call_time_pct": 60.0,
         "terminus2_time_taken": 10.0,
+        "model_calls_gt_10min": 0,
+        "num_compactions": 2,
     }
     assert response.output[-1].content[0].text == "done"
     assert response.usage.input_tokens == 4

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import multiprocessing
 import socket
 from concurrent.futures import ProcessPoolExecutor
@@ -25,6 +26,7 @@ from yarl import URL
 
 import nemo_gym.global_config
 import nemo_gym.server_utils
+from nemo_gym.config_types import BaseRunServerInstanceConfig
 from nemo_gym.global_config import (
     NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
@@ -511,7 +513,6 @@ class TestServerUtils:
         from fastapi.testclient import TestClient
         from starlette.middleware.sessions import SessionMiddleware
 
-        from nemo_gym.config_types import BaseRunServerInstanceConfig
         from nemo_gym.server_utils import SESSION_ID_KEY
 
         class TestSimpleServer(SimpleServer):
@@ -542,6 +543,90 @@ class TestServerUtils:
             response = client.get("/session")
             assert response.json()["session_id"]
             assert 1 == len(response.headers.get_list("set-cookie"))
+
+    def test_cancellation_middleware_preserves_request_body(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        class TestSimpleServer(SimpleServer):
+            def setup_webserver(self):
+                assert False
+
+        server = TestSimpleServer(
+            config=BaseRunServerInstanceConfig(name="my_server", host="", port=0, entrypoint=""),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        app = FastAPI()
+        server.setup_cancellation_middleware(app)
+
+        @app.post("/echo")
+        async def echo(body: dict) -> dict:
+            return body
+
+        with TestClient(app) as client:
+            response = client.post("/echo", json={"message": "hello"})
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "hello"}
+
+    async def test_cancellation_middleware_cancels_handler_on_disconnect(self) -> None:
+        from fastapi import FastAPI, Request
+
+        class TestSimpleServer(SimpleServer):
+            def setup_webserver(self):
+                assert False
+
+        server = TestSimpleServer(
+            config=BaseRunServerInstanceConfig(name="my_server", host="", port=0, entrypoint=""),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        app = FastAPI()
+        server.setup_exception_middleware(app)
+        server.setup_cancellation_middleware(app)
+        handler_started = asyncio.Event()
+        handler_cancelled = asyncio.Event()
+
+        @app.post("/work")
+        async def work(request: Request) -> None:
+            assert await request.json() == {"message": "hello"}
+            handler_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                handler_cancelled.set()
+                raise
+
+        incoming_messages = asyncio.Queue()
+        await incoming_messages.put({"type": "http.request", "body": b'{"message":"hello"}', "more_body": False})
+
+        async def receive():
+            return await incoming_messages.get()
+
+        sent_messages = []
+
+        async def send(message):
+            sent_messages.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/work",
+            "raw_path": b"/work",
+            "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+        app_task = asyncio.create_task(app(scope, receive, send))
+        await asyncio.wait_for(handler_started.wait(), timeout=1)
+        await incoming_messages.put({"type": "http.disconnect"})
+        await asyncio.wait_for(app_task, timeout=1)
+
+        assert handler_cancelled.is_set()
+        assert sent_messages == []
 
     def test_upstream_error_log_has_bounded_body_and_redacted_url(self) -> None:
         request_info = RequestInfo(


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. Servers cancel requests when client cancels requests: nemo_gym/mcp_auto_exposure.py, nemo_gym/server_utils.py, tests/unit_tests/test_server_utils.py
2. Terminus2 Model call timeout parity: resources_servers/terminal_bench_2_1/app.py, responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py, responses_api_agents/terminus_2_sandboxed_agent/app.py

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
