### PR TITLE
fix: preserve renamed config compatibility

### DIFF
--- a/environments/reasoning_gym_claude_code/.nemo_gym_tombstone
+++ b/environments/reasoning_gym_claude_code/.nemo_gym_tombstone
@@ -1,0 +1,1 @@
+claude_code_reasoning_gym

--- a/environments/reasoning_gym_claude_code/README.md
+++ b/environments/reasoning_gym_claude_code/README.md
@@ -1,0 +1,5 @@
+# Environment moved
+
+This compatibility directory preserves the former `reasoning_gym_claude_code` entry point. Use [`claude_code_reasoning_gym`](../claude_code_reasoning_gym/) for new commands and configuration.
+
+The `prepare.py` wrapper forwards to the renamed environment. NeMo Gym also resolves the former `config.yaml` path to the canonical configuration.

--- a/environments/reasoning_gym_claude_code/__init__.py
+++ b/environments/reasoning_gym_claude_code/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility package for the renamed ``claude_code_reasoning_gym`` environment."""

--- a/environments/reasoning_gym_claude_code/prepare.py
+++ b/environments/reasoning_gym_claude_code/prepare.py
@@ -7,8 +7,11 @@ import logging
 from environments.claude_code_reasoning_gym.prepare import main
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "`environments/reasoning_gym_claude_code/prepare.py` is deprecated; "
         "use `environments/claude_code_reasoning_gym/prepare.py`."
     )

--- a/environments/reasoning_gym_claude_code/prepare.py
+++ b/environments/reasoning_gym_claude_code/prepare.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deprecated entry point for ``claude_code_reasoning_gym.prepare``."""
+
+import logging
+
+from environments.claude_code_reasoning_gym.prepare import main
+
+
+if __name__ == "__main__":
+    logging.getLogger(__name__).warning(
+        "`environments/reasoning_gym_claude_code/prepare.py` is deprecated; "
+        "use `environments/claude_code_reasoning_gym/prepare.py`."
+    )
+    main()

--- a/environments/reasoning_gym_hermes/.nemo_gym_tombstone
+++ b/environments/reasoning_gym_hermes/.nemo_gym_tombstone
@@ -1,0 +1,1 @@
+hermes_reasoning_gym

--- a/environments/reasoning_gym_hermes/README.md
+++ b/environments/reasoning_gym_hermes/README.md
@@ -1,0 +1,5 @@
+# Environment moved
+
+This compatibility directory preserves the former `reasoning_gym_hermes` entry point. Use [`hermes_reasoning_gym`](../hermes_reasoning_gym/) for new commands and configuration.
+
+The `prepare.py` wrapper forwards to the renamed environment. NeMo Gym also resolves the former `config.yaml` path to the canonical configuration.

--- a/environments/reasoning_gym_hermes/__init__.py
+++ b/environments/reasoning_gym_hermes/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility package for the renamed ``hermes_reasoning_gym`` environment."""

--- a/environments/reasoning_gym_hermes/prepare.py
+++ b/environments/reasoning_gym_hermes/prepare.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deprecated entry point for ``hermes_reasoning_gym.prepare``."""
+
+import logging
+
+from environments.hermes_reasoning_gym.prepare import main
+
+
+if __name__ == "__main__":
+    logging.getLogger(__name__).warning(
+        "`environments/reasoning_gym_hermes/prepare.py` is deprecated; "
+        "use `environments/hermes_reasoning_gym/prepare.py`."
+    )
+    main()

--- a/environments/reasoning_gym_hermes/prepare.py
+++ b/environments/reasoning_gym_hermes/prepare.py
@@ -7,8 +7,11 @@ import logging
 from environments.hermes_reasoning_gym.prepare import main
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "`environments/reasoning_gym_hermes/prepare.py` is deprecated; "
         "use `environments/hermes_reasoning_gym/prepare.py`."
     )

--- a/environments/reasoning_gym_orchestrator/.nemo_gym_tombstone
+++ b/environments/reasoning_gym_orchestrator/.nemo_gym_tombstone
@@ -1,0 +1,1 @@
+langgraph_orchestrator_reasoning_gym

--- a/environments/reasoning_gym_orchestrator/README.md
+++ b/environments/reasoning_gym_orchestrator/README.md
@@ -1,0 +1,5 @@
+# Environment moved
+
+This compatibility directory preserves the former `reasoning_gym_orchestrator` entry point. Use [`langgraph_orchestrator_reasoning_gym`](../langgraph_orchestrator_reasoning_gym/) for new commands and configuration.
+
+The `prepare.py` wrapper forwards to the renamed environment. NeMo Gym also resolves the former `config.yaml` path to the canonical configuration.

--- a/environments/reasoning_gym_orchestrator/__init__.py
+++ b/environments/reasoning_gym_orchestrator/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility package for the renamed ``langgraph_orchestrator_reasoning_gym`` environment."""

--- a/environments/reasoning_gym_orchestrator/prepare.py
+++ b/environments/reasoning_gym_orchestrator/prepare.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deprecated entry point for ``langgraph_orchestrator_reasoning_gym.prepare``."""
+
+import logging
+
+from environments.langgraph_orchestrator_reasoning_gym.prepare import main
+
+
+if __name__ == "__main__":
+    logging.getLogger(__name__).warning(
+        "`environments/reasoning_gym_orchestrator/prepare.py` is deprecated; "
+        "use `environments/langgraph_orchestrator_reasoning_gym/prepare.py`."
+    )
+    main()

--- a/environments/reasoning_gym_orchestrator/prepare.py
+++ b/environments/reasoning_gym_orchestrator/prepare.py
@@ -7,8 +7,11 @@ import logging
 from environments.langgraph_orchestrator_reasoning_gym.prepare import main
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "`environments/reasoning_gym_orchestrator/prepare.py` is deprecated; "
         "use `environments/langgraph_orchestrator_reasoning_gym/prepare.py`."
     )

--- a/environments/reasoning_gym_parallel_thinking/.nemo_gym_tombstone
+++ b/environments/reasoning_gym_parallel_thinking/.nemo_gym_tombstone
@@ -1,0 +1,1 @@
+langgraph_parallel_thinking_reasoning_gym

--- a/environments/reasoning_gym_parallel_thinking/README.md
+++ b/environments/reasoning_gym_parallel_thinking/README.md
@@ -1,0 +1,5 @@
+# Environment moved
+
+This compatibility directory preserves the former `reasoning_gym_parallel_thinking` entry point. Use [`langgraph_parallel_thinking_reasoning_gym`](../langgraph_parallel_thinking_reasoning_gym/) for new commands and configuration.
+
+The `prepare.py` wrapper forwards to the renamed environment. NeMo Gym also resolves the former `config.yaml` path to the canonical configuration.

--- a/environments/reasoning_gym_parallel_thinking/__init__.py
+++ b/environments/reasoning_gym_parallel_thinking/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility package for the renamed ``langgraph_parallel_thinking_reasoning_gym`` environment."""

--- a/environments/reasoning_gym_parallel_thinking/prepare.py
+++ b/environments/reasoning_gym_parallel_thinking/prepare.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deprecated entry point for ``langgraph_parallel_thinking_reasoning_gym.prepare``."""
+
+import logging
+
+from environments.langgraph_parallel_thinking_reasoning_gym.prepare import main
+
+
+if __name__ == "__main__":
+    logging.getLogger(__name__).warning(
+        "`environments/reasoning_gym_parallel_thinking/prepare.py` is deprecated; "
+        "use `environments/langgraph_parallel_thinking_reasoning_gym/prepare.py`."
+    )
+    main()

--- a/environments/reasoning_gym_parallel_thinking/prepare.py
+++ b/environments/reasoning_gym_parallel_thinking/prepare.py
@@ -7,8 +7,11 @@ import logging
 from environments.langgraph_parallel_thinking_reasoning_gym.prepare import main
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "`environments/reasoning_gym_parallel_thinking/prepare.py` is deprecated; "
         "use `environments/langgraph_parallel_thinking_reasoning_gym/prepare.py`."
     )

--- a/environments/reasoning_gym_reflection/.nemo_gym_tombstone
+++ b/environments/reasoning_gym_reflection/.nemo_gym_tombstone
@@ -1,0 +1,1 @@
+langgraph_reflection_reasoning_gym

--- a/environments/reasoning_gym_reflection/README.md
+++ b/environments/reasoning_gym_reflection/README.md
@@ -1,0 +1,5 @@
+# Environment moved
+
+This compatibility directory preserves the former `reasoning_gym_reflection` entry point. Use [`langgraph_reflection_reasoning_gym`](../langgraph_reflection_reasoning_gym/) for new commands and configuration.
+
+The `prepare.py` wrapper forwards to the renamed environment. NeMo Gym also resolves the former `config.yaml` path to the canonical configuration.

--- a/environments/reasoning_gym_reflection/__init__.py
+++ b/environments/reasoning_gym_reflection/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility package for the renamed ``langgraph_reflection_reasoning_gym`` environment."""

--- a/environments/reasoning_gym_reflection/prepare.py
+++ b/environments/reasoning_gym_reflection/prepare.py
@@ -7,8 +7,11 @@ import logging
 from environments.langgraph_reflection_reasoning_gym.prepare import main
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "`environments/reasoning_gym_reflection/prepare.py` is deprecated; "
         "use `environments/langgraph_reflection_reasoning_gym/prepare.py`."
     )

--- a/environments/reasoning_gym_reflection/prepare.py
+++ b/environments/reasoning_gym_reflection/prepare.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deprecated entry point for ``langgraph_reflection_reasoning_gym.prepare``."""
+
+import logging
+
+from environments.langgraph_reflection_reasoning_gym.prepare import main
+
+
+if __name__ == "__main__":
+    logging.getLogger(__name__).warning(
+        "`environments/reasoning_gym_reflection/prepare.py` is deprecated; "
+        "use `environments/langgraph_reflection_reasoning_gym/prepare.py`."
+    )
+    main()

--- a/environments/reasoning_gym_rewoo/.nemo_gym_tombstone
+++ b/environments/reasoning_gym_rewoo/.nemo_gym_tombstone
@@ -1,0 +1,1 @@
+langgraph_rewoo_reasoning_gym

--- a/environments/reasoning_gym_rewoo/README.md
+++ b/environments/reasoning_gym_rewoo/README.md
@@ -1,0 +1,5 @@
+# Environment moved
+
+This compatibility directory preserves the former `reasoning_gym_rewoo` entry point. Use [`langgraph_rewoo_reasoning_gym`](../langgraph_rewoo_reasoning_gym/) for new commands and configuration.
+
+The `prepare.py` wrapper forwards to the renamed environment. NeMo Gym also resolves the former `config.yaml` path to the canonical configuration.

--- a/environments/reasoning_gym_rewoo/__init__.py
+++ b/environments/reasoning_gym_rewoo/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility package for the renamed ``langgraph_rewoo_reasoning_gym`` environment."""

--- a/environments/reasoning_gym_rewoo/prepare.py
+++ b/environments/reasoning_gym_rewoo/prepare.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deprecated entry point for ``langgraph_rewoo_reasoning_gym.prepare``."""
+
+import logging
+
+from environments.langgraph_rewoo_reasoning_gym.prepare import main
+
+
+if __name__ == "__main__":
+    logging.getLogger(__name__).warning(
+        "`environments/reasoning_gym_rewoo/prepare.py` is deprecated; "
+        "use `environments/langgraph_rewoo_reasoning_gym/prepare.py`."
+    )
+    main()

--- a/environments/reasoning_gym_rewoo/prepare.py
+++ b/environments/reasoning_gym_rewoo/prepare.py
@@ -7,8 +7,11 @@ import logging
 from environments.langgraph_rewoo_reasoning_gym.prepare import main
 
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == "__main__":
-    logging.getLogger(__name__).warning(
+    logger.warning(
         "`environments/reasoning_gym_rewoo/prepare.py` is deprecated; "
         "use `environments/langgraph_rewoo_reasoning_gym/prepare.py`."
     )

--- a/nemo_gym/_config_aliases.py
+++ b/nemo_gym/_config_aliases.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+
+LEGACY_ENVIRONMENT_ALIASES = {
+    "reasoning_gym_claude_code": "claude_code_reasoning_gym",
+    "reasoning_gym_hermes": "hermes_reasoning_gym",
+    "reasoning_gym_orchestrator": "langgraph_orchestrator_reasoning_gym",
+    "reasoning_gym_parallel_thinking": "langgraph_parallel_thinking_reasoning_gym",
+    "reasoning_gym_reflection": "langgraph_reflection_reasoning_gym",
+    "reasoning_gym_rewoo": "langgraph_rewoo_reasoning_gym",
+}
+
+LEGACY_AGENT_ALIASES = {
+    f"{legacy}_agent": f"{canonical}_agent" for legacy, canonical in LEGACY_ENVIRONMENT_ALIASES.items()
+}
+
+LEGACY_CONFIG_PATH_ALIASES = {
+    **{
+        f"environments/{legacy}/config.yaml": f"environments/{canonical}/config.yaml"
+        for legacy, canonical in LEGACY_ENVIRONMENT_ALIASES.items()
+    },
+    "responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml": (
+        "responses_api_agents/stirrup_agent/configs/stirrup_agent.yaml"
+    ),
+    "responses_api_agents/tau2/configs/tau2_agent.yaml": "responses_api_agents/tau2/configs/tau2.yaml",
+    "responses_api_agents/verifiers_agent/configs/acereason-math.yaml": (
+        "responses_api_agents/verifiers_agent/configs/verifiers_agent.yaml"
+    ),
+}
+
+
+def legacy_config_path_alias(path: str) -> str | None:
+    """Return the canonical path for a legacy relative config path."""
+    parsed = Path(path)
+    if parsed.is_absolute():
+        return None
+    return LEGACY_CONFIG_PATH_ALIASES.get(parsed.as_posix())

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from nemo_gym import NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME, _augment_sys_path, component_search_roots
+from nemo_gym._config_aliases import LEGACY_ENVIRONMENT_ALIASES, legacy_config_path_alias
 from nemo_gym.cli.utils import did_you_mean
 
 
@@ -395,6 +396,19 @@ def _asset_config_path(flag: str, value: str) -> str:
         )
     if matches:
         return str(matches[0])
+
+    if flag == "environment" and value in LEGACY_ENVIRONMENT_ALIASES:
+        canonical = LEGACY_ENVIRONMENT_ALIASES[value]
+        resolved = _asset_config_path(flag, canonical)
+        logger.warning(f"`--environment {value}` is deprecated; use `--environment {canonical}`.")
+        return resolved
+
+    if canonical_path := legacy_config_path_alias(path):
+        for root in roots:
+            candidate = root / canonical_path
+            if candidate.exists():
+                logger.warning(f"Config path `{path}` is deprecated; use `{canonical_path}`.")
+                return str(candidate.resolve())
 
     # No match: build a "did you mean?" hint and the roots searched
     if flag == "benchmark":

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -37,6 +37,7 @@ from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 from ray import __version__ as ray_version
 
 from nemo_gym import CACHE_DIR, RESULTS_DIR, WORKING_DIR, _resolve_under_cwd_or_install, component_search_roots
+from nemo_gym._config_aliases import LEGACY_AGENT_ALIASES, legacy_config_path_alias
 from nemo_gym.config_types import (
     AgentCompositionError,
     AlmostServerError,
@@ -65,6 +66,8 @@ from nemo_gym.telemetry.setup import (
     telemetry_config_from_global_config,
 )
 
+
+logger = logging.getLogger(__name__)
 
 _GLOBAL_CONFIG_DICT = None
 NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME = "NEMO_GYM_CONFIG_DICT"
@@ -429,6 +432,12 @@ class GlobalConfigDictParser(BaseModel):
             else:
                 searched_locations = [root / config_path for root in component_search_roots()]
             config_path = _resolve_under_cwd_or_install(original_entry)
+            if not config_path.exists() and (canonical_entry := legacy_config_path_alias(original_entry)):
+                canonical_path = _resolve_under_cwd_or_install(canonical_entry)
+                if canonical_path.exists():
+                    logger.warning(f"Config path `{original_entry}` is deprecated; use `{canonical_entry}`.")
+                    config_paths[index] = canonical_entry
+                    config_path = canonical_path
 
             try:
                 extra_config = _load_config_yaml(config_path)
@@ -851,6 +860,46 @@ Use the name the composed config reports."""
             routes.update({str(key): value for key, value in declared.items()})
         global_config_dict["agent_map"] = routes
 
+    @staticmethod
+    def apply_legacy_agent_aliases(global_config_dict: DictConfig) -> None:
+        """Route legacy reasoning-gym agent names to their canonical instances."""
+        declared = global_config_dict.get("agent_map")
+        routes = dict(declared) if isinstance(declared, DictConfig) else {}
+        active_aliases = {}
+        for legacy, canonical in LEGACY_AGENT_ALIASES.items():
+            destination = routes.get(canonical, canonical)
+            if legacy not in global_config_dict and destination in global_config_dict:
+                active_aliases[legacy] = destination
+        if not active_aliases:
+            return
+
+        deprecated_uses = set()
+        selected = global_config_dict.get("agent_name")
+        if selected in active_aliases:
+            deprecated_uses.add(str(selected))
+            global_config_dict["agent_name"] = active_aliases[selected]
+
+        for key, destination in list(routes.items()):
+            if destination in active_aliases:
+                deprecated_uses.add(str(destination))
+                routes[key] = active_aliases[destination]
+        for legacy, destination in active_aliases.items():
+            routes.setdefault(legacy, destination)
+        global_config_dict["agent_map"] = routes
+
+        fan_out = global_config_dict.get("fan_out")
+        if isinstance(fan_out, DictConfig):
+            for key, destinations in fan_out.items():
+                if not isinstance(destinations, (list, ListConfig)):
+                    continue
+                replacements = [active_aliases.get(destination, destination) for destination in destinations]
+                deprecated_uses.update(destination for destination in destinations if destination in active_aliases)
+                fan_out[key] = replacements
+
+        if deprecated_uses:
+            replacements = ", ".join(f"`{legacy}` -> `{active_aliases[legacy]}`" for legacy in sorted(deprecated_uses))
+            logger.warning(f"Legacy agent names are deprecated; use {replacements}.")
+
     def _raise_on_unsupported_pairing(
         self, global_config_dict: DictConfig, source: _AgentInstance, targets: List[_AgentInstance]
     ) -> None:
@@ -1161,6 +1210,7 @@ Pass each config with --config (it builds the list for you), e.g.:
         # Must run after the swap above (inherited bindings must exist to carry over) and before the
         # missing-value check below (it removes the unbound agent instance that still carries '???').
         self.compose_unbound_agent(global_config_dict, held_agent_overrides)
+        self.apply_legacy_agent_aliases(global_config_dict)
 
         # Fail fast with one actionable error if any required value is still '???'. Runs *after*
         # _recursively_swap_keys so that _delete_key/_inherit_from/_copy have been applied first —

--- a/nemo_gym/registry.py
+++ b/nemo_gym/registry.py
@@ -33,6 +33,7 @@ ENVIRONMENTS_DIR = PARENT_DIR / ENVIRONMENTS_SUBDIR
 BENCHMARKS_SUBDIR = "benchmarks"
 RESOURCES_SERVERS_SUBDIR = "resources_servers"
 ENVIRONMENT_CONFIG_FILENAME = "config.yaml"
+ENVIRONMENT_TOMBSTONE_FILENAME = ".nemo_gym_tombstone"
 MANIFEST_FILENAME = "manifest.yaml"
 
 CatalogKind = Literal["environment", "benchmark"]
@@ -226,7 +227,8 @@ def _legacy_config_paths(tree_dir: Path, kind: CatalogKind) -> Iterable[tuple[st
 
     for child in sorted(tree_dir.iterdir()):
         config_path = child / ENVIRONMENT_CONFIG_FILENAME
-        if child.is_dir() and config_path.is_file():
+        tombstone_path = child / ENVIRONMENT_TOMBSTONE_FILENAME
+        if child.is_dir() and config_path.is_file() and not tombstone_path.is_file():
             yield child.name, config_path
 
 
@@ -243,6 +245,9 @@ def _discover_registry_tree(
     entries: Dict[tuple[CatalogKind, str], EnvironmentCatalogEntry] = {}
     manifest_configs: set[Path] = set()
     for manifest_path in sorted(tree_dir.rglob(MANIFEST_FILENAME)):
+        relative_path = manifest_path.relative_to(tree_dir)
+        if kind == "environment" and (tree_dir / relative_path.parts[0] / ENVIRONMENT_TOMBSTONE_FILENAME).is_file():
+            continue
         key = (kind, _path_identity(tree_dir, manifest_path))
         if key in claimed:
             continue

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -21,11 +21,12 @@ from pathlib import Path
 
 import pytest
 from hydra.core.override_parser.overrides_parser import OverridesParser
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture, MonkeyPatch
 
 import nemo_gym.cli.main as cli_main
 import nemo_gym.global_config as gc
 from nemo_gym import NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME, WORKING_DIR
+from nemo_gym._config_aliases import LEGACY_ENVIRONMENT_ALIASES
 from nemo_gym.cli.main import main
 from nemo_gym.global_config import NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME
 
@@ -1240,6 +1241,50 @@ class TestAssetSelectors:
         # Used by `gym env start` / `gym eval run` for environments/ (see environments/*/README.md).
         _, overrides = _dispatch_for(monkeypatch, ["env", "start", "--environment", "circle_count"])
         assert overrides == [f"+config_paths=[{WORKING_DIR / 'environments/circle_count/config.yaml'}]"]
+
+    @pytest.mark.parametrize(("legacy", "canonical"), LEGACY_ENVIRONMENT_ALIASES.items())
+    def test_legacy_environment_selector_resolves_to_canonical_config(
+        self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, legacy: str, canonical: str
+    ) -> None:
+        with caplog.at_level(logging.WARNING):
+            _, overrides = _dispatch_for(monkeypatch, ["env", "start", "--environment", legacy])
+
+        assert overrides == [f"+config_paths=[{WORKING_DIR / f'environments/{canonical}/config.yaml'}]"]
+        assert f"`--environment {legacy}` is deprecated" in caplog.text
+
+    def test_user_environment_with_legacy_name_takes_precedence(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture
+    ) -> None:
+        legacy = next(iter(LEGACY_ENVIRONMENT_ALIASES))
+        config = tmp_path / "environments" / legacy / "config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text("{}\n")
+        monkeypatch.chdir(tmp_path)
+
+        with caplog.at_level(logging.WARNING):
+            resolved = cli_main._asset_config_path("environment", legacy)
+
+        assert resolved == str(config)
+        assert "deprecated" not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("legacy", "canonical"),
+        [
+            ("stirrup_agent/stirrup_gdpval", "stirrup_agent/stirrup_agent"),
+            ("tau2/tau2_agent", "tau2/tau2"),
+            ("verifiers_agent/acereason-math", "verifiers_agent/verifiers_agent"),
+        ],
+    )
+    def test_legacy_agent_type_flavor_resolves_to_canonical_config(
+        self, caplog: LogCaptureFixture, legacy: str, canonical: str
+    ) -> None:
+        with caplog.at_level(logging.WARNING):
+            resolved = cli_main._asset_config_path("agent-type", legacy)
+
+        server, flavor = canonical.split("/")
+        expected = WORKING_DIR / "responses_api_agents" / server / "configs" / f"{flavor}.yaml"
+        assert resolved == str(expected)
+        assert "deprecated" in caplog.text
 
     def test_nested_manifest_wins_over_legacy_flavor_with_the_same_name(
         self, monkeypatch: MonkeyPatch, tmp_path: Path

--- a/tests/unit_tests/test_environment_tombstones.py
+++ b/tests/unit_tests/test_environment_tombstones.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import runpy
+import sys
+from types import ModuleType
+
+import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
+
+from nemo_gym import WORKING_DIR
+from nemo_gym._config_aliases import LEGACY_ENVIRONMENT_ALIASES
+
+
+@pytest.mark.parametrize(("legacy", "canonical"), LEGACY_ENVIRONMENT_ALIASES.items())
+def test_legacy_prepare_entry_point_forwards_to_canonical_environment(
+    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, legacy: str, canonical: str
+) -> None:
+    called = False
+
+    def fake_main() -> None:
+        nonlocal called
+        called = True
+
+    canonical_prepare = ModuleType(f"environments.{canonical}.prepare")
+    canonical_prepare.main = fake_main
+    monkeypatch.setitem(sys.modules, canonical_prepare.__name__, canonical_prepare)
+    with caplog.at_level(logging.WARNING):
+        runpy.run_path(str(WORKING_DIR / "environments" / legacy / "prepare.py"), run_name="__main__")
+
+    assert called
+    assert f"`environments/{legacy}/prepare.py` is deprecated" in caplog.text

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -25,6 +25,7 @@ from pytest import CaptureFixture, LogCaptureFixture, MonkeyPatch, mark, raises
 import nemo_gym.global_config
 import nemo_gym.server_utils
 from nemo_gym import CACHE_DIR, NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME, RESULTS_DIR, WORKING_DIR
+from nemo_gym._config_aliases import LEGACY_AGENT_ALIASES, LEGACY_CONFIG_PATH_ALIASES
 from nemo_gym.config_types import (
     AgentCompositionError,
     AlmostServerError,
@@ -1872,6 +1873,67 @@ class TestConfigLoadErrors:
         message = str(exc_info.value)
         assert str(missing) in message
         assert message.count("  - ") == 1
+
+    @mark.parametrize(("legacy", "canonical"), LEGACY_CONFIG_PATH_ALIASES.items())
+    def test_load_extra_config_paths_resolves_legacy_alias(
+        self, caplog: LogCaptureFixture, legacy: str, canonical: str
+    ) -> None:
+        parser = GlobalConfigDictParser()
+
+        with caplog.at_level("WARNING"):
+            config_paths, configs = parser.load_extra_config_paths([legacy])
+
+        assert config_paths == [canonical]
+        assert len(configs) == 1
+        assert f"Config path `{legacy}` is deprecated; use `{canonical}`." in caplog.text
+
+    def test_existing_legacy_config_path_takes_precedence(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture
+    ) -> None:
+        legacy = next(iter(LEGACY_CONFIG_PATH_ALIASES))
+        local_config = tmp_path / legacy
+        local_config.parent.mkdir(parents=True)
+        local_config.write_text("local: true\n")
+        monkeypatch.chdir(tmp_path)
+
+        parser = GlobalConfigDictParser()
+        with caplog.at_level("WARNING"):
+            config_paths, configs = parser.load_extra_config_paths([legacy])
+
+        assert config_paths == [legacy]
+        assert configs[0].local is True
+        assert "deprecated" not in caplog.text
+
+    @mark.parametrize(("legacy", "canonical"), LEGACY_AGENT_ALIASES.items())
+    def test_legacy_agent_names_route_to_canonical_instance(
+        self, caplog: LogCaptureFixture, legacy: str, canonical: str
+    ) -> None:
+        config = OmegaConf.create(
+            {
+                canonical: {},
+                "agent_name": legacy,
+                "agent_map": {"source": legacy},
+                "fan_out": {"source": [legacy]},
+            }
+        )
+
+        with caplog.at_level("WARNING"):
+            GlobalConfigDictParser.apply_legacy_agent_aliases(config)
+
+        assert config.agent_name == canonical
+        assert config.agent_map.source == canonical
+        assert config.agent_map[legacy] == canonical
+        assert config.fan_out.source == [canonical]
+        assert f"`{legacy}` -> `{canonical}`" in caplog.text
+
+    def test_legacy_agent_alias_follows_composed_agent_route(self) -> None:
+        legacy, canonical = next(iter(LEGACY_AGENT_ALIASES.items()))
+        composed = "reasoning_gym_custom_agent"
+        config = OmegaConf.create({composed: {}, "agent_map": {canonical: composed}})
+
+        GlobalConfigDictParser.apply_legacy_agent_aliases(config)
+
+        assert config.agent_map[legacy] == composed
 
     def test_load_extra_config_paths_malformed_yaml_raises_config_error(self, tmp_path: Path) -> None:
         bad = tmp_path / "bad.yaml"

--- a/tests/unit_tests/test_registry.py
+++ b/tests/unit_tests/test_registry.py
@@ -128,6 +128,13 @@ class TestDiscoverEnvironments:
 
         assert set(_discover_environments_in_dir(envs_dir)) == {"real"}
 
+    def test_ignores_tombstone_directories(self, tmp_path: Path) -> None:
+        envs_dir = tmp_path / "environments"
+        manifest_path = _write_manifest(tmp_path, "environments", "moved", _manifest("moved"))
+        manifest_path.parent.joinpath(registry_module.ENVIRONMENT_TOMBSTONE_FILENAME).write_text("replacement\n")
+
+        assert _discover_environments_in_dir(envs_dir) == {}
+
     def test_unparseable_or_metadataless_configs_still_discovered(self, tmp_path: Path) -> None:
         # Configs without a parseable resources_servers block (or malformed YAML) must still be
         # discovered by name, just with no description/domain — never crash discovery.


### PR DESCRIPTION
## Summary

- Retain tombstone directories for the six renamed reasoning-gym environments, with migration pointers and `prepare.py` wrappers that log the deprecated and canonical paths before forwarding.
- Mark tombstone directories with `.nemo_gym_tombstone` and exclude marked directories from legacy and manifest-backed environment discovery.
- Resolve the pre-v0.6.0 environment names and config paths to their canonical configs and emit deprecation warnings.
- Resolve the renamed Stirrup, Tau2, and Verifiers agent config paths, including legacy `--agent-type` flavors.
- Route legacy reasoning-gym agent instance names through canonical or runtime-composed agents.
- Preserve higher-priority user configs that reuse a legacy built-in name.