### PR TITLE
fix(rollout-collection): make run_examples() rollout-latency stamping opt-in

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -22,6 +22,7 @@ from asyncio import Future, Semaphore
 from collections import Counter, defaultdict
 from collections.abc import Mapping
 from contextlib import nullcontext
+from dataclasses import dataclass
 from datetime import timedelta
 from difflib import get_close_matches
 from itertools import repeat
@@ -151,10 +152,18 @@ AGENT_RUN_ERROR_FAILURE_CLASS = "agent_run_error"
 _NO_RESULT_FAILURE_CLASSES = frozenset({AGENT_REQUEST_FAILED_FAILURE_CLASS, AGENT_RUN_ERROR_FAILURE_CLASS})
 NG_TRAJECTORY_KEY = "ng_trajectory"
 NG_PERF_KEY = "ng_perf"
-_NG_ROLLOUT_LATENCY_MS_KEY = "_ng_rollout_latency_ms"
 _MODEL_CALL_PAYLOAD_KEYS = ("request", "response", "request_raw", "response_raw")
 
 _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
+
+
+@dataclass(frozen=True)
+class _CompletedRollout:
+    """A finished ``/run`` dispatch, with timing carried alongside (not inside) the raw result."""
+
+    row: Dict[str, Any]
+    result: Dict[str, Any]
+    rollout_latency_ms: Optional[float]
 
 
 def _nonnegative_int(value: Any) -> Optional[int]:
@@ -520,8 +529,9 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
     return ng_perf
 
 
-def _attach_ng_perf(result: dict[str, Any], *, observability_enabled: bool) -> None:
-    rollout_latency_ms = result.pop(_NG_ROLLOUT_LATENCY_MS_KEY, None)
+def _attach_ng_perf(
+    result: dict[str, Any], *, observability_enabled: bool, rollout_latency_ms: Optional[float] = None
+) -> None:
     if not observability_enabled:
         # ng_perf stays absent entirely when observability is off (OQ4): a caller who
         # disabled it only wants the final score, not partial/best-effort perf evidence.
@@ -1371,13 +1381,13 @@ class RolloutCollectionHelper(BaseModel):
         results_file = output_fpath.open("ab")
         failures_file = failures_fpath.open("ab")
         failure_counts: Counter = Counter()
-        for future in self.run_examples(
+        for future in self._run_examples_with_metadata(
             input_rows,
             semaphore=semaphore,
             route_failures_to_sidecar=config.route_failures_to_sidecar,
-            include_rollout_latency=True,
         ):
-            row, result = await future
+            completed = await future
+            row, result, rollout_latency_ms = completed.row, completed.result, completed.rollout_latency_ms
 
             result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
             result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
@@ -1410,10 +1420,8 @@ class RolloutCollectionHelper(BaseModel):
             if "ng_model_call_capture" in result or "ng_agent_observations" in result or NG_TRAJECTORY_KEY in result:
                 _attach_trajectory_record(row, result)
 
-            # Assembles ng_perf from ng_trajectory when observability is enabled;
-            # additionally drops the internal wall-clock timer key so it never
-            # leaks into a persisted rollout.
-            _attach_ng_perf(result, observability_enabled=observability_enabled)
+            # Assembles ng_perf from ng_trajectory when observability is enabled.
+            _attach_ng_perf(result, observability_enabled=observability_enabled, rollout_latency_ms=rollout_latency_ms)
 
             # Freeze and rebuild tokens only for participating agents.
             # This step does not retire the frozen snapshot.
@@ -1876,29 +1884,20 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
             f"--allow-unsupported-pairing (or set {ALLOW_UNSUPPORTED_PAIRING_ENV_VAR_NAME}=1) to bypass the check."
         )
 
-    def run_examples(
+    def _run_examples_with_metadata(
         self,
         examples: List[Dict],
         head_server_config: Optional[BaseServerConfig] = None,
         semaphore: Optional[Semaphore] = None,
         route_failures_to_sidecar: bool = False,
-        include_rollout_latency: bool = False,
     ) -> Iterator[Future]:  # pragma: no cover
         """
-        We provide this function as a lower level interface for running rollout collection.
+        Internal dispatch shared by ``run_examples`` and Gym's own collection paths.
 
-        Rows are dispatched as given: task_sources are resolved and agent names validated here,
-        but run-level knobs (``agent_map``, ``fan_out``, ``num_repeats``) are NOT applied — call
-        ``preprocess_examples`` first if you need them.
-
-        ``route_failures_to_sidecar`` makes a failed `/run` a failure row instead of an exception
-        that ends every rollout still in flight. It defaults off because those rollouts then leave
-        the score.
-
-        ``include_rollout_latency`` stamps the private ``_ng_rollout_latency_ms`` timing key onto
-        successful results, for callers that will feed the result through ``_attach_ng_perf`` (which
-        consumes and removes it). It defaults off so direct callers get exactly the `/run` result,
-        with no Gym-private fields.
+        Identical contract to ``run_examples``, but each future resolves to a ``_CompletedRollout``
+        that carries ``rollout_latency_ms`` alongside the raw ``/run`` result instead of inside it,
+        so internal-only timing never has to be smuggled through (and stripped back out of) a dict
+        that a direct caller of ``run_examples`` could also observe.
         """
         server_client = self.setup_server_client(head_server_config)
         self.resolve_task_sources(examples, server_client.global_config_dict)
@@ -1906,7 +1905,7 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
         self._validate_agent_pairings(examples, server_client.global_config_dict)
         semaphore = semaphore or nullcontext()
 
-        async def _post_subroutine(row: Dict) -> Tuple[Dict, Dict]:
+        async def _post_subroutine(row: Dict) -> _CompletedRollout:
             async with semaphore:
                 started_at = time()
                 res = None
@@ -1914,11 +1913,10 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                     res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
                     await raise_for_status(res)
                     result = await get_response_json(res)
-                    if include_rollout_latency:
-                        # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
-                        # from summed model-call/tool latencies to account for additional overhead.
-                        result[_NG_ROLLOUT_LATENCY_MS_KEY] = (time() - started_at) * 1000
-                    return row, result
+                    # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
+                    # from summed model-call/tool latencies to account for additional overhead.
+                    rollout_latency_ms = (time() - started_at) * 1000
+                    return _CompletedRollout(row=row, result=result, rollout_latency_ms=rollout_latency_ms)
                 except Exception as e:
                     print(
                         "[rollout_collection] /run failed "
@@ -1933,7 +1931,9 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                     # The status comes from the error when it carries one, and from the response
                     # when the body was the part that failed.
                     status = getattr(e, "status", None) or getattr(res, "status", None)
-                    return row, _agent_request_failure_row(e, status)
+                    return _CompletedRollout(
+                        row=row, result=_agent_request_failure_row(e, status), rollout_latency_ms=None
+                    )
 
         return tqdm.as_completed(
             map(_post_subroutine, examples),
@@ -1941,6 +1941,42 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
             miniters=10,
             total=len(examples),
             maxinterval=60,
+        )
+
+    def run_examples(
+        self,
+        examples: List[Dict],
+        head_server_config: Optional[BaseServerConfig] = None,
+        semaphore: Optional[Semaphore] = None,
+        route_failures_to_sidecar: bool = False,
+    ) -> Iterator[Future]:  # pragma: no cover
+        """
+        We provide this function as a lower level interface for running rollout collection.
+
+        Rows are dispatched as given: task_sources are resolved and agent names validated here,
+        but run-level knobs (``agent_map``, ``fan_out``, ``num_repeats``) are NOT applied — call
+        ``preprocess_examples`` first if you need them.
+
+        ``route_failures_to_sidecar`` makes a failed `/run` a failure row instead of an exception
+        that ends every rollout still in flight. It defaults off because those rollouts then leave
+        the score.
+
+        Every future resolves to exactly the ``(row, result)`` pair Gym's own `/run` endpoint
+        returned — no Gym-private fields are ever added to ``result``.
+        """
+
+        async def _without_metadata(future: Future) -> Tuple[Dict, Dict]:
+            completed = await future
+            return completed.row, completed.result
+
+        return map(
+            _without_metadata,
+            self._run_examples_with_metadata(
+                examples,
+                head_server_config=head_server_config,
+                semaphore=semaphore,
+                route_failures_to_sidecar=route_failures_to_sidecar,
+            ),
         )
 
     def setup_server_client(

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -1372,7 +1372,10 @@ class RolloutCollectionHelper(BaseModel):
         failures_file = failures_fpath.open("ab")
         failure_counts: Counter = Counter()
         for future in self.run_examples(
-            input_rows, semaphore=semaphore, route_failures_to_sidecar=config.route_failures_to_sidecar
+            input_rows,
+            semaphore=semaphore,
+            route_failures_to_sidecar=config.route_failures_to_sidecar,
+            include_rollout_latency=True,
         ):
             row, result = await future
 
@@ -1879,6 +1882,7 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
         head_server_config: Optional[BaseServerConfig] = None,
         semaphore: Optional[Semaphore] = None,
         route_failures_to_sidecar: bool = False,
+        include_rollout_latency: bool = False,
     ) -> Iterator[Future]:  # pragma: no cover
         """
         We provide this function as a lower level interface for running rollout collection.
@@ -1890,6 +1894,11 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
         ``route_failures_to_sidecar`` makes a failed `/run` a failure row instead of an exception
         that ends every rollout still in flight. It defaults off because those rollouts then leave
         the score.
+
+        ``include_rollout_latency`` stamps the private ``_ng_rollout_latency_ms`` timing key onto
+        successful results, for callers that will feed the result through ``_attach_ng_perf`` (which
+        consumes and removes it). It defaults off so direct callers get exactly the `/run` result,
+        with no Gym-private fields.
         """
         server_client = self.setup_server_client(head_server_config)
         self.resolve_task_sources(examples, server_client.global_config_dict)
@@ -1905,9 +1914,10 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                     res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
                     await raise_for_status(res)
                     result = await get_response_json(res)
-                    # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
-                    # from summed model-call/tool latencies to account for additional overhead.
-                    result[_NG_ROLLOUT_LATENCY_MS_KEY] = (time() - started_at) * 1000
+                    if include_rollout_latency:
+                        # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
+                        # from summed model-call/tool latencies to account for additional overhead.
+                        result[_NG_ROLLOUT_LATENCY_MS_KEY] = (time() - started_at) * 1000
                     return row, result
                 except Exception as e:
                     print(

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -859,7 +859,7 @@ async def run_e2e_multistage(
 
             semaphore = Semaphore(semaphore_size)
         results: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
-        for future in helper.run_examples(rows, semaphore=semaphore or nullcontext()):
+        for future in helper.run_examples(rows, semaphore=semaphore or nullcontext(), include_rollout_latency=True):
             row, result = await future
             _attach_ng_perf(result, observability_enabled=observability_enabled)
             results.append((row, result))

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -859,10 +859,14 @@ async def run_e2e_multistage(
 
             semaphore = Semaphore(semaphore_size)
         results: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
-        for future in helper.run_examples(rows, semaphore=semaphore or nullcontext(), include_rollout_latency=True):
-            row, result = await future
-            _attach_ng_perf(result, observability_enabled=observability_enabled)
-            results.append((row, result))
+        for future in helper._run_examples_with_metadata(rows, semaphore=semaphore or nullcontext()):
+            completed = await future
+            _attach_ng_perf(
+                completed.result,
+                observability_enabled=observability_enabled,
+                rollout_latency_ms=completed.rollout_latency_ms,
+            )
+            results.append((completed.row, completed.result))
         return results
 
     output_fpath = Path(rollout_collection_config.output_jsonl_fpath)

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -1219,10 +1219,29 @@ class TestRolloutCollection:
         monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", AsyncMock())
         monkeypatch.setattr(nemo_gym.rollout_collection, "get_response_json", AsyncMock(return_value={"response": {}}))
 
-        _, result = await next(RolloutCollectionHelper().run_examples([row]))
+        _, result = await next(RolloutCollectionHelper().run_examples([row], include_rollout_latency=True))
 
         assert isinstance(result["_ng_rollout_latency_ms"], float)
         assert result["_ng_rollout_latency_ms"] >= 0
+
+    async def test_run_examples_does_not_stamp_latency_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Direct callers (e.g. NeMo-RL) get the raw /run result, with no Gym-private fields."""
+        row = {AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
+        response = MagicMock()
+        response.status = 200
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=response)
+        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {"responses_api_agents": {"impl": {}}}})
+        monkeypatch.setattr(
+            nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
+        )
+        monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", AsyncMock())
+        monkeypatch.setattr(nemo_gym.rollout_collection, "get_response_json", AsyncMock(return_value={"response": {}}))
+
+        _, result = await next(RolloutCollectionHelper().run_examples([row]))
+
+        assert "_ng_rollout_latency_ms" not in result
 
     async def test_run_from_config_does_not_route_failures_unless_asked(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, empty_global_config: MagicMock

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -61,6 +61,7 @@ from nemo_gym.rollout_collection import (
     _attach_trajectory_record,
     _build_ng_perf,
     _build_trajectory_record,
+    _CompletedRollout,
     _expand_input_glob,
     _failure_rows_counted_as_zero,
     _failures_path_for,
@@ -707,7 +708,6 @@ class TestRolloutCollection:
 
     def test_attach_ng_perf_absent_when_observability_disabled(self) -> None:
         result = {
-            "_ng_rollout_latency_ms": 42.0,
             NG_TRAJECTORY_KEY: {
                 "task_id": "t",
                 "rollout_id": "t-0",
@@ -715,14 +715,12 @@ class TestRolloutCollection:
             },
         }
 
-        _attach_ng_perf(result, observability_enabled=False)
+        _attach_ng_perf(result, observability_enabled=False, rollout_latency_ms=42.0)
 
         assert NG_PERF_KEY not in result
-        assert "_ng_rollout_latency_ms" not in result
 
     def test_attach_ng_perf_sets_ng_perf_when_enabled(self) -> None:
         result = {
-            "_ng_rollout_latency_ms": 42.0,
             NG_TRAJECTORY_KEY: {
                 "task_id": "t",
                 "rollout_id": "t-0",
@@ -730,7 +728,7 @@ class TestRolloutCollection:
             },
         }
 
-        _attach_ng_perf(result, observability_enabled=True)
+        _attach_ng_perf(result, observability_enabled=True, rollout_latency_ms=42.0)
 
         assert result[NG_PERF_KEY] == {
             "num_turns": 1,
@@ -738,17 +736,15 @@ class TestRolloutCollection:
             "token_observability_coverage": 0.0,
             "total_latency_ms": 42.0,
         }
-        assert "_ng_rollout_latency_ms" not in result
 
     def test_attach_ng_perf_swallows_build_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # An unexpected assembly failure must never take down rollout collection over an observability side-channel.
-        result = {"_ng_rollout_latency_ms": 42.0, NG_TRAJECTORY_KEY: {}}
+        result = {NG_TRAJECTORY_KEY: {}}
         monkeypatch.setattr(nemo_gym.rollout_collection, "_build_ng_perf", MagicMock(side_effect=ValueError))
 
-        _attach_ng_perf(result, observability_enabled=True)
+        _attach_ng_perf(result, observability_enabled=True, rollout_latency_ms=42.0)
 
         assert NG_PERF_KEY not in result
-        assert "_ng_rollout_latency_ms" not in result
 
     async def test_run_examples_logs_failed_run(
         self,
@@ -1205,7 +1201,8 @@ class TestRolloutCollection:
         merged = [orjson.loads(line) for line in merged_fpath.read_bytes().splitlines()]
         assert [row["reward"] for row in merged] == [1.0]
 
-    async def test_run_examples_stamps_independent_rollout_latency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_run_examples_never_leaks_rollout_latency_into_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Direct callers (e.g. NeMo-RL) get exactly the raw /run result, with no Gym-private fields."""
         row = {AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
         response = MagicMock()
         response.status = 200
@@ -1219,29 +1216,35 @@ class TestRolloutCollection:
         monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", AsyncMock())
         monkeypatch.setattr(nemo_gym.rollout_collection, "get_response_json", AsyncMock(return_value={"response": {}}))
 
-        _, result = await next(RolloutCollectionHelper().run_examples([row], include_rollout_latency=True))
+        returned_row, result = await next(RolloutCollectionHelper().run_examples([row]))
 
-        assert isinstance(result["_ng_rollout_latency_ms"], float)
-        assert result["_ng_rollout_latency_ms"] >= 0
-
-    async def test_run_examples_does_not_stamp_latency_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Direct callers (e.g. NeMo-RL) get the raw /run result, with no Gym-private fields."""
-        row = {AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
-        response = MagicMock()
-        response.status = 200
-
-        mock_server_client = MagicMock()
-        mock_server_client.post = AsyncMock(return_value=response)
-        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {"responses_api_agents": {"impl": {}}}})
-        monkeypatch.setattr(
-            nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
-        )
-        monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", AsyncMock())
-        monkeypatch.setattr(nemo_gym.rollout_collection, "get_response_json", AsyncMock(return_value={"response": {}}))
-
-        _, result = await next(RolloutCollectionHelper().run_examples([row]))
-
+        assert returned_row is row
+        assert result == {"response": {}}
         assert "_ng_rollout_latency_ms" not in result
+
+    async def test_run_examples_with_metadata_carries_rollout_latency_alongside_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Internal callers get the timing via _CompletedRollout, never through the result dict."""
+        row = {AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
+        response = MagicMock()
+        response.status = 200
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=response)
+        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {"responses_api_agents": {"impl": {}}}})
+        monkeypatch.setattr(
+            nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
+        )
+        monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", AsyncMock())
+        monkeypatch.setattr(nemo_gym.rollout_collection, "get_response_json", AsyncMock(return_value={"response": {}}))
+
+        completed = await next(RolloutCollectionHelper()._run_examples_with_metadata([row]))
+
+        assert completed.row is row
+        assert completed.result == {"response": {}}
+        assert isinstance(completed.rollout_latency_ms, float)
+        assert completed.rollout_latency_ms >= 0
 
     async def test_run_from_config_does_not_route_failures_unless_asked(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, empty_global_config: MagicMock
@@ -1287,14 +1290,20 @@ class TestRolloutCollection:
         output_jsonl_fpath = tmp_path / "output.jsonl"
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples: list[dict], *args, **kwargs):
+            def _run_examples_with_metadata(self, examples: list[dict], *args, **kwargs):
                 assert kwargs["route_failures_to_sidecar"] is False
                 futures = []
                 for example in examples:
                     future = Future()
                     scored = {"reward": 1.0}
                     judge_failed = {"reward": 0.0, NG_FAILURE_CLASS_KEY: "judge_failed", "error": "judge 503"}
-                    future.set_result((example, scored if example["x"] == 0 else judge_failed))
+                    future.set_result(
+                        _CompletedRollout(
+                            row=example,
+                            result=scored if example["x"] == 0 else judge_failed,
+                            rollout_latency_ms=None,
+                        )
+                    )
                     futures.append(future)
                 return futures
 
@@ -1343,7 +1352,7 @@ class TestRolloutCollection:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples: list[dict], *args, **kwargs):
+            def _run_examples_with_metadata(self, examples: list[dict], *args, **kwargs):
                 assert examples == []
                 return []
 
@@ -1777,7 +1786,7 @@ class TestRolloutCollection:
         )
 
         class TestRolloutCollectionHelper(RolloutCollectionHelper):
-            def run_examples(
+            def _run_examples_with_metadata(
                 self,
                 examples: list[dict],
                 *args,
@@ -1787,7 +1796,11 @@ class TestRolloutCollection:
                 for example in examples:
                     future = Future()
                     # (row, result)
-                    future.set_result((example, {"response": {"usage": {"abc usage": 1}}}))
+                    future.set_result(
+                        _CompletedRollout(
+                            row=example, result={"response": {"usage": {"abc usage": 1}}}, rollout_latency_ms=None
+                        )
+                    )
                     futures.append(future)
 
                 return futures
@@ -1926,13 +1939,19 @@ class TestRolloutCollection:
             return float(task_idx + rollout_idx)
 
         class TestRolloutCollectionHelper(RolloutCollectionHelper):
-            def run_examples(self, examples: list[dict], *args, **kwargs):
+            def _run_examples_with_metadata(self, examples: list[dict], *args, **kwargs):
                 futures = []
                 for example in examples:
                     future = Future()
                     task_idx = example[TASK_INDEX_KEY_NAME]
                     rollout_idx = example[ROLLOUT_INDEX_KEY_NAME]
-                    future.set_result((example, {"response": {}, "reward": reward_for(task_idx, rollout_idx)}))
+                    future.set_result(
+                        _CompletedRollout(
+                            row=example,
+                            result={"response": {}, "reward": reward_for(task_idx, rollout_idx)},
+                            rollout_latency_ms=None,
+                        )
+                    )
                     futures.append(future)
                 return futures
 
@@ -2005,11 +2024,13 @@ class TestRolloutCollection:
         )
 
         class TestRolloutCollectionHelper(RolloutCollectionHelper):
-            def run_examples(self, examples: list[dict], *args, **kwargs):
+            def _run_examples_with_metadata(self, examples: list[dict], *args, **kwargs):
                 futures = []
                 for example in examples:
                     future = Future()
-                    future.set_result((example, {"response": {}, "reward": 1.0}))
+                    future.set_result(
+                        _CompletedRollout(row=example, result={"response": {}, "reward": 1.0}, rollout_latency_ms=None)
+                    )
                     futures.append(future)
                 return futures
 
@@ -2066,9 +2087,9 @@ class TestRolloutCollection:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 future = Future()
-                future.set_result((examples[0], {"reward": 1.0}))
+                future.set_result(_CompletedRollout(row=examples[0], result={"reward": 1.0}, rollout_latency_ms=None))
                 return [future]
 
         await Helper().run_from_config(config)
@@ -2099,11 +2120,15 @@ class TestRolloutCollection:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 futures = []
                 for example in examples:
                     future = Future()
-                    future.set_result((example, {"response": {"usage": {"abc usage": 1}}}))
+                    future.set_result(
+                        _CompletedRollout(
+                            row=example, result={"response": {"usage": {"abc usage": 1}}}, rollout_latency_ms=None
+                        )
+                    )
                     futures.append(future)
                 return futures
 
@@ -2154,7 +2179,7 @@ class TestRolloutCollection:
         store.record("0-0", {"model_call_id": "stale", "dialect": "responses", "request": {}, "response": {}})
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 [example] = examples
                 assert example[TASK_INDEX_KEY_NAME] == 0 and example[ROLLOUT_INDEX_KEY_NAME] == 0
                 assert store.read("0-0") == []
@@ -2172,7 +2197,7 @@ class TestRolloutCollection:
                         "rollout_id": "0-0",
                         "gaps": [{"code": "multimodal_history_redacted"}],
                     }
-                future.set_result((example, result))
+                future.set_result(_CompletedRollout(row=example, result=result, rollout_latency_ms=None))
                 return [future]
 
         results = await Helper().run_from_config(config)
@@ -2223,14 +2248,16 @@ class TestRolloutCollection:
         store = CaptureStore(capture_dir)
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 [example] = examples
                 store.record(
                     "step7.0-0",
                     {"model_call_id": "call", "dialect": "responses", "request": {}, "response": {}},
                 )
                 future = Future()
-                future.set_result((example, {"response": {"usage": {}}}))
+                future.set_result(
+                    _CompletedRollout(row=example, result={"response": {"usage": {}}}, rollout_latency_ms=None)
+                )
                 return [future]
 
         results = await Helper().run_from_config(config)
@@ -2271,10 +2298,14 @@ class TestRolloutCollection:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 [example] = examples
                 future = Future()
-                future.set_result((example, {"response": {"output": [], "usage": {}}}))
+                future.set_result(
+                    _CompletedRollout(
+                        row=example, result={"response": {"output": [], "usage": {}}}, rollout_latency_ms=None
+                    )
+                )
                 return [future]
 
         [result] = await Helper().run_from_config(config)
@@ -2316,7 +2347,7 @@ class TestRolloutCollection:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 raise AssertionError("Dispatch must not start without a TokenSource.")
 
         with pytest.raises(ValueError, match="rollout-collector process"):
@@ -2376,10 +2407,14 @@ class TestRolloutCollection:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 [example] = examples
                 future = Future()
-                future.set_result((example, {"response": {"output": [], "usage": {}}}))
+                future.set_result(
+                    _CompletedRollout(
+                        row=example, result={"response": {"output": [], "usage": {}}}, rollout_latency_ms=None
+                    )
+                )
                 return [future]
 
         with pytest.warns(UserWarning, match="capture contains no token records"):
@@ -2404,7 +2439,7 @@ class TestRolloutCollection:
         )
 
         class TestRolloutCollectionHelper(RolloutCollectionHelper):
-            def run_examples(
+            def _run_examples_with_metadata(
                 self,
                 examples: list[dict],
                 *args,
@@ -2414,7 +2449,11 @@ class TestRolloutCollection:
                 for example in examples:
                     future = Future()
                     # (row, result)
-                    future.set_result((example, {"response": {"usage": {"abc usage": 1}}}))
+                    future.set_result(
+                        _CompletedRollout(
+                            row=example, result={"response": {"usage": {"abc usage": 1}}}, rollout_latency_ms=None
+                        )
+                    )
                     futures.append(future)
 
                 # Reverse!
@@ -2489,7 +2528,7 @@ class TestRolloutCollection:
         captured: dict[str, list[dict]] = {}
 
         class TestRolloutCollectionHelper(RolloutCollectionHelper):
-            def run_examples(
+            def _run_examples_with_metadata(
                 self,
                 examples: list[dict],
                 *args,
@@ -2506,7 +2545,7 @@ class TestRolloutCollection:
                         result[NG_FAILURE_CLASS_KEY] = "verify_failed"
                     elif example["x"] == 2:
                         result[NG_NO_PERSIST_KEY] = True
-                    future.set_result((example, result))
+                    future.set_result(_CompletedRollout(row=example, result=result, rollout_latency_ms=None))
                     futures.append(future)
                 return futures
 
@@ -2565,10 +2604,10 @@ class TestRolloutCollection:
         captured: dict[str, list[dict]] = {}
 
         class TestRolloutCollectionHelper(RolloutCollectionHelper):
-            def run_examples(self, examples: list[dict], *args, **kwargs):
+            def _run_examples_with_metadata(self, examples: list[dict], *args, **kwargs):
                 [example] = examples
                 future = Future()
-                future.set_result((example, {"case": "new"}))
+                future.set_result(_CompletedRollout(row=example, result={"case": "new"}, rollout_latency_ms=None))
                 return [future]
 
             async def _call_aggregate_metrics(self, results, rows, output_fpath):
@@ -2931,11 +2970,13 @@ class TestDisableAggregationAndCallerTaskIndex:
         )
 
         class Helper(RolloutCollectionHelper):
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 futures = []
                 for ex in examples:
                     fut = Future()
-                    fut.set_result((ex, {"response": {"usage": {}}}))
+                    fut.set_result(
+                        _CompletedRollout(row=ex, result={"response": {"usage": {}}}, rollout_latency_ms=None)
+                    )
                     futures.append(fut)
                 return futures
 
@@ -3871,9 +3912,9 @@ class TestTaskSourcePreprocess:
             def setup_server_client(self, head_server_config=None):
                 return mock_client
 
-            def run_examples(self, examples, *args, **kwargs):
+            def _run_examples_with_metadata(self, examples, *args, **kwargs):
                 future = Future()
-                future.set_result((examples[0], {"response": {}}))
+                future.set_result(_CompletedRollout(row=examples[0], result={"response": {}}, rollout_latency_ms=None))
                 return [future]
 
         await Helper().run_from_config(config)

--- a/tests/unit_tests/test_rollout_health.py
+++ b/tests/unit_tests/test_rollout_health.py
@@ -17,7 +17,7 @@ import nemo_gym.health.checks as health_checks
 import nemo_gym.rollout_collection as rollout_collection
 import nemo_gym.rollout_health as health
 from nemo_gym.base_responses_api_model import build_model_call_record
-from nemo_gym.rollout_collection import RolloutCollectionConfig, RolloutCollectionHelper
+from nemo_gym.rollout_collection import RolloutCollectionConfig, RolloutCollectionHelper, _CompletedRollout
 from nemo_gym.rollout_health import CHECK_REGISTRY, run_health_checks
 from nemo_gym.rollout_observability import TrajectoryRecord
 
@@ -244,14 +244,14 @@ async def test_health_on_and_off_leave_collection_and_metrics_byte_identical(
     }
 
     class GoldenHelper(RolloutCollectionHelper):
-        def run_examples(self, examples, *args, **kwargs):
+        def _run_examples_with_metadata(self, examples, *args, **kwargs):
             futures = []
             for example in examples:
                 future = Future()
                 future.set_result(
-                    (
-                        example,
-                        {
+                    _CompletedRollout(
+                        row=example,
+                        result={
                             "response": {
                                 "output": [
                                     {
@@ -264,6 +264,7 @@ async def test_health_on_and_off_leave_collection_and_metrics_byte_identical(
                             },
                             "reward": 1.0,
                         },
+                        rollout_latency_ms=None,
                     )
                 )
                 futures.append(future)


### PR DESCRIPTION
## Summary
- `RolloutCollectionHelper.run_examples()` unconditionally stamped a private `_ng_rollout_latency_ms` field onto every successful `/run` result. Gym's own `run_from_config()` path stripped it back off via `_attach_ng_perf()`, but direct callers of the lower-level `run_examples()` API (e.g. NeMo-RL, per NeMo-RL PR #3837) got the raw field in their result, where it gets misread as a live (nondeterministic) environment metric.
- Adds `include_rollout_latency: bool = False` to `run_examples()`; the timing key is only stamped when the caller opts in.
- Updates the two internal call sites that route through `_attach_ng_perf()` (`nemo_gym/rollout_collection.py`'s `run_from_config`, and `resources_servers/gdpval/multistage_orchestrator.py`'s multistage path) to pass `include_rollout_latency=True`, so `ng_perf.total_latency_ms` is unaffected.

## Test plan
- [x] `pytest tests/unit_tests/test_rollout_collection.py` — 190 passed (updated the existing stamping test to opt in explicitly, added a new test asserting the field is absent by default)
- [x] `pre-commit run --files nemo_gym/rollout_collection.py resources_servers/gdpval/multistage_orchestrator.py tests/unit_tests/test_rollout_collection.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)