### PR TITLE
chore: add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "NeMo Gym",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for NeMo Gym.
+# Installs uv (astral.sh egress is blocked, so we use PyPI), then materializes
+# the Python 3.13.14 project virtualenv and dev dependencies from uv.lock.
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv not found; installing from PyPI..."
+    python3 -m pip install --user --upgrade uv
+fi
+
+echo "uv version: $(uv --version)"
+
+# `uv sync` creates .venv using the pinned interpreter in .python-version
+# (3.13.14), downloading it if necessary, and installs locked dependencies.
+# It is a no-op when the environment already matches uv.lock.
+uv sync --extra dev
+
+# Install git hooks so linting/format checks match CI. Safe to re-run and
+# non-fatal: some managed environments set core.hooksPath, which makes
+# pre-commit refuse to install hooks. The venv is fully usable either way.
+uv run pre-commit install || echo "pre-commit hook install skipped (non-fatal)."
+
+echo "NeMo Gym environment ready."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a Cursor Cloud Agent development environment for NeMo Gym so agents boot into a ready-to-use dev setup.

- `.cursor/environment.json` — declares the environment (`ubuntu` user, install command).
- `.cursor/install.sh` — idempotent bootstrap that installs `uv` from PyPI (the `astral.sh` installer is blocked by egress), then runs `uv sync --extra dev` to materialize the pinned Python 3.13.14 virtualenv from `uv.lock`, and installs pre-commit hooks (non-fatal when a managed `core.hooksPath` is set).

No application/library code is changed.

### Validation (performed in this environment)

- Fresh install from a clean state: `uv sync --extra dev` builds the 3.13.14 venv and installs all locked deps; second run is a no-op (idempotent).
- Core unit tests: `pytest tests/unit_tests/ -m "not sandbox"` → 3626 passed, 102 skipped.
- End-to-end rollout: started the `mcqa` resources server + `simple_agent` + model server via `gym env start`, then ran `gym eval run` against a local mock inference endpoint. The full pipeline (agent → model → verifier → aggregate metrics) ran and the verifier produced a genuine mixed score (2/5 correct, 40% accuracy), confirming verification really discriminates correct vs incorrect answers.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1525869-5687-405f-b212-08f0524cdfd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1525869-5687-405f-b212-08f0524cdfd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

