### PR TITLE
keep incomplete_details alongside usage

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -1666,7 +1666,7 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
         server_client = self.setup_server_client()
 
         async def _fetch_agent_metrics(agent_name: str, agent_result_list: List[Dict]) -> Dict:
-            # Strip heavyweight fields before sending, but preserve response.usage
+            # Strip heavyweight fields before sending, but preserve response.usage and response.incomplete_details if present.
             stripped = []
             for r in agent_result_list:
                 entry = {
@@ -1681,9 +1681,16 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                         NG_TRAJECTORY_KEY,
                     )
                 }
-                usage = (r.get("response") or {}).get("usage")
-                if usage:
-                    entry["response"] = {"usage": usage}
+                response = r.get("response") or {}
+                response_metadata = {}
+                usage = response.get("usage")
+                if usage is not None:
+                    response_metadata["usage"] = usage
+                incomplete_details = response.get("incomplete_details")
+                if incomplete_details is not None:
+                    response_metadata["incomplete_details"] = incomplete_details
+                if response_metadata:
+                    entry["response"] = response_metadata
                 stripped.append(entry)
 
             agg_request = AggregateMetricsRequest(verify_responses=stripped)

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -2710,7 +2710,10 @@ class TestRolloutCollection:
                 TASK_INDEX_KEY_NAME: 0,
                 ROLLOUT_INDEX_KEY_NAME: 0,
                 "reward": 1.0,
-                "response": {"usage": {"tokens": 10}},
+                "response": {
+                    "usage": {"tokens": 10},
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                },
                 "ng_agent_observations": {"invocations": [{"conversation": ["large"]}]},
                 "ng_model_call_capture": {"calls": [{"request": "large"}]},
                 "ng_trajectory": {"model_calls": [{"request": "large"}]},
@@ -2747,6 +2750,7 @@ class TestRolloutCollection:
             assert "ng_model_call_capture" not in item
             assert "ng_trajectory" not in item
             assert "usage" in item["response"]
+        assert sent_data[0]["response"]["incomplete_details"] == {"reason": "max_output_tokens"}
 
     async def test_call_aggregate_metrics_includes_perf_summary_when_present(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## What does this PR do?

Keeps response.incomplete_details alongside token usage so benchmarks can treat cases such as max_output_tokens differently from other rollout failures.

## Checklist

- [X] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [X] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [X] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [X] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [X] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
