### PR TITLE
add option to not increment endpoint retry limit

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -1069,6 +1069,7 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
 
     base_url: str
     api_key: str
+    no_infinite_endpoint_retries: bool = False
 
     internal: bool = Field(
         default=False,
@@ -1108,7 +1109,7 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
 
             if response.status in RETRY_ERROR_CODES:
                 # If we hit a rate limit, we don't want to hit max num tries, so we increment both.
-                if response.status in RATE_LIMIT_ERROR_CODES:
+                if response.status in RATE_LIMIT_ERROR_CODES and not self.no_infinite_endpoint_retries:
                     max_num_tries += 1
 
                 content = (await response.content.read()).decode()

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -1069,11 +1069,10 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
 
     base_url: str
     api_key: str
-    no_infinite_endpoint_retries: bool = False
 
     internal: bool = Field(
         default=False,
-        description="Set this to true if this particular client is only used to call internal NeMo Gym servers.",
+        description="Set this to true for internal NeMo Gym servers, which may retry indefinitely.",
     )
 
     max_connection_retries: Optional[int] = Field(
@@ -1108,8 +1107,8 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
             response = await request(**request_kwargs)
 
             if response.status in RETRY_ERROR_CODES:
-                # If we hit a rate limit, we don't want to hit max num tries, so we increment both.
-                if response.status in RATE_LIMIT_ERROR_CODES and not self.no_infinite_endpoint_retries:
+                # Internal NeMo Gym servers extend max tries for retryable errors.
+                if response.status in RATE_LIMIT_ERROR_CODES and self.internal:
                     max_num_tries += 1
 
                 content = (await response.content.read()).decode()

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -153,8 +153,6 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     base_url: Union[str, List[str]]
     api_key: str
     model: str
-    # Do not increment max_num_tries for retryable endpoint errors.
-    no_infinite_endpoint_retries: bool = False
     return_token_id_information: bool
     # Request inline prompt and generation token IDs from compatible vLLM endpoints.
     request_prompt_and_generation_token_ids: bool = False
@@ -301,7 +299,6 @@ class VLLMModel(SimpleResponsesAPIModel):
             NeMoGymAsyncOpenAI(
                 base_url=base_url,
                 api_key=self.config.api_key,
-                no_infinite_endpoint_retries=self.config.no_infinite_endpoint_retries,
                 default_headers=self.config.default_headers,
                 max_connection_retries=(
                     self.config.endpoint_connection_retries if self.config.endpoint_file else None
@@ -1481,7 +1478,6 @@ class VLLMModel(SimpleResponsesAPIModel):
             NeMoGymAsyncOpenAI(
                 base_url=url,
                 api_key=self.config.api_key,
-                no_infinite_endpoint_retries=self.config.no_infinite_endpoint_retries,
                 default_headers=self.config.default_headers,
                 max_connection_retries=self.config.endpoint_connection_retries,
             )

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -153,6 +153,8 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     base_url: Union[str, List[str]]
     api_key: str
     model: str
+    # Do not increment max_num_tries for retryable endpoint errors.
+    no_infinite_endpoint_retries: bool = False
     return_token_id_information: bool
     # Request inline prompt and generation token IDs from compatible vLLM endpoints.
     request_prompt_and_generation_token_ids: bool = False
@@ -299,6 +301,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             NeMoGymAsyncOpenAI(
                 base_url=base_url,
                 api_key=self.config.api_key,
+                no_infinite_endpoint_retries=self.config.no_infinite_endpoint_retries,
                 default_headers=self.config.default_headers,
                 max_connection_retries=(
                     self.config.endpoint_connection_retries if self.config.endpoint_file else None
@@ -1478,6 +1481,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             NeMoGymAsyncOpenAI(
                 base_url=url,
                 api_key=self.config.api_key,
+                no_infinite_endpoint_retries=self.config.no_infinite_endpoint_retries,
                 default_headers=self.config.default_headers,
                 max_connection_retries=self.config.endpoint_connection_retries,
             )

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -27,6 +27,7 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+from unittest.mock import AsyncMock, MagicMock
 
 import openai
 import pytest
@@ -67,6 +68,7 @@ from openai.types.responses.response_output_item import (
 from pydantic import ValidationError
 
 from nemo_gym.openai_utils import (
+    MAX_NUM_TRIES,
     RESPONSES_TO_TRAIN,
     NeMoGymAsyncOpenAI,
     NeMoGymChatCompletion,
@@ -124,6 +126,24 @@ def _response_with_output(output: list) -> dict:
 class TestOpenAIUtils:
     async def test_NeMoGymAsyncOpenAI(self) -> None:
         NeMoGymAsyncOpenAI(api_key="abc", base_url="https://api.openai.com/v1")
+
+    async def test_no_infinite_endpoint_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        response = MagicMock(status=504)
+        response.content.read = AsyncMock(return_value=b"gateway timeout")
+        request = AsyncMock(return_value=response)
+        monkeypatch.setattr("nemo_gym.openai_utils.request", request)
+        monkeypatch.setattr("nemo_gym.openai_utils.sleep", AsyncMock())
+        monkeypatch.setattr(
+            "nemo_gym.openai_utils.raise_for_status", AsyncMock(side_effect=RuntimeError("gateway timeout"))
+        )
+
+        client = NeMoGymAsyncOpenAI(
+            api_key="abc", base_url="https://example.com/v1", no_infinite_endpoint_retries=True
+        )
+        with pytest.raises(RuntimeError, match="gateway timeout"):
+            await client._request_with_retry(method="POST", url="https://example.com/v1/chat/completions")
+
+        assert request.await_count == MAX_NUM_TRIES
 
 
 class TestNeMoGymResponseCreateParamsNonStreaming:

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
-from types import UnionType
+from types import SimpleNamespace, UnionType
 from typing import (
     Annotated,
     Any,
@@ -27,7 +27,7 @@ from typing import (
     get_origin,
     get_type_hints,
 )
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import openai
 import pytest
@@ -127,21 +127,16 @@ class TestOpenAIUtils:
     async def test_NeMoGymAsyncOpenAI(self) -> None:
         NeMoGymAsyncOpenAI(api_key="abc", base_url="https://api.openai.com/v1")
 
-    async def test_no_infinite_endpoint_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        response = MagicMock(status=504)
-        response.content.read = AsyncMock(return_value=b"gateway timeout")
-        request = AsyncMock(return_value=response)
+    async def test_external_endpoint_retries_are_bounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        response = SimpleNamespace(status=504, content=SimpleNamespace(read=AsyncMock(return_value=b"")))
+        request = AsyncMock(side_effect=[response] * MAX_NUM_TRIES + [SimpleNamespace(status=200)])
         monkeypatch.setattr("nemo_gym.openai_utils.request", request)
         monkeypatch.setattr("nemo_gym.openai_utils.sleep", AsyncMock())
-        monkeypatch.setattr(
-            "nemo_gym.openai_utils.raise_for_status", AsyncMock(side_effect=RuntimeError("gateway timeout"))
-        )
+        monkeypatch.setattr("nemo_gym.openai_utils.raise_for_status", AsyncMock(side_effect=RuntimeError))
 
-        client = NeMoGymAsyncOpenAI(
-            api_key="abc", base_url="https://example.com/v1", no_infinite_endpoint_retries=True
-        )
-        with pytest.raises(RuntimeError, match="gateway timeout"):
-            await client._request_with_retry(method="POST", url="https://example.com/v1/chat/completions")
+        client = NeMoGymAsyncOpenAI(api_key="abc", base_url="https://example.com/v1")
+        with pytest.raises(RuntimeError):
+            await client._request_with_retry()
 
         assert request.await_count == MAX_NUM_TRIES
 


### PR DESCRIPTION
## What does this PR do?

Adds a no_infinite_endpoint_retries option for vLLM endpoints. When enabled, retryable endpoint errors no longer increase max_num_tries, so requests fail after the fixed retry limit instead of retrying indefinitely.

## Checklist

- [X] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [X] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [X] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [X] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [X] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
