### PR TITLE
CCC Environment Compile Solutions Once Optimization

### DIFF
--- a/resources_servers/competitive_coding_challenges/README.md
+++ b/resources_servers/competitive_coding_challenges/README.md
@@ -24,14 +24,16 @@ competitive_coding_challenges
     num_parallel_requests: 16
     time_scale: 2.0
     shared_dir: ${oc.env:SHARED_TEMP_DIR,/tmp}
+    local_compile_dir: ${oc.env:LOCAL_COMPILE_DIR,null}
 ```
 
 You must set the following at runtime:
-- `export SHARED_TEMP_DIR=` local directory for code execution to store compilation files and share between ray instances and nodes
+- `export SHARED_TEMP_DIR=` shared directory for code-execution artifacts that must be visible to all Ray nodes
 - `export CCC_TEST_FILE=` path to metadata.jsonl file which contains data test cases and necessary execution artifacts
 
 and optionally can set to following:
 - `export CCC_LOG_JSONL_PATH=` set path to view generations and runtime/compilation information (ex: stderr, stdout)
+- `export LOCAL_COMPILE_DIR=` node-local directory where compilation is staged before completed artifacts are published to `SHARED_TEMP_DIR`
 - `test_batch_size` per problem test case parallelism
 - `num_parallel_requests` number of problems to evaluate in parallel
 - `time_scale` timeout limit factor, multiply's each problem's inherent time limit

--- a/resources_servers/competitive_coding_challenges/README.md
+++ b/resources_servers/competitive_coding_challenges/README.md
@@ -24,7 +24,7 @@ competitive_coding_challenges
     num_parallel_requests: 16
     time_scale: 2.0
     shared_dir: ${oc.env:SHARED_TEMP_DIR,/tmp}
-    local_compile_dir: ${oc.env:LOCAL_COMPILE_DIR,null}
+    local_compile_dir: ${oc.env:LOCAL_COMPILE_DIR,/tmp/nemo-gym-compile}
 ```
 
 You must set the following at runtime:
@@ -33,7 +33,8 @@ You must set the following at runtime:
 
 and optionally can set to following:
 - `export CCC_LOG_JSONL_PATH=` set path to view generations and runtime/compilation information (ex: stderr, stdout)
-- `export LOCAL_COMPILE_DIR=` node-local directory where compilation is staged before completed artifacts are published to `SHARED_TEMP_DIR`
+- `export LOCAL_COMPILE_DIR=` override the default `/tmp/nemo-gym-compile` staging directory before completed artifacts are published to `SHARED_TEMP_DIR`
+- `local_compile_dir: null` disable local compilation staging and compile directly in `SHARED_TEMP_DIR`
 - `test_batch_size` per problem test case parallelism
 - `num_parallel_requests` number of problems to evaluate in parallel
 - `time_scale` timeout limit factor, multiply's each problem's inherent time limit

--- a/resources_servers/competitive_coding_challenges/app.py
+++ b/resources_servers/competitive_coding_challenges/app.py
@@ -85,6 +85,7 @@ class CompetitiveCodingChallengesResourcesServerConfig(BaseResourcesServerConfig
     num_parallel_requests: int = 16
     time_scale: float = 2.0
     shared_dir: str = "/tmp"
+    local_compile_dir: Optional[str] = None
     reward_mode: Literal["binary", "fraction"] = "binary"
 
 
@@ -288,6 +289,7 @@ class CompetitiveCodingChallengesResourcesServer(SimpleResourcesServer):
                 "test_batch_size": self.config.test_batch_size,
                 "time_scale": self.config.time_scale,
                 "shared_dir": self.config.shared_dir,
+                "local_compile_dir": self.config.local_compile_dir,
                 "run_all_tests": self.config.reward_mode == "fraction",
             },
             num_parallel_requests=self.config.num_parallel_requests,

--- a/resources_servers/competitive_coding_challenges/app.py
+++ b/resources_servers/competitive_coding_challenges/app.py
@@ -85,7 +85,7 @@ class CompetitiveCodingChallengesResourcesServerConfig(BaseResourcesServerConfig
     num_parallel_requests: int = 16
     time_scale: float = 2.0
     shared_dir: str = "/tmp"
-    local_compile_dir: Optional[str] = None
+    local_compile_dir: Optional[str] = "/tmp/nemo-gym-compile"
     reward_mode: Literal["binary", "fraction"] = "binary"
 
 

--- a/resources_servers/competitive_coding_challenges/app.py
+++ b/resources_servers/competitive_coding_challenges/app.py
@@ -277,6 +277,12 @@ class CompetitiveCodingChallengesResourcesServer(SimpleResourcesServer):
     def setup_webserver(self) -> FastAPI:
         app = super().setup_webserver()
 
+        if os.path.abspath(self.config.shared_dir) == "/tmp":
+            LOG.warning(
+                "CCC shared_dir is /tmp. If the resources server and sandbox run in separate containers, "
+                "/tmp may not be visible to both. Set SHARED_TEMP_DIR to a path mounted into both containers."
+            )
+
         print(
             f"Initializing CompetitiveCodingChallenges evaluator with config: {self.config.model_dump_json(indent=2)}"
         )

--- a/resources_servers/competitive_coding_challenges/ccc_eval.py
+++ b/resources_servers/competitive_coding_challenges/ccc_eval.py
@@ -5,6 +5,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import threading
 import time
@@ -151,6 +152,7 @@ class CCCEvaluatorConfig(BaseEvaluatorConfig):
     time_scale: float = 2.0
     overwrite: bool = False
     shared_dir: str = "/tmp"
+    local_compile_dir: str | None = None
     run_all_tests: bool = False
 
 
@@ -173,6 +175,53 @@ def _get_thread_test_sandbox() -> LocalSandbox:
         sandbox = LocalSandbox()
         _test_sandbox_tls.sandbox = sandbox
     return sandbox
+
+
+def _compile_in_sandbox(
+    tls: threading.local,
+    sandbox: LocalSandbox,
+    work_dir: str,
+    local_compile_dir: str | None,
+    *,
+    timeout: int = 120,
+    ignore_failure: bool = False,
+) -> dict:
+    """Compile in node-local storage and publish the result to ``work_dir``.
+
+    ``work_dir`` remains on shared storage so a later sandbox request can run on
+    any node. When ``local_compile_dir`` is configured, the compiler only works
+    in a request-unique directory below that node-local root. The completed tree
+    is copied back once after compilation.
+    """
+    quoted_work_dir = shlex.quote(work_dir)
+    if not local_compile_dir:
+        command = f"cd {quoted_work_dir} && ./compile.sh"
+    else:
+        local_work_dir = os.path.join(local_compile_dir, os.path.basename(work_dir.rstrip(os.sep)))
+        quoted_local_work_dir = shlex.quote(local_work_dir)
+        command = f"""
+shared_work_dir={quoted_work_dir}
+local_work_dir={quoted_local_work_dir}
+cleanup_local_compile_dir() {{
+  rm -rf -- "$local_work_dir"
+}}
+trap cleanup_local_compile_dir EXIT
+mkdir -p -- "$local_work_dir"
+cp -a -- "$shared_work_dir"/. "$local_work_dir"/
+cd "$local_work_dir"
+compile_status=0
+./compile.sh || compile_status=$?
+publish_status=0
+cp -a -- "$local_work_dir"/. "$shared_work_dir"/ || publish_status=$?
+if [ "$publish_status" -ne 0 ]; then
+  exit "$publish_status"
+fi
+exit "$compile_status"
+""".strip()
+
+    if ignore_failure:
+        command = f"({command}) || true"
+    return _exec_sync(tls, sandbox, command, language="shell", timeout=timeout)
 
 
 def wait_for_sandbox(sandbox, timeout: int = 240, poll: float = 1.0):
@@ -343,6 +392,7 @@ def _precompile_problem(
     run_code: str,
     sandbox: LocalSandbox,
     shared_dir: str,
+    local_compile_dir: str | None,
 ) -> str:
     if getattr(sandbox, "_owner_tid", None) != threading.get_ident():
         sandbox = LocalSandbox()
@@ -366,48 +416,80 @@ def _precompile_problem(
             f.write(script_content)
         os.chmod(script_path, 0o755)
 
-    _exec_sync(_precompile_loop_tls, sandbox, f"cd {pre_dir} && ./compile.sh || true", language="shell", timeout=120)
+    _compile_in_sandbox(
+        _precompile_loop_tls,
+        sandbox,
+        pre_dir,
+        local_compile_dir,
+        timeout=120,
+        ignore_failure=True,
+    )
     return pre_dir
 
 
+def _test_result_from_compile(compile_result: dict) -> dict:
+    return {
+        "compile_success": not compile_result.get("stderr"),
+        "compile_stdout": compile_result.get("stdout", ""),
+        "compile_stderr": compile_result.get("stderr", ""),
+        "run_stdout": "",
+        "run_stderr": "",
+        "error": "",
+        "score": 0.0,
+    }
+
+
+def _compile_solution_once(
+    problem_id: str,
+    task_type: str,
+    generated_code: str,
+    precompiled_dir: str,
+    shared_dir: str,
+    local_compile_dir: str | None,
+) -> tuple[str, dict]:
+    """Compile one generated solution and publish a reusable shared artifact."""
+    solution_dir = f"{shared_dir}/ccc_solution_{os.getpid()}_{time.time_ns()}"
+    try:
+        os.makedirs(os.path.join(solution_dir, "graders"), exist_ok=True)
+        if precompiled_dir and os.path.isdir(precompiled_dir):
+            shutil.copytree(precompiled_dir, solution_dir, dirs_exist_ok=True)
+        if task_type == "SIMULATION":
+            with open(os.path.join(solution_dir, "solution.odo"), "w", encoding="utf-8") as f:
+                f.write(generated_code)
+        else:
+            with open(os.path.join(solution_dir, "graders", f"{problem_id}.cpp"), "w", encoding="utf-8") as f:
+                f.write(generated_code)
+
+        sandbox = _get_thread_test_sandbox()
+        compile_result = _compile_in_sandbox(
+            _test_loop_tls,
+            sandbox,
+            solution_dir,
+            local_compile_dir,
+            timeout=120,
+        )
+        return solution_dir, compile_result
+    except Exception:
+        shutil.rmtree(solution_dir, ignore_errors=True)
+        raise
+
+
 def run_test_case(task_args: dict, worker_id: int) -> dict:
+    result = _test_result_from_compile(task_args["compile_result"])
+    if not result["compile_success"]:
+        return result
+
     unique_dir = f"{task_args['shared_dir']}/ccc_run_{worker_id}_{os.getpid()}_{time.time_ns()}"
     try:
-        precompiled_dir = task_args.get("precompiled_dir")
-        os.makedirs(unique_dir, exist_ok=True)
-        os.makedirs(os.path.join(unique_dir, "graders"), exist_ok=True)
+        compiled_solution_dir = task_args["compiled_solution_dir"]
+        shutil.copytree(compiled_solution_dir, unique_dir)
         os.makedirs(os.path.join(unique_dir, "tmp"), exist_ok=True)
-        if precompiled_dir and os.path.isdir(precompiled_dir):
-            shutil.copytree(precompiled_dir, unique_dir, dirs_exist_ok=True)
-        if task_args.get("task_type") == "SIMULATION":
-            with open(os.path.join(unique_dir, "solution.odo"), "w", encoding="utf-8") as f:
-                f.write(task_args["generated_code"])
-        else:
-            with open(
-                os.path.join(unique_dir, "graders", f"{task_args['problem_id']}.cpp"), "w", encoding="utf-8"
-            ) as f:
-                f.write(task_args["generated_code"])
         with open(os.path.join(unique_dir, "input.txt"), "w", encoding="latin1") as f:
             f.write(task_args["test_input"])
         with open(os.path.join(unique_dir, "correct_output.txt"), "w", encoding="latin1") as f:
             f.write(task_args["test_output"])
 
         sandbox = _get_thread_test_sandbox()
-        compile_result = _exec_sync(
-            _test_loop_tls, sandbox, f"cd {unique_dir} && ./compile.sh", language="shell", timeout=120
-        )
-        result = {
-            "compile_success": not compile_result.get("stderr"),
-            "compile_stdout": compile_result.get("stdout", ""),
-            "compile_stderr": compile_result.get("stderr", ""),
-            "run_stdout": "",
-            "run_stderr": "",
-            "error": "",
-            "score": 0.0,
-        }
-        if not result["compile_success"]:
-            return result
-
         run_timeout = max(30, int(30 * float(task_args.get("time_scale", 1.0))))
         run_start = time.monotonic()
         run_result = _exec_sync(
@@ -556,18 +638,15 @@ class CCCEvaluator(BaseEvaluator):
             problem_metadata["run"],
             self.sandbox,
             self.eval_cfg.shared_dir,
+            self.eval_cfg.local_compile_dir,
         )
         self.precompiled_cache[cache_key] = {"grader": grader_dir}
         return grader_dir
 
-    def _build_test_task(
-        self, problem_id: str, pre_dir: str, completion: str, test_data: dict, task_type: str = "Batch"
-    ):
+    def _build_test_task(self, compiled_solution_dir: str, compile_result: dict, test_data: dict):
         return {
-            "generated_code": completion,
-            "task_type": task_type,
-            "problem_id": problem_id,
-            "precompiled_dir": pre_dir,
+            "compiled_solution_dir": compiled_solution_dir,
+            "compile_result": compile_result,
             "test_input": test_data["input"],
             "test_output": test_data["output"],
             "time_scale": self.eval_cfg.time_scale,
@@ -589,31 +668,14 @@ class CCCEvaluator(BaseEvaluator):
             return float(sum(1 for out in outputs if float(out.get("score", 0.0)) > 0.0))
         raise ValueError(f"Unsupported aggregation: {aggregation}")
 
-    async def _evaluate_entry(self, entry: dict) -> dict:
-        await self._initialize_runtime()
-
-        problem_id = entry.get("problem_id") or entry.get("ioi_id")
-        if not problem_id:
-            raise ValueError("Missing 'problem_id' field in entry")
-
-        competition_id = self._get_competition_id(entry)
-        problem_metadata = self.get_problem_metadata(problem_id, competition_id)
-        task_config = extract_task_config(problem_metadata)
-        task_type = str(task_config.get("task_type", "Batch"))
-        if task_type == "SIMULATION":
-            completion = extract_final_code_block((entry.get("generation") or ""), ("txt", "text", "plain"))
-        elif task_type == "MULTIFILE":
-            completion = extract_final_code_block((entry.get("generation") or ""), ("cpp",))
-        else:
-            completion = add_includes(
-                extract_final_code_block((entry.get("generation") or ""), ("cpp",)),
-                problem_metadata.get("problem_header_include"),
-                problem_id,
-            )
-        cache_key = self._cache_key(problem_id, competition_id)
-        pre_dir = await asyncio.to_thread(self._get_precompiled_dir, cache_key, problem_id, problem_metadata)
-        time_scale = self.eval_cfg.time_scale * (0.5 if float(entry.get("total_time") or 0.0) > 300.0 else 1.0)
-
+    async def _evaluate_compiled_solution(
+        self,
+        entry: dict,
+        problem_metadata: dict,
+        compiled_solution_dir: str,
+        compile_result: dict,
+        time_scale: float,
+    ) -> dict:
         subtask_state = {
             subtask_name: {
                 "aggregation": subtask_meta["aggregation"],
@@ -650,7 +712,7 @@ class CCCEvaluator(BaseEvaluator):
                 if not should_run:
                     continue
                 batch.append((test_name, test_data))
-                task = self._build_test_task(problem_id, pre_dir, completion, test_data, task_type=task_type)
+                task = self._build_test_task(compiled_solution_dir, compile_result, test_data)
                 task["time_scale"] = time_scale
                 tasks.append(task)
             if not batch:
@@ -690,6 +752,50 @@ class CCCEvaluator(BaseEvaluator):
             "total_test_execution_time_s": sum(all_run_times),
             "mean_test_execution_time_s": sum(all_run_times) / num_tests_run if num_tests_run else 0.0,
         }
+
+    async def _evaluate_entry(self, entry: dict) -> dict:
+        await self._initialize_runtime()
+
+        problem_id = entry.get("problem_id") or entry.get("ioi_id")
+        if not problem_id:
+            raise ValueError("Missing 'problem_id' field in entry")
+
+        competition_id = self._get_competition_id(entry)
+        problem_metadata = self.get_problem_metadata(problem_id, competition_id)
+        task_config = extract_task_config(problem_metadata)
+        task_type = str(task_config.get("task_type", "Batch"))
+        if task_type == "SIMULATION":
+            completion = extract_final_code_block((entry.get("generation") or ""), ("txt", "text", "plain"))
+        elif task_type == "MULTIFILE":
+            completion = extract_final_code_block((entry.get("generation") or ""), ("cpp",))
+        else:
+            completion = add_includes(
+                extract_final_code_block((entry.get("generation") or ""), ("cpp",)),
+                problem_metadata.get("problem_header_include"),
+                problem_id,
+            )
+        cache_key = self._cache_key(problem_id, competition_id)
+        pre_dir = await asyncio.to_thread(self._get_precompiled_dir, cache_key, problem_id, problem_metadata)
+        time_scale = self.eval_cfg.time_scale * (0.5 if float(entry.get("total_time") or 0.0) > 300.0 else 1.0)
+        compiled_solution_dir, compile_result = await asyncio.to_thread(
+            _compile_solution_once,
+            problem_id,
+            task_type,
+            completion,
+            pre_dir,
+            self.eval_cfg.shared_dir,
+            self.eval_cfg.local_compile_dir,
+        )
+        try:
+            return await self._evaluate_compiled_solution(
+                entry,
+                problem_metadata,
+                compiled_solution_dir,
+                compile_result,
+                time_scale,
+            )
+        finally:
+            shutil.rmtree(compiled_solution_dir, ignore_errors=True)
 
     async def eval_full(self, input_files):  # type: ignore[override]
         await self._initialize_runtime()

--- a/resources_servers/competitive_coding_challenges/ccc_eval.py
+++ b/resources_servers/competitive_coding_challenges/ccc_eval.py
@@ -12,6 +12,7 @@ import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, is_dataclass
+from uuid import uuid4
 
 import httpx
 
@@ -448,7 +449,7 @@ def _compile_solution_once(
     local_compile_dir: str | None,
 ) -> tuple[str, dict]:
     """Compile one generated solution and publish a reusable shared artifact."""
-    solution_dir = f"{shared_dir}/ccc_solution_{os.getpid()}_{time.time_ns()}"
+    solution_dir = f"{shared_dir}/ccc_solution_{uuid4().hex}"
     try:
         os.makedirs(os.path.join(solution_dir, "graders"), exist_ok=True)
         if precompiled_dir and os.path.isdir(precompiled_dir):

--- a/resources_servers/competitive_coding_challenges/ccc_eval.py
+++ b/resources_servers/competitive_coding_challenges/ccc_eval.py
@@ -207,12 +207,12 @@ cleanup_local_compile_dir() {{
 }}
 trap cleanup_local_compile_dir EXIT
 mkdir -p -- "$local_work_dir"
-cp -a -- "$shared_work_dir"/. "$local_work_dir"/
+cp -R -- "$shared_work_dir"/. "$local_work_dir"/
 cd "$local_work_dir"
 compile_status=0
 ./compile.sh || compile_status=$?
 publish_status=0
-cp -a -- "$local_work_dir"/. "$shared_work_dir"/ || publish_status=$?
+cp -R -- "$local_work_dir"/. "$shared_work_dir"/ || publish_status=$?
 if [ "$publish_status" -ne 0 ]; then
   exit "$publish_status"
 fi
@@ -429,7 +429,7 @@ def _precompile_problem(
 
 def _test_result_from_compile(compile_result: dict) -> dict:
     return {
-        "compile_success": not compile_result.get("stderr"),
+        "compile_success": compile_result.get("process_status") == "completed",
         "compile_stdout": compile_result.get("stdout", ""),
         "compile_stderr": compile_result.get("stderr", ""),
         "run_stdout": "",

--- a/resources_servers/competitive_coding_challenges/ccc_eval.py
+++ b/resources_servers/competitive_coding_challenges/ccc_eval.py
@@ -152,7 +152,7 @@ class CCCEvaluatorConfig(BaseEvaluatorConfig):
     time_scale: float = 2.0
     overwrite: bool = False
     shared_dir: str = "/tmp"
-    local_compile_dir: str | None = None
+    local_compile_dir: str | None = "/tmp/nemo-gym-compile"
     run_all_tests: bool = False
 
 

--- a/resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml
+++ b/resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml
@@ -10,6 +10,7 @@ competitive_coding_challenges_resources_server:
       num_parallel_requests: 16
       time_scale: 2.0
       shared_dir: ${oc.env:SHARED_TEMP_DIR,/tmp}
+      local_compile_dir: ${oc.env:LOCAL_COMPILE_DIR,null}
       reward_mode: binary
       verified: false
 competitive_coding_challenges_simple_agent:

--- a/resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml
+++ b/resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml
@@ -10,7 +10,7 @@ competitive_coding_challenges_resources_server:
       num_parallel_requests: 16
       time_scale: 2.0
       shared_dir: ${oc.env:SHARED_TEMP_DIR,/tmp}
-      local_compile_dir: ${oc.env:LOCAL_COMPILE_DIR,null}
+      local_compile_dir: ${oc.env:LOCAL_COMPILE_DIR,/tmp/nemo-gym-compile}
       reward_mode: binary
       verified: false
 competitive_coding_challenges_simple_agent:

--- a/resources_servers/competitive_coding_challenges/tests/test_app.py
+++ b/resources_servers/competitive_coding_challenges/tests/test_app.py
@@ -125,6 +125,7 @@ def test_setup_webserver_initializes_evaluator(server: CompetitiveCodingChalleng
             "test_batch_size": server.config.test_batch_size,
             "time_scale": server.config.time_scale,
             "shared_dir": server.config.shared_dir,
+            "local_compile_dir": server.config.local_compile_dir,
             "run_all_tests": False,
         },
         num_parallel_requests=server.config.num_parallel_requests,

--- a/resources_servers/competitive_coding_challenges/tests/test_app.py
+++ b/resources_servers/competitive_coding_challenges/tests/test_app.py
@@ -113,6 +113,7 @@ def server() -> CompetitiveCodingChallengesResourcesServer:
 
 def test_sanity(server: CompetitiveCodingChallengesResourcesServer) -> None:
     assert server.config.name == "competitive_coding_challenges"
+    assert server.config.local_compile_dir == "/tmp/nemo-gym-compile"
 
 
 def test_setup_webserver_initializes_evaluator(server: CompetitiveCodingChallengesResourcesServer) -> None:
@@ -132,6 +133,14 @@ def test_setup_webserver_initializes_evaluator(server: CompetitiveCodingChalleng
     )
     assert app is not None
     assert server._evaluator is evaluator_cls.return_value
+
+
+def test_setup_webserver_allows_disabling_local_compile_staging() -> None:
+    server = _make_server(local_compile_dir=None)
+    with patch("resources_servers.competitive_coding_challenges.app.CCCEvaluator") as evaluator_cls:
+        server.setup_webserver()
+
+    assert evaluator_cls.call_args.kwargs["config"]["local_compile_dir"] is None
 
 
 @pytest.mark.asyncio

--- a/resources_servers/competitive_coding_challenges/tests/test_app.py
+++ b/resources_servers/competitive_coding_challenges/tests/test_app.py
@@ -135,6 +135,19 @@ def test_setup_webserver_initializes_evaluator(server: CompetitiveCodingChalleng
     assert server._evaluator is evaluator_cls.return_value
 
 
+def test_setup_webserver_warns_when_shared_dir_is_tmp(
+    server: CompetitiveCodingChallengesResourcesServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    with (
+        caplog.at_level("WARNING", logger="resources_servers.competitive_coding_challenges.app"),
+        patch("resources_servers.competitive_coding_challenges.app.CCCEvaluator"),
+    ):
+        server.setup_webserver()
+
+    assert "CCC shared_dir is /tmp" in caplog.text
+    assert "Set SHARED_TEMP_DIR to a path mounted into both containers" in caplog.text
+
+
 def test_setup_webserver_allows_disabling_local_compile_staging() -> None:
     server = _make_server(local_compile_dir=None)
     with patch("resources_servers.competitive_coding_challenges.app.CCCEvaluator") as evaluator_cls:

--- a/resources_servers/competitive_coding_challenges/tests/test_ccc_eval.py
+++ b/resources_servers/competitive_coding_challenges/tests/test_ccc_eval.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from resources_servers.competitive_coding_challenges import ccc_eval
+
+
+def _execute_shell(_tls, _sandbox, command, *, language, timeout):
+    assert language == "shell"
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    return {
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "returncode": completed.returncode,
+    }
+
+
+def _write_compile_script(work_dir, artifact_text):
+    script = work_dir / "compile.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        "pwd > compile_pwd.txt\n"
+        "printf 'compile\\n' >> compile_invocations.txt\n"
+        "cat > compiled_artifact <<'EOF'\n"
+        "#!/bin/bash\n"
+        f"printf '%s\\n' {artifact_text!r}\n"
+        "EOF\n"
+        "chmod +x compiled_artifact\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
+def test_compile_stages_on_local_storage_and_publishes_artifacts(monkeypatch, tmp_path):
+    shared_work_dir = tmp_path / "shared" / "ccc_run_1"
+    shared_work_dir.mkdir(parents=True)
+    _write_compile_script(shared_work_dir, "compiled locally")
+    local_compile_dir = tmp_path / "local"
+    monkeypatch.setattr(ccc_eval, "_exec_sync", _execute_shell)
+
+    result = ccc_eval._compile_in_sandbox(
+        object(),
+        object(),
+        str(shared_work_dir),
+        str(local_compile_dir),
+    )
+
+    assert result["returncode"] == 0
+    published_artifact = subprocess.run(
+        [shared_work_dir / "compiled_artifact"], capture_output=True, text=True, check=True
+    )
+    assert published_artifact.stdout == "compiled locally\n"
+    compile_pwd = (shared_work_dir / "compile_pwd.txt").read_text().strip()
+    assert compile_pwd == str(local_compile_dir / shared_work_dir.name)
+    assert not (local_compile_dir / shared_work_dir.name).exists()
+
+
+def test_compile_without_local_storage_preserves_shared_behavior(monkeypatch, tmp_path):
+    shared_work_dir = tmp_path / "shared" / "ccc_run_2"
+    shared_work_dir.mkdir(parents=True)
+    _write_compile_script(shared_work_dir, "compiled shared")
+    monkeypatch.setattr(ccc_eval, "_exec_sync", _execute_shell)
+
+    result = ccc_eval._compile_in_sandbox(object(), object(), str(shared_work_dir), None)
+
+    assert result["returncode"] == 0
+    published_artifact = subprocess.run(
+        [shared_work_dir / "compiled_artifact"], capture_output=True, text=True, check=True
+    )
+    assert published_artifact.stdout == "compiled shared\n"
+    assert (shared_work_dir / "compile_pwd.txt").read_text().strip() == str(shared_work_dir)
+
+
+def test_compiled_solution_is_reused_without_recompiling_per_test(monkeypatch, tmp_path):
+    shared_dir = tmp_path / "shared"
+    precompiled_dir = shared_dir / "ccc_pre_toy"
+    (precompiled_dir / "graders").mkdir(parents=True)
+    _write_compile_script(precompiled_dir, "reusable artifact")
+    run_script = precompiled_dir / "run.sh"
+    run_script.write_text(
+        "#!/bin/bash\ntest -x ./compiled_artifact\n./compiled_artifact >/dev/null\nprintf '1\\n'\n",
+        encoding="utf-8",
+    )
+    run_script.chmod(0o755)
+    monkeypatch.setattr(ccc_eval, "_exec_sync", _execute_shell)
+
+    compiled_solution_dir, compile_result = ccc_eval._compile_solution_once(
+        "toy",
+        "Batch",
+        "int solve() { return 0; }\n",
+        str(precompiled_dir),
+        str(shared_dir),
+        str(tmp_path / "local"),
+    )
+    compiled_solution_path = Path(compiled_solution_dir)
+
+    task = {
+        "compiled_solution_dir": compiled_solution_dir,
+        "compile_result": compile_result,
+        "test_input": "input one\n",
+        "test_output": "output one\n",
+        "time_scale": 1.0,
+        "shared_dir": str(shared_dir),
+    }
+    first_result = ccc_eval.run_test_case(task, worker_id=0)
+    task["test_input"] = "input two\n"
+    task["test_output"] = "output two\n"
+    second_result = ccc_eval.run_test_case(task, worker_id=1)
+
+    assert first_result["compile_success"] is True
+    assert first_result["score"] == 1.0
+    assert second_result["compile_success"] is True
+    assert second_result["score"] == 1.0
+    assert (tmp_path / "local").exists()
+    assert (compiled_solution_path / "compile_invocations.txt").read_text(encoding="utf-8") == "compile\n"
+    assert list(shared_dir.glob("ccc_run_*")) == []
+    shutil.rmtree(compiled_solution_path)
+
+
+def test_compile_failure_skips_test_staging_and_sandbox_execution(monkeypatch, tmp_path):
+    def fail_if_called():
+        raise AssertionError("sandbox must not be called after a compile failure")
+
+    monkeypatch.setattr(ccc_eval, "_get_thread_test_sandbox", fail_if_called)
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    result = ccc_eval.run_test_case(
+        {
+            "compiled_solution_dir": str(shared_dir / "missing"),
+            "compile_result": {"stdout": "", "stderr": "compile failed"},
+            "test_input": "",
+            "test_output": "",
+            "time_scale": 1.0,
+            "shared_dir": str(shared_dir),
+        },
+        worker_id=0,
+    )
+
+    assert result["compile_success"] is False
+    assert result["compile_stderr"] == "compile failed"
+    assert list(shared_dir.glob("ccc_run_*")) == []

--- a/resources_servers/competitive_coding_challenges/tests/test_ccc_eval.py
+++ b/resources_servers/competitive_coding_challenges/tests/test_ccc_eval.py
@@ -30,6 +30,7 @@ def _execute_shell(_tls, _sandbox, command, *, language, timeout):
         check=False,
     )
     return {
+        "process_status": "completed" if completed.returncode == 0 else "error",
         "stdout": completed.stdout,
         "stderr": completed.stderr,
         "returncode": completed.returncode,
@@ -92,6 +93,31 @@ def test_compile_without_local_storage_preserves_shared_behavior(monkeypatch, tm
     assert (shared_work_dir / "compile_pwd.txt").read_text().strip() == str(shared_work_dir)
 
 
+def test_compile_success_uses_process_status_when_stderr_has_warnings():
+    result = ccc_eval._test_result_from_compile(
+        {
+            "process_status": "completed",
+            "stdout": "",
+            "stderr": "compiler warning\n",
+        }
+    )
+
+    assert result["compile_success"] is True
+    assert result["compile_stderr"] == "compiler warning\n"
+
+
+def test_compile_failure_uses_process_status_when_stderr_is_empty():
+    result = ccc_eval._test_result_from_compile(
+        {
+            "process_status": "error",
+            "stdout": "",
+            "stderr": "",
+        }
+    )
+
+    assert result["compile_success"] is False
+
+
 def test_compiled_solution_is_reused_without_recompiling_per_test(monkeypatch, tmp_path):
     shared_dir = tmp_path / "shared"
     precompiled_dir = shared_dir / "ccc_pre_toy"
@@ -148,7 +174,7 @@ def test_compile_failure_skips_test_staging_and_sandbox_execution(monkeypatch, t
     result = ccc_eval.run_test_case(
         {
             "compiled_solution_dir": str(shared_dir / "missing"),
-            "compile_result": {"stdout": "", "stderr": "compile failed"},
+            "compile_result": {"process_status": "error", "stdout": "", "stderr": "compile failed"},
             "test_input": "",
             "test_output": "",
             "time_scale": 1.0,


### PR DESCRIPTION
## What does this PR do?

Previously, the same generated solution was compiled independently for every test case. At high rollout concurrency, this creates redundant compiler work and metadata-heavy temporary-file traffic on shared filesystems.

This change reduces compilation to once per solution and allows compiler I/O to occur on node-local storage while retaining distributed test execution and per-test isolation. Additionally, I add warning logs for when `SHARED_TEMP_DIR` is not set to help with debugging.

## Summary

- Compile each generated solution once and reuse the compiled artifact across its test cases.
- Add optional `local_compile_dir` / `LOCAL_COMPILE_DIR` support for staging compilation on node-local storage (defaults to `tmp`).
- Existing shared-storage behavior can be specified with `LOCAL_COMPILE_DIR` set to null.
- Added warning logs for when `SHARED_TEMP_DIR` is not set to help with debugging.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).