### PR TITLE
docs: fix r0.6.0 documentation inconsistencies

### DIFF
--- a/fern/versions/latest/pages/evaluation/benchmarks.mdx
+++ b/fern/versions/latest/pages/evaluation/benchmarks.mdx
@@ -14,7 +14,7 @@ All environments can be used for training. A benchmark is the evaluation-configu
 
 ## How Benchmarks Relate to Environments
 
-The same resources server powers both. For example, `math_with_judge` is used for RL training via the `code_gen` environment **and** as the verifier for benchmarks like `aime24`, `aime25`, and `gsm8k`. The benchmark config chains to the resources server via `config_paths` and adds a `type: benchmark` dataset with its own `prepare_script` and `num_repeats`.
+The same resources server powers both. For example, `resources_servers/math_with_judge/configs/math_with_judge.yaml` provides the OpenMathReasoning training dataset **and** uses `math_with_judge` as the verifier for benchmarks like `aime24`, `aime25`, and `gsm8k`. The benchmark config chains to the resources server via `config_paths` and adds a `type: benchmark` dataset with its own `prepare_script` and `num_repeats`.
 
 ```yaml
 # benchmarks/aime24/config.yaml

--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -54,7 +54,7 @@ docker run --gpus all -it --rm \
   -p 6006:6006 \
   --ulimit memlock=-1 \
   --ulimit stack=67108864 \
-  nvcr.io/nvidian/nemo-gym:v0.5.1
+  nvcr.io/nvidia/nemo-gym:v0.5.1
 ```
 
 The image's default entrypoint is `gym`, so it drops you straight into the CLI. To get a shell instead, override the entrypoint:
@@ -69,7 +69,7 @@ docker run --gpus all -it --rm \
   -p 6006:6006 \
   --ulimit memlock=-1 \
   --ulimit stack=67108864 \
-  nvcr.io/nvidian/nemo-gym:v0.5.1
+  nvcr.io/nvidia/nemo-gym:v0.5.1
 ```
 
 <Note>

--- a/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
@@ -9,13 +9,13 @@ Reference for NeMo Gym version compatibility with supported training frameworks.
 
 ## NeMo RL Container
 
-The following table maps NeMo Gym versions to compatible NeMo RL containers for each model recipe. Use the latest version when possible; the table provides historical compatibility for users who cannot upgrade.
+The following table shows which NeMo Gym version each published NeMo RL container bundles and the model recipe that container supports. NeMo Gym and NeMo RL release independently, so not every NeMo Gym version has a matching NeMo RL image.
 
 **Single source of truth:** When a tutorial or install page needs a container, use the value from this table for the relevant Gym version and recipe. Do not hard-code a different tag elsewhere without a comment pointing back here.
 
 **v0.3.0 exception:** NeMo Gym v0.3.0 paired with Nemotron 3 Ultra has no pre-built NGC container that packaged Gym, so this row references the `ultra-v3` Dockerfile. That is a one-off.
 
-**v0.4.0 and later:** NeMo RL plans to publish an NGC container for every Gym release. New rows should use NGC tags; Dockerfile references should not be added unless the same gap recurs.
+The latest published pairing is NeMo RL v0.7.0 with NeMo Gym v0.4.0.
 
 Match the container to your **model recipe**, not only your NeMo Gym version. For example, the [NeMo RL GRPO](/tutorials/training-tutorials/nemo-rl-grpo) tutorial trains Nemotron Nano 9B v2 and uses the Nano NGC container from the v0.1.1 row below—not the v0.3.0 Ultra Dockerfile.
 
@@ -27,8 +27,7 @@ Match the container to your **model recipe**, not only your NeMo Gym version. Fo
 | v0.1.1 | [`nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.4.0) | [Nemotron 3 Nano](/model-recipes/nemotron-3-nano) |
 
 <Note>
-[NeMo RL GRPO](/tutorials/training-tutorials/nemo-rl-grpo) for the NeMo RL training tutorial.
-
+For end-to-end setup and training instructions, see the [NeMo RL GRPO tutorial](/tutorials/training-tutorials/nemo-rl-grpo).
 </Note>
 
 ---
@@ -38,8 +37,7 @@ Match the container to your **model recipe**, not only your NeMo Gym version. Fo
 The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsloth_zoo==2026.1.4`. Other versions are not guaranteed to work.
 
 <Note>
-[Unsloth](/tutorials/training-tutorials/unsloth) for the Unsloth training tutorial.
-
+For setup and training instructions, see the [Unsloth tutorial](/tutorials/training-tutorials/unsloth).
 </Note>
 
 ---
@@ -49,6 +47,5 @@ The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsl
 NeMo Gym 0.2.1+ is compatible with verl pinned to the commit in [`REQUIRED_VERL.txt`](https://github.com/verl-project/verl-recipe/blob/main/nemo_gym/REQUIRED_VERL.txt), tested on the `verlai/verl:vllm017.latest` container (vLLM 0.17.0). Other versions are not guaranteed to work.
 
 <Note>
-[Training with VeRL](/tutorials/training-tutorials/verl) for the verl training tutorial.
-
+For setup and training instructions, see the [Training with VeRL tutorial](/tutorials/training-tutorials/verl).
 </Note>

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx
@@ -35,7 +35,7 @@ Make sure you have these prerequisites ready:
   - Multi-node production: 8+ nodes with 8 GPUs each recommended
   - RAM: 64 GB+ per node
 - ✅ **Storage**: 100 GB+ free disk space on a shared filesystem
-- ✅ **Software**: Linux, Python 3.12+, Git, Slurm for multi-node training
+- ✅ **Software**: Linux, Python 3.13.14+, Git, Slurm for multi-node training
 - ✅ **Familiarity**: Python, LLM fine-tuning, basic RL concepts (in-depth RLVR/GRPO knowledge not required)
 
 <Note>


### PR DESCRIPTION
## Summary

- Align the remaining NeMo RL GRPO prerequisite with the Python 3.13.14 minimum.
- Document that released NeMo RL containers do not bundle NeMo Gym v0.5.x, preserve the latest supported pairing, and complete the framework tutorial notes.
- Correct the `math_with_judge` training example and the standalone NeMo Gym container path.