### PR TITLE
score reasoning only but completed responses as zero for lmarena_v3

### DIFF
--- a/resources_servers/arena/metrics.py
+++ b/resources_servers/arena/metrics.py
@@ -128,19 +128,24 @@ class ArenaMetrics:
 
                 # Only complete, parsed judge pairs contribute to either win rate.
                 total_rollouts += 1
-                reasoning_only_response_rollouts += int(bool(reasoning) and not response)
+                reasoning_only = bool(reasoning) and not response
+                reasoning_only_response_rollouts += int(reasoning_only)
                 incomplete_reason = ((rollout.get("response") or {}).get("incomplete_details") or {}).get("reason")
-                if self.config.style_control_method == "reference_length" and incomplete_reason == "max_output_tokens":
-                    # Context-window rejections have no usage because generation never started.
-                    if (rollout.get("response") or {}).get("usage") is None:
-                        context_window_exceeded_rollouts += 1
-                    else:
-                        max_token_reached_rollouts += 1
+                if self.config.style_control_method == "reference_length" and (
+                    incomplete_reason == "max_output_tokens" or (incomplete_reason is None and reasoning_only)
+                ):
+                    if incomplete_reason == "max_output_tokens":
+                        # Context-window rejections have no usage because generation never started.
+                        if (rollout.get("response") or {}).get("usage") is None:
+                            context_window_exceeded_rollouts += 1
+                        else:
+                            max_token_reached_rollouts += 1
                     category = rollout.get("category")
                     if not category:
                         raise ValueError("category is required for scoring")
 
-                    # A response that reaches the generation limit is a zero, not an infrastructure failure.
+                    # These unjudged v3 rollouts (generation limit or reasoning only) score zero
+                    # and do not count as rollout failures.
                     scores = np.zeros(2)
                     scores_by_category[category].append(scores)
                     if rollout.get("is_lmarena_v2_prompt"):

--- a/resources_servers/arena/tests/test_app.py
+++ b/resources_servers/arena/tests/test_app.py
@@ -1278,7 +1278,7 @@ class TestArenaResourcesServer:
         assert metrics["win_rate"] == approx(0.5, abs=0.05)
         assert metrics["verbosity_acceptance_rate"] == approx(0.5)
 
-    def test_compute_metrics_v3_max_token_response_scores_zero(self, config: ArenaResourcesServerConfig):
+    def test_compute_metrics_v3_unjudged_model_outputs_score_zero(self, config: ArenaResourcesServerConfig):
         config.style_control_method = "reference_length"
         config.style_length_ratio_range = (0.5, 1.75)
         config.style_short_reference_max_tokens = 100
@@ -1306,16 +1306,22 @@ class TestArenaResourcesServer:
         context_exceeded = truncated | {
             "response": {"incomplete_details": {"reason": "max_output_tokens"}, "usage": None}
         }
+        reasoning_only = truncated | {
+            "response": {"status": "completed"},
+            "policy_answer": None,
+            "policy_reasoning": "Reasoning without a final answer",
+        }
 
-        metrics = reference_server.compute_metrics([[win], [truncated], [context_exceeded]])
+        metrics = reference_server.compute_metrics([[win], [truncated], [context_exceeded], [reasoning_only]])
 
-        assert metrics["max_token_reached_rate"] == approx(1 / 3)
-        assert metrics["context_window_exceeded_rate"] == approx(1 / 3)
+        assert metrics["max_token_reached_rate"] == approx(1 / 4)
+        assert metrics["context_window_exceeded_rate"] == approx(1 / 4)
         assert metrics["rollout_failure_rate"] == approx(0.0)
+        assert metrics["reasoning_only_response_rate"] == approx(1 / 4)
         assert metrics["missing_judgment_rate"] == approx(0.0)
-        assert metrics["win_rate_no_SC"] == approx(1 / 3, abs=0.05)
-        assert metrics["win_rate"] == approx(1 / 3, abs=0.05)
-        assert metrics["verbosity_acceptance_rate"] == approx(1 / 3)
+        assert metrics["win_rate_no_SC"] == approx(1 / 4, abs=0.05)
+        assert metrics["win_rate"] == approx(1 / 4, abs=0.05)
+        assert metrics["verbosity_acceptance_rate"] == approx(1 / 4)
 
     def test_compute_metrics_v2_max_token_response_remains_failure(self, server: ArenaResourcesServer):
         server.config.max_rollout_failure_rate = 1.0


### PR DESCRIPTION
## What does this PR do?

score rollouts with policy responses marked as completed but containing only reasoning content as zero, instead of treating them as failures and excluding them from lmarena_v3 score calculation

## Checklist

- [X] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [X] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [X] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [X] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [X] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
