### PR TITLE
fix(conversational_tool_use_simulation): nested server setup

### DIFF
--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -415,6 +415,8 @@ class RunHelper:  # pragma: no cover
             server_rel_path = Path(first_key, second_key)
             dir_path = _resolve_server_dir(server_rel_path)
 
+            # TODO: Move the conversational tool use simulation server to Gym's standard two-level
+            # ``<server_type>/<server_name>`` hierarchy, then remove this variable-depth path handling.
             # Child apps may import through their top-level component package (for example,
             # ``responses_api_agents.conversational_tool_use``). Derive the component root from
             # the full relative path rather than assuming every server is exactly two levels deep.

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -412,14 +412,22 @@ class RunHelper:  # pragma: no cover
             assert not entrypoint_fpath.is_absolute()
 
             # Resolve cwd-first (a local server), else the install location for built-ins.
-            dir_path = _resolve_server_dir(Path(first_key, second_key))
+            server_rel_path = Path(first_key, second_key)
+            dir_path = _resolve_server_dir(server_rel_path)
+
+            # Child apps may import through their top-level component package (for example,
+            # ``responses_api_agents.conversational_tool_use``). Derive the component root from
+            # the full relative path rather than assuming every server is exactly two levels deep.
+            project_root = dir_path
+            for _ in server_rel_path.parts:
+                project_root = project_root.parent
 
             command = f"""{setup_env_command(dir_path, global_config_dict, top_level_path)} \\
     && {NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME}={escaped_config_dict_yaml_str} \\
     {NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME}={shlex.quote(top_level_path)} \\
     python {str(entrypoint_fpath)}"""
 
-            process = run_command(command, dir_path, server_name=top_level_path)
+            process = run_command(command, dir_path, server_name=top_level_path, project_root=project_root)
             self._processes[top_level_path] = process
             # In dry run mode, wait for each setup command to finish before starting the next.
             # This installs uv virtual environments serially, which significantly reduces uv

--- a/nemo_gym/cli/setup_command.py
+++ b/nemo_gym/cli/setup_command.py
@@ -129,7 +129,15 @@ def setup_env_command(dir_path: Path, global_config_dict: DictConfig, prefix: st
 
     verbose_flag = "-v " if global_config_dict.get(PIP_INSTALL_VERBOSE_KEY_NAME) else ""
 
-    is_editable_install = (dir_path.resolve() / "../../pyproject.toml").exists()
+    resolved_dir_path = dir_path.resolve()
+    gym_source_root = PARENT_DIR.resolve()
+    # Most server directories are ``<server_type>/<name>``, but some built-ins (for example,
+    # conversational_tool_use/simulation) are nested more deeply.  Keep the historical two-level
+    # check for external projects, and also recognize any server contained in this editable Gym
+    # checkout so its requirements can install the local source instead of the PyPI package.
+    is_editable_install = (resolved_dir_path / "../../pyproject.toml").exists() or (
+        (gym_source_root / "pyproject.toml").exists() and resolved_dir_path.is_relative_to(gym_source_root)
+    )
 
     if should_skip_venv_setup:
         env_setup_cmd = f"source {venv_activate_fpath}"
@@ -165,7 +173,7 @@ def setup_env_command(dir_path: Path, global_config_dict: DictConfig, prefix: st
                 install_flags = _get_nemo_gym_install_flags()
                 version_spec = _get_nemo_gym_version_spec(is_editable_install)
                 install_cmd = (
-                    f"""(echo 'nemo-gym{version_spec}' && grep -v -F '../..' requirements.txt) | """
+                    f"""(echo 'nemo-gym{version_spec}' && (grep -v -F '../..' requirements.txt || [ $? -eq 1 ])) | """
                     f"""uv pip install {verbose_flag}{uv_pip_python_flag}{install_flags}{override_flag}-r /dev/stdin {" ".join(head_server_deps)}"""
                 )
         else:

--- a/nemo_gym/cli/setup_command.py
+++ b/nemo_gym/cli/setup_command.py
@@ -131,6 +131,8 @@ def setup_env_command(dir_path: Path, global_config_dict: DictConfig, prefix: st
 
     resolved_dir_path = dir_path.resolve()
     gym_source_root = PARENT_DIR.resolve()
+    # TODO: Move the conversational tool use simulation server to Gym's standard two-level
+    # ``<server_type>/<server_name>`` hierarchy, then remove this editable-checkout fallback.
     # Most server directories are ``<server_type>/<name>``, but some built-ins (for example,
     # conversational_tool_use/simulation) are nested more deeply.  Keep the historical two-level
     # check for external projects, and also recognize any server contained in this editable Gym

--- a/tests/unit_tests/test_cli_setup_command.py
+++ b/tests/unit_tests/test_cli_setup_command.py
@@ -220,7 +220,7 @@ class TestCLISetupCommandSetupEnvCommand:
                 global_config_dict=self._debug_global_config_dict(tmp_path),
                 prefix="my server name",
             )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && (echo 'nemo-gym=={version}' && grep -v -F '../..' requirements.txt) | uv pip install -r /dev/stdin ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && (echo 'nemo-gym=={version}' && (grep -v -F '../..' requirements.txt || [ $? -eq 1 ])) | uv pip install -r /dev/stdin ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
         assert expected_command == actual_command
 
     @pytest.mark.parametrize("version", ["0.3.0", "0.3.0rc0", "1.0.0", "2.1.3rc1"])


### PR DESCRIPTION
Fix conversational_tool_use_agent, specifically its nested server:

```
responses_api_agents/conversational_tool_use/simulation
```

The old setup logic assumed servers were exactly two directories deep, causing incorrect project-root/`PYTHONPATH` and editable-install detection for this environment.