### PR TITLE
feat(opensandbox): add connection.tls_verify (default off) to the OpenSandbox provider

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -80,7 +80,7 @@ The provider constructor accepts four optional config sections:
 
 | Section | Purpose |
 | --- | --- |
-| `connection` | OpenSandbox SDK connection settings: domain, API key, protocol, request timeout, and server proxy mode. |
+| `connection` | OpenSandbox SDK connection settings: domain, API key, protocol, request timeout, server proxy mode, and `tls_verify`. |
 | `create` | Sandbox create timeout, retry, image pull policy, and health-check behavior. |
 | `probe` | Post-create command probe used to verify command execution before the sandbox is returned. |
 | `operations` | Retry and timeout behavior for SDK operations after create, including command retries, close timeout, background command polling, and the dedicated `status_poll_timeout_s` budget for background status polls. |
@@ -245,3 +245,5 @@ The provider's `create.image_pull_policy` defaults to `IfNotPresent`. Valid valu
 Create retries handle transient allocation, connection, image pull, and server-side errors. Command retries are controlled separately by `operations.command_retries`.
 
 execd, the exec daemon inside each sandbox, holds every command response open for `EXECD_API_GRACE_SHUTDOWN` (default 1s) after the command's last event, which is fixed latency on each command and on the readiness probe. Set it in the sandbox spec's `env` to shorten it; the shipped SWE-bench and OpenCode configs use `50ms`, and the provider's `operations.background_poll_initial_s` (0.5) is sized to that.
+
+`connection.tls_verify` (default `false`) controls certificate verification on every connection the provider opens, both the SDK transport and PTY WebSockets. The default skips verification so that `https://` endpoints with a certificate the client cannot verify, such as a validation cluster behind a self-signed load balancer, work without extra setup; set `tls_verify: true` for endpoints with a verifiable certificate. Pair `https` endpoints with `connection.protocol: https`. The `cleanup_sandboxes.py` helper mirrors the setting with `--tls-verify` and reads `tls_verify` from `--connection-config`.

--- a/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
+++ b/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
@@ -31,6 +31,7 @@ async def cleanup_sandboxes(
     run_id: str,
     user: str,
     reap: bool,
+    tls_verify: bool = False,
 ) -> int:
     """List exact run-owned sandboxes and optionally delete them."""
     base_url = domain.strip().rstrip("/")
@@ -45,7 +46,12 @@ async def cleanup_sandboxes(
         normalized = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._-")
         scope[key] = normalized[:63].strip("._-") or "metadata"
 
-    connector = aiohttp.TCPConnector(limit=REAP_CONCURRENCY, limit_per_host=REAP_CONCURRENCY)
+    connector_kwargs: dict[str, Any] = {"limit": REAP_CONCURRENCY, "limit_per_host": REAP_CONCURRENCY}
+    # Same default as the provider's connection.tls_verify: no certificate verification
+    # unless asked for, so cells behind a self-signed load balancer work out of the box.
+    if not tls_verify:
+        connector_kwargs["ssl"] = False
+    connector = aiohttp.TCPConnector(**connector_kwargs)
     timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
     async with aiohttp.ClientSession(
         connector=connector,
@@ -143,6 +149,8 @@ def _run(
     access_key: str,
     protocol: str,
     args: argparse.Namespace,
+    *,
+    tls_verify: bool = False,
 ) -> int:
     """Run the cleanup and turn its failures into a message and a status."""
     try:
@@ -154,6 +162,7 @@ def _run(
                 run_id=args.run_id,
                 user=args.user,
                 reap=args.reap,
+                tls_verify=tls_verify,
             )
         )
     except (aiohttp.ClientError, OSError, TypeError, ValueError) as error:
@@ -178,6 +187,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--user", required=True)
     parser.add_argument("--reap", action="store_true", help="Delete exact matches; otherwise only audit them.")
+    parser.add_argument(
+        "--tls-verify",
+        action="store_true",
+        help="Verify the server certificate (off by default, like connection.tls_verify).",
+    )
     args = parser.parse_args(argv)
 
     for name, value in (("run-id", args.run_id), ("user", args.user)):
@@ -188,7 +202,7 @@ def main(argv: list[str] | None = None) -> int:
         for name, value in (("domain", args.domain), ("api-key", args.api_key)):
             if value is None or not value.strip():
                 parser.error(f"--{name} is required when --connection-config is omitted")
-        return _run(parser, args.domain.strip(), args.api_key.strip(), args.protocol, args)
+        return _run(parser, args.domain.strip(), args.api_key.strip(), args.protocol, args, tls_verify=args.tls_verify)
     for name, value in (("domain", args.domain), ("api-key", args.api_key)):
         if value is not None:
             parser.error(f"--{name} cannot be combined with --connection-config")
@@ -217,7 +231,9 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(protocol, str) or protocol.strip() not in {"http", "https"}:
             raise ValueError("connection config 'sandbox.opensandbox.connection.protocol' must be http or https")
 
-        return _run(parser, domain.strip(), access_key.strip(), protocol.strip(), args)
+        tls_verify = bool(connection.get("tls_verify", False)) or args.tls_verify
+
+        return _run(parser, domain.strip(), access_key.strip(), protocol.strip(), args, tls_verify=tls_verify)
     except yaml.YAMLError:
         print("OpenSandbox cleanup failed: invalid YAML connection config", file=sys.stderr)
         return 1

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -37,6 +37,10 @@ sandbox:
       # "aiohttp" routes through the optional httpx-aiohttp bridge, falling
       # back to httpx with a warning when it is not installed.
       transport_backend: aiohttp
+      # Certificate verification for every connection the provider opens (SDK
+      # transport and PTY sockets). Off by default; set true for endpoints whose
+      # certificate the client can verify.
+      tls_verify: false
     create:
       request_timeout_s: 1200
       # Must exceed the spec's ready_timeout_s (1200 for mini_swe_agent_2): this

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -403,7 +403,9 @@ class OpenSandboxConnectionConfig:
     ``transport_backend`` is "httpx" or "aiohttp" (via the optional
     ``httpx-aiohttp`` bridge, falling back to httpx when it is absent).
     The pool is shared, so ``max_connections`` also caps in-flight sandbox
-    operations per process; null means no cap.
+    operations per process; null means no cap. ``tls_verify`` applies to every
+    connection the provider opens (SDK transport and PTY sockets) and is off by
+    default; set it for endpoints whose certificate the client can verify.
     """
 
     domain: str | None = None
@@ -420,6 +422,7 @@ class OpenSandboxConnectionConfig:
     max_connections: int | None = 100
     connect_retries: int = 2
     transport_backend: str = "httpx"
+    tls_verify: bool = False
 
 
 @dataclass(frozen=True)
@@ -721,17 +724,18 @@ class OpenSandboxProvider:
             max_keepalive_connections=max_keepalive,
             keepalive_expiry=self._connection.keepalive_expiry_s,
         )
+        verify = self._connection.tls_verify
         if self._connection.transport_backend == "aiohttp":
             try:
                 from httpx_aiohttp import AiohttpTransport
 
-                return AiohttpTransport(limits=limits, retries=self._connection.connect_retries)
+                return AiohttpTransport(verify=verify, limits=limits, retries=self._connection.connect_retries)
             except ImportError:
                 LOGGER.warning(
                     "connection.transport_backend=aiohttp requested but httpx-aiohttp "
                     "is not installed; falling back to the httpx transport"
                 )
-        return httpx.AsyncHTTPTransport(limits=limits, retries=self._connection.connect_retries)
+        return httpx.AsyncHTTPTransport(verify=verify, limits=limits, retries=self._connection.connect_retries)
 
     async def _retire_closed_pty_sessions(self) -> None:
         """Release sessions that ended on their own; their aiohttp client is
@@ -1467,8 +1471,11 @@ class OpenSandboxProvider:
         )
 
     def _pty_http_client(self) -> Any:
+        """Return the aiohttp client for one PTY session (same ``tls_verify`` as the SDK transport)."""
         import aiohttp
 
+        if not self._connection.tls_verify:
+            return aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))
         return aiohttp.ClientSession()
 
     async def _pty_target(self, handle: SandboxHandle) -> tuple[str, dict[str, str], float | None]:

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -120,6 +120,7 @@ def run_cleanup(
     run_id: str = "job-7",
     user: str = "alice",
     reap: bool = True,
+    tls_verify: bool = False,
 ) -> int:
     return asyncio.run(
         cleanup_sandboxes.cleanup_sandboxes(
@@ -128,6 +129,7 @@ def run_cleanup(
             access_key=TEST_ACCESS_KEY,
             run_id=run_id,
             user=user,
+            tls_verify=tls_verify,
             reap=reap,
         )
     )
@@ -160,6 +162,7 @@ def test_cleanup_uses_one_pool_and_deletes_only_exact_run_and_user(monkeypatch: 
         {
             "limit": cleanup_sandboxes.REAP_CONCURRENCY,
             "limit_per_host": cleanup_sandboxes.REAP_CONCURRENCY,
+            "ssl": False,
         }
     ]
     assert len(session_calls) == 1
@@ -450,6 +453,7 @@ def test_cli_uses_standalone_connection_config_and_forwards_return_codes(
             "run_id": "job-7",
             "user": "alice",
             "reap": True,
+            "tls_verify": False,
         }
     ]
 
@@ -806,6 +810,7 @@ def test_cli_takes_the_connection_from_arguments(
             "run_id": "job-7",
             "user": "alice",
             "reap": True,
+            "tls_verify": False,
         }
     ]
 
@@ -868,3 +873,27 @@ def test_slurm_launcher_falls_back_to_the_checkout_env_yaml(tmp_path: Path) -> N
     assert cleanup_call[cleanup_call.index("--connection-config") + 1] == f"{repo_root}/env.yaml"
     assert "--domain" not in cleanup_call
     assert "--api-key" not in cleanup_call
+
+
+def test_tls_verification_is_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = Session(page([]), page([]), page([]))
+    connector_calls, _, _ = install_session(monkeypatch, session)
+
+    assert run_cleanup(domain="https://sandbox.example", protocol="https") == 0
+
+    assert connector_calls == [
+        {
+            "limit": cleanup_sandboxes.REAP_CONCURRENCY,
+            "limit_per_host": cleanup_sandboxes.REAP_CONCURRENCY,
+            "ssl": False,
+        }
+    ]
+
+
+def test_tls_verify_keeps_certificate_verification(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = Session(page([]), page([]), page([]))
+    connector_calls, _, _ = install_session(monkeypatch, session)
+
+    assert run_cleanup(domain="https://sandbox.example", protocol="https", tls_verify=True) == 0
+
+    assert "ssl" not in connector_calls[0]

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1858,3 +1858,40 @@ async def test_exec_background_retries_timed_out_status_poll(monkeypatch: pytest
 
     assert commands.status_calls == ["exec-slowpoll", "exec-slowpoll"]
     assert result.return_code == 0
+
+
+def test_tls_verify_reaches_transports(fake_opensandbox_sdk: None) -> None:
+    import ssl
+
+    ConnectionConfig = opensandbox_provider.OpenSandboxConnectionConfig
+    assert ConnectionConfig().tls_verify is False
+    assert ConnectionConfig(tls_verify=True).tls_verify is True
+
+    default = opensandbox_provider.OpenSandboxProvider(connection={"transport_backend": "httpx"})
+    assert default._build_transport()._pool._ssl_context.verify_mode == ssl.CERT_NONE
+    verified = opensandbox_provider.OpenSandboxProvider(connection={"transport_backend": "httpx", "tls_verify": True})
+    assert verified._build_transport()._pool._ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+    httpx_aiohttp = pytest.importorskip("httpx_aiohttp", reason="optional httpx-aiohttp is not installed")
+    bridge = opensandbox_provider.OpenSandboxProvider(connection={"transport_backend": "aiohttp"})._build_transport()
+    assert isinstance(bridge, httpx_aiohttp.AiohttpTransport)
+    assert bridge.ssl_context.verify_mode == ssl.CERT_NONE
+    bridge_verified = opensandbox_provider.OpenSandboxProvider(
+        connection={"transport_backend": "aiohttp", "tls_verify": True}
+    )._build_transport()
+    assert bridge_verified.ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_pty_http_client_follows_tls_verify(fake_opensandbox_sdk: None) -> None:
+    default = opensandbox_provider.OpenSandboxProvider()._pty_http_client()
+    try:
+        assert default.connector._ssl is False
+    finally:
+        await default.close()
+
+    verified = opensandbox_provider.OpenSandboxProvider(connection={"tls_verify": True})._pty_http_client()
+    try:
+        assert verified.connector._ssl is True
+    finally:
+        await verified.close()


### PR DESCRIPTION
## Summary

Make the OpenSandbox provider usable against an `https://` endpoint whose certificate the client cannot verify, such as the cell-3 validation cluster behind a self-signed load balancer, with a config key only (no environment variable).

- New `connection.tls_verify` on the provider, **default `false`**, applied to every connection it opens: the httpx transport, the httpx-aiohttp bridge transport (`transport_backend: aiohttp`, the shipped default), and the aiohttp client behind each PTY WebSocket session.
- Set `tls_verify: true` for endpoints with a verifiable certificate. Pair `https` endpoints with `connection.protocol: https`.
- `cleanup_sandboxes.py` mirrors the setting: `--tls-verify` flag, or `tls_verify` from `--connection-config`; verification is off by default there too.
- Docs and the shipped yaml gain the setting.

Note the default: with this change the provider does **not** verify server certificates unless `tls_verify: true` is set. That is the intended behavior for the current deployments (internal endpoints, self-signed certificates); flip the yaml default if the project prefers verification on.

## Usage with an `https://` endpoint

Two settings are required for an `https://` endpoint: `connection.protocol=https` (the shipped default is `http`, and without this override nothing works) and `connection.tls_verify=false` (the default) when the certificate is self-signed or otherwise unverifiable. Minimal form, as overrides on the shipped provider config:

```bash
gym env start \
  --config responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml \
  --config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml \
  --config responses_api_models/vllm_model/configs/vllm_model.yaml \
  ++sandbox.opensandbox.connection.domain=https://sandbox.example.internal \
  ++sandbox.opensandbox.connection.protocol=https \
  ++sandbox.opensandbox.connection.tls_verify=false
```

Or as an override config layered on top of the shipped one (`--config configs/opensandbox_https.yaml` in place of the three `++` lines):

```yaml
# configs/opensandbox_https.yaml
sandbox:
  opensandbox:
    connection:
      domain: https://sandbox.example.internal        # or ${oc.env:OPENSANDBOX_DOMAIN,...}
      api_key: ${oc.env:OPENSANDBOX_API_KEY}
      protocol: https      # required: the shipped default is http
      tls_verify: false    # default; set true when the certificate chain is verifiable
```

The cleanup helper follows the same setting:

```bash
python nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py \
  --connection-config configs/opensandbox_https.yaml --run-id <slurm-job-id> --user <user>   # protocol and tls_verify from the config
python nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py \
  --domain https://sandbox.example.internal --protocol https --api-key "$OPENSANDBOX_API_KEY" --tls-verify \
  --run-id <slurm-job-id> --user <user>                                                          # verification on
```

## Why

Every cell-3 run so far has run from side branches that carried an env-var opt-out; `main` has no way to reach an https endpoint with an unverifiable certificate, so a stock checkout cannot run there. This is the smallest upstreamable piece, expressed as Hydra config so it composes like the other connection settings.

## Test plan

- [x] `pytest tests/unit_tests/test_opensandbox_provider.py tests/unit_tests/test_opensandbox_cleanup.py` in a fresh worktree venv with `opensandbox`, `httpx-aiohttp`, `tenacity` installed: 107 passed. New tests: `CERT_NONE` by default and `CERT_REQUIRED` with `tls_verify: true` on both the httpx and bridge transports, the PTY client's connector `ssl` flag following the setting, and the cleanup script's connector with and without `--tls-verify`.
- [x] `pre-commit run --files ...` on the changed files.
- [x] SWE-bench Verified from this branch against an https endpoint with a self-signed certificate: 1475 rows / 0.7159 mean reward / 1056 resolved at the 2 h wall, no TLS or sandbox errors (details in the comment below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
