### PR TITLE
fix(nemotron_3.5_super): repin vllm-router to the current head of #238

### DIFF
--- a/benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh
+++ b/benchmarks/nemotron_3.5_super/build_vllm_router_wheel.sh
@@ -34,7 +34,7 @@ VLLM_ROUTER_GIT_URL=${VLLM_ROUTER_GIT_URL:-https://github.com/vllm-project/route
 # to preserve worker load during checks") unchanged plus a fix for the prefill-side
 # regression #216 exposes; see the README. Fetching a bare SHA works because GitHub
 # serves any commit reachable from a ref, and PR heads are refs.
-VLLM_ROUTER_COMMIT=${VLLM_ROUTER_COMMIT:-5b7ce08ea8cd27123cf6c23313cd92d3ba0da70e}
+VLLM_ROUTER_COMMIT=${VLLM_ROUTER_COMMIT:-84b4425d7550b993d17010db0408ab170dc6eecb}
 RUST_TOOLCHAIN=${RUST_TOOLCHAIN:-1.95.0}
 # Load-accounting unit tests from the fix. Compiling the test binary roughly
 # doubles the job, so it is opt-out.


### PR DESCRIPTION
The pin added in #3080 pointed at a commit that also carried per-role balance threshold flags (--prefill-balance-abs-threshold and friends). They have been dropped from vllm-project/router#238 to keep the PR to the bug fix, so this moves the pin to the new head.

No behaviour change. The remaining commits are unchanged: #216 (health checker no longer resets in-flight worker load) plus the fix for the prefill-side regression #216 exposes, where cache_aware decided prefix affinity from the fleet-wide load spread instead of per request.