### PR TITLE
feat(aviary): support post-terminal model response

### DIFF
--- a/resources_servers/bbh_hypotest/configs/bbh_hypotest_opensandbox.yaml
+++ b/resources_servers/bbh_hypotest/configs/bbh_hypotest_opensandbox.yaml
@@ -115,6 +115,7 @@ bbh_hypotest_aviary_agent:
       entrypoint: app.py
       max_steps: 100
       return_transitions: false
+      generate_final_response_after_done: true
       resources_server:
         type: resources_servers
         name: bbh_hypotest_aviary_resources_server

--- a/responses_api_agents/aviary_agent/app.py
+++ b/responses_api_agents/aviary_agent/app.py
@@ -76,6 +76,12 @@ class AviaryAgentConfig(BaseResponsesAPIAgentConfig):
     done_if_no_tool_calls: bool = Field(
         default=True, description="If True, end the rollout if the model does not call any tools."
     )
+    generate_final_response_after_done: bool = Field(
+        default=False,
+        description="If True, make one final model call after the environment returns done. "
+        "The terminal observation is included in the model context, tools are disabled, "
+        "and the final model output is not sent back to the environment.",
+    )
 
     collapse_old_env_states: bool = Field(
         default=False,
@@ -156,11 +162,16 @@ class AviaryAgent(SimpleResponsesAPIAgent):
         model_server_cookies = None
 
         step = 0
+        final_response_pending = False
         try:
             while True:
-                if self.config.max_steps is not None and step >= self.config.max_steps:
+                is_final_response_turn = final_response_pending
+                final_response_pending = False
+
+                if self.config.max_steps is not None and step >= self.config.max_steps and not is_final_response_turn:
                     break
-                step += 1
+                if not is_final_response_turn:
+                    step += 1
                 successful_transition = True
 
                 # Sample action from model
@@ -197,8 +208,17 @@ class AviaryAgent(SimpleResponsesAPIAgent):
                     o for o in model_output if o.type == "message" and o.role == "assistant"
                 ]
                 done = False
+                environment_done = False
 
-                if not all_fn_calls and all_output_messages:
+                if is_final_response_turn:
+                    if all_fn_calls:
+                        logger.warning(
+                            "Model emitted tool calls during its post-terminal response; "
+                            "ignoring them and ending the rollout."
+                        )
+                    obs = []
+                    done = True
+                elif not all_fn_calls and all_output_messages:
                     if self.config.done_if_no_tool_calls:
                         done = True
                         obs = []
@@ -223,7 +243,8 @@ class AviaryAgent(SimpleResponsesAPIAgent):
                     )
                     env_response = AviaryStepResponse.model_validate(await raw_env_response.json())
                     obs = env_response.obs
-                    done = env_response.done
+                    environment_done = env_response.done
+                    done = environment_done
 
                 agent_state = self.update_agent_state(agent_state, model_output, obs, successful_transition)
                 if self.config.return_transitions:
@@ -232,6 +253,11 @@ class AviaryAgent(SimpleResponsesAPIAgent):
                     all_messages.extend(model_output)
                     if successful_transition:
                         all_messages.extend(obs)
+
+                if environment_done and self.config.generate_final_response_after_done:
+                    agent_state = agent_state.model_copy(update={"tools": [], "tool_choice": "none"})
+                    final_response_pending = True
+                    continue
 
                 if done:
                     break

--- a/responses_api_agents/aviary_agent/tests/test_app.py
+++ b/responses_api_agents/aviary_agent/tests/test_app.py
@@ -308,6 +308,114 @@ class TestApp:
         assert calls[4][1]["json"]["action"][0]["call_id"] == "call_2"
         assert calls[5] == call(server_name="my resources name", url_path="/close", json={"env_id": env_id})
 
+    async def test_responses_generates_final_response_after_environment_done(self) -> None:
+        config = AviaryAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my model name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources name",
+            ),
+            max_steps=1,
+            return_transitions=False,
+            generate_final_response_after_done=True,
+        )
+        agent = AviaryAgent(config=config, server_client=MagicMock(spec=ServerClient))
+
+        env_id = str(uuid.uuid4())
+        mock_seed_session_data = {
+            "env_id": env_id,
+            "obs": [{"role": "user", "content": "Initial observation"}],
+            "tools": [],
+        }
+        mock_terminal_response = {
+            "id": "resp_terminal",
+            "created_at": 1753983920.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                NeMoGymResponseFunctionToolCall(
+                    call_id="submit_call",
+                    name="submit_answer",
+                    arguments=json.dumps({"answer": "The answer is 42"}),
+                ).model_dump()
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        mock_terminal_step = {
+            "obs": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "submit_call",
+                    "output": "Correct answer!",
+                }
+            ],
+            "reward": 1.0,
+            "done": True,
+        }
+        mock_final_response = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [{"annotations": [], "text": "The answer is 42", "type": "output_text"}],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": False,
+            "tool_choice": "none",
+            "tools": [],
+        }
+        mock_close_data = {"message": "Success", "success": True}
+
+        dotjson_mock = AsyncMock()
+        dotjson_mock.json.side_effect = [
+            mock_seed_session_data,
+            mock_terminal_response,
+            mock_terminal_step,
+            mock_final_response,
+            mock_close_data,
+        ]
+        dotjson_mock.raise_for_status = MagicMock()
+        dotjson_mock.cookies = MagicMock()
+        agent.server_client.post = AsyncMock(return_value=dotjson_mock)
+
+        request = AviaryAgentRunRequest(
+            task_idx=42, responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[])
+        )
+        response = await agent.responses(request)
+
+        assert [item.type for item in response.output] == ["function_call", "function_call_output", "message"]
+        assert response.output[-1].content[0].text == "The answer is 42"
+
+        calls = agent.server_client.post.await_args_list
+        assert [request_call.kwargs["url_path"] for request_call in calls] == [
+            "/seed_session",
+            "/v1/responses",
+            "/step",
+            "/v1/responses",
+            "/close",
+        ]
+
+        final_model_input = calls[3].kwargs["json"]
+        assert final_model_input.tools == []
+        assert final_model_input.tool_choice == "none"
+        assert final_model_input.input[-1].type == "function_call_output"
+        assert final_model_input.input[-1].output == "Correct answer!"
+
     async def test_responses_return_transitions_false(self) -> None:
         config = AviaryAgentConfig(
             host="0.0.0.0",


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

Adds BixBench-Hypothesis environment as independent training environment, and adds support for terminal model response to satisfy reward shaping requirements.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
