### PR TITLE
fix(conversational_tool_use_simulation): fall back to reason_for_contact when the opening user message fails

### DIFF
--- a/resources_servers/conversational_tool_use_simulation/app.py
+++ b/resources_servers/conversational_tool_use_simulation/app.py
@@ -46,6 +46,7 @@ from nemo_gym.server_utils import SESSION_ID_KEY, get_response_json, raise_for_s
 
 TRAJECTORY_COMPLETE_INDICATOR = "###STOP###"
 AGENT_TRANSFER_INDICATOR = "###TRANSFER###"
+DEFAULT_FIRST_USER_MESSAGE = "I need help with my account."
 
 
 class JudgeProviderError(Exception):
@@ -129,6 +130,12 @@ class ConversationalToolUseSimulationConfig(BaseResourcesServerConfig):
     enable_termination: bool = True
     verification_type: VerificationType = VerificationType.MESSAGE
     enforce_transfer_ground_truth: bool = False
+    # When the simulator cannot produce a usable opening user message (generation
+    # error, or a first message that already carries a stop/transfer indicator), fall
+    # back to the scenario's reason_for_contact instead of ending the trajectory before
+    # the agent has spoken. A trajectory with no agent turn has no trainable tokens,
+    # so downstream trainers cannot represent it.
+    fallback_first_user_message: bool = True
 
 
 class CustomerScenario(BaseModel):
@@ -1069,6 +1076,10 @@ Return type in JSON Schema format: {return_type}
         if state.terminal_state:
             return NextUserMessageResponse(message="", should_continue=False, terminal_state=state.terminal_state)
 
+        use_first_message_fallback = self.config.fallback_first_user_message and not any(
+            existing.source == Source.USER for existing in state.messages
+        )
+
         user_message = ""
         message = None
         invalid = None
@@ -1085,19 +1096,29 @@ Return type in JSON Schema format: {return_type}
                 if invalid is None:
                     break
         except Exception as exc:
-            self._record_generation_failure(
-                state,
-                TrajectoryInvalidReason.MESSAGE_GENERATION_ERROR,
-                VerificationFailureLabel.USER_FAILURE,
-                f"{exc}",
-            )
-            return NextUserMessageResponse(
-                message="",
-                should_continue=False,
-                terminal_state=state.terminal_state,
-            )
+            if use_first_message_fallback:
+                user_message, message = self._fallback_first_user_message(
+                    state, f"{TrajectoryInvalidReason.MESSAGE_GENERATION_ERROR}: {exc}"
+                )
+                invalid = None
+            else:
+                self._record_generation_failure(
+                    state,
+                    TrajectoryInvalidReason.MESSAGE_GENERATION_ERROR,
+                    VerificationFailureLabel.USER_FAILURE,
+                    f"{exc}",
+                )
+                return NextUserMessageResponse(
+                    message="",
+                    should_continue=False,
+                    terminal_state=state.terminal_state,
+                )
 
         assert message is not None
+        if invalid is not None and use_first_message_fallback:
+            invalid_reason, error = invalid
+            user_message, message = self._fallback_first_user_message(state, f"{invalid_reason}: {error}")
+            invalid = None
         state.messages.append(message)
         if invalid is not None:
             invalid_reason, error = invalid
@@ -1418,6 +1439,26 @@ Return type in JSON Schema format: {return_type}
     def _next_tool_call_index(self, state: ConversationSessionState) -> int:
         return 1 + sum(1 for message in state.messages if message.type == MessageType.TOOL_CALL)
 
+    def _fallback_first_user_message(
+        self, state: ConversationSessionState, reason: str
+    ) -> tuple[str, ConversationMessage]:
+        """Return a usable opening user message when the simulator could not produce one.
+
+        Prefers the scenario's ``reason_for_contact`` and falls back to a generic
+        request. The reason is recorded in ``source_artifacts`` so the rate of
+        simulator failures stays visible without invalidating the trajectory.
+        """
+        text = (state.customer_scenario.reason_for_contact or "").strip()
+        if not text or TRAJECTORY_COMPLETE_INDICATOR in text or AGENT_TRANSFER_INDICATOR in text:
+            text = DEFAULT_FIRST_USER_MESSAGE
+        state.source_artifacts.setdefault("first_user_message_fallbacks", []).append(reason)
+        print(
+            f"[conversational-tool-use-simulation] rollout={state.rollout_id} first user message fallback: {reason}",
+            flush=True,
+        )
+        message = ConversationMessage(type=MessageType.TEXT, source=Source.USER, content=text)
+        return text, message
+
     def _record_generation_failure(
         self,
         state: ConversationSessionState,
@@ -1478,7 +1519,7 @@ Return type in JSON Schema format: {return_type}
         model_server = self.config.user_model_server or self.config.simulator_model_server
         if model_server is None:
             if not any(message.source == Source.USER for message in state.messages):
-                return state.customer_scenario.reason_for_contact or "I need help with my account.", None
+                return state.customer_scenario.reason_for_contact or DEFAULT_FIRST_USER_MESSAGE, None
             return "Thanks. Please continue helping me with this request.", None
 
         response = await self._call_model(

--- a/resources_servers/conversational_tool_use_simulation/tests/test_app.py
+++ b/resources_servers/conversational_tool_use_simulation/tests/test_app.py
@@ -60,7 +60,9 @@ class JsonResponseStub:
 
 
 def make_server(
-    enable_llm_judge: bool = False, enforce_transfer_ground_truth: bool = False
+    enable_llm_judge: bool = False,
+    enforce_transfer_ground_truth: bool = False,
+    fallback_first_user_message: bool = True,
 ) -> ConversationalToolUseSimulationServer:
     config = ConversationalToolUseSimulationConfig(
         host="0.0.0.0",
@@ -70,6 +72,7 @@ def make_server(
         domain="agent",
         enable_llm_judge=enable_llm_judge,
         enforce_transfer_ground_truth=enforce_transfer_ground_truth,
+        fallback_first_user_message=fallback_first_user_message,
         judge_model_server={"type": "responses_api_models", "name": "judge_model"} if enable_llm_judge else None,
     )
     return ConversationalToolUseSimulationServer(config=config, server_client=MagicMock(spec=ServerClient))
@@ -541,8 +544,40 @@ async def test_user_stop_completes_and_agent_stop_does_not(monkeypatch) -> None:
     assert "session_1" not in server.session_id_to_state
 
 
-async def test_first_user_stop_is_invalid(monkeypatch) -> None:
+async def test_first_user_stop_falls_back_to_reason_for_contact(monkeypatch) -> None:
     server = make_server()
+    request = RequestStub()
+
+    await server.seed_session(
+        request,
+        ConversationalToolUseSeedSessionRequest(
+            domain_name="subscription support",
+            profile="general",
+            policy="policy",
+            customer_scenario={"reason_for_contact": "I need help."},
+        ),
+    )
+
+    async def stop_user_message(state):
+        return "###STOP###", None
+
+    monkeypatch.setattr(server, "_generate_user_message", stop_user_message)
+    user_message = await server.next_user_message(request)
+    assert user_message.should_continue is True
+    assert user_message.terminal_state is None
+    assert user_message.message == "I need help."
+
+    state = server.session_id_to_state["session_1"]
+    assert [message.content for message in state.messages] == ["I need help."]
+    assert state.invalid_reasons == []
+    assert state.terminal_state is None
+    fallbacks = state.source_artifacts["first_user_message_fallbacks"]
+    assert len(fallbacks) == 1
+    assert fallbacks[0].startswith("invalid_user_message: ")
+
+
+async def test_first_user_stop_is_invalid_when_fallback_disabled(monkeypatch) -> None:
+    server = make_server(fallback_first_user_message=False)
     request = RequestStub()
 
     await server.seed_session(
@@ -746,8 +781,95 @@ async def test_tool_argument_enum_is_validated_by_jsonschema() -> None:
     assert verified.result.trajectory.messages[-1].tool_name == "update_subscription"
 
 
-async def test_user_generation_error_records_invalid_reason(monkeypatch) -> None:
+async def test_first_user_generation_error_falls_back_to_reason_for_contact(monkeypatch) -> None:
     server = make_server()
+    request = RequestStub()
+
+    await server.seed_session(
+        request,
+        ConversationalToolUseSeedSessionRequest(
+            domain_name="subscription support",
+            profile="general",
+            policy="policy",
+            customer_scenario={"reason_for_contact": "I need help."},
+        ),
+    )
+
+    async def raise_generation_error(state):
+        raise RuntimeError("model server returned no text")
+
+    monkeypatch.setattr(server, "_generate_user_message", raise_generation_error)
+
+    user_message = await server.next_user_message(request)
+
+    assert user_message.should_continue is True
+    assert user_message.terminal_state is None
+    assert user_message.message == "I need help."
+    state = server.session_id_to_state["session_1"]
+    assert [message.content for message in state.messages] == ["I need help."]
+    assert state.generation_invalid_reason is None
+    assert state.terminal_error is None
+    assert state.source_artifacts["first_user_message_fallbacks"] == [
+        "message_generation_error: model server returned no text"
+    ]
+
+
+async def test_first_user_fallback_uses_default_when_reason_for_contact_is_unusable(monkeypatch) -> None:
+    for reason_for_contact in ("", "   ", "Cancel it. ###STOP###"):
+        server = make_server()
+        request = RequestStub()
+        await server.seed_session(
+            request,
+            ConversationalToolUseSeedSessionRequest(
+                domain_name="subscription support",
+                profile="general",
+                policy="policy",
+                customer_scenario={"reason_for_contact": reason_for_contact},
+            ),
+        )
+
+        async def raise_generation_error(state):
+            raise RuntimeError("model server returned no text")
+
+        monkeypatch.setattr(server, "_generate_user_message", raise_generation_error)
+        user_message = await server.next_user_message(request)
+        assert user_message.should_continue is True
+        assert user_message.message == "I need help with my account."
+
+
+async def test_later_user_generation_error_still_records_invalid_reason(monkeypatch) -> None:
+    server = make_server()
+    request = RequestStub()
+
+    await server.seed_session(
+        request,
+        ConversationalToolUseSeedSessionRequest(
+            domain_name="subscription support",
+            profile="general",
+            policy="policy",
+            customer_scenario={"reason_for_contact": "I need help."},
+        ),
+    )
+
+    first = await server.next_user_message(request)
+    assert first.should_continue is True
+    await server.record_agent_message(request, RecordAgentMessageRequest(content="Sure, what is the issue?"))
+
+    async def raise_generation_error(state):
+        raise RuntimeError("model server returned no text")
+
+    monkeypatch.setattr(server, "_generate_user_message", raise_generation_error)
+    user_message = await server.next_user_message(request)
+
+    assert user_message.should_continue is False
+    assert user_message.terminal_state == "incomplete"
+    state = server.session_id_to_state["session_1"]
+    assert state.generation_invalid_reason == "message_generation_error"
+    assert "first_user_message_fallbacks" not in state.source_artifacts
+
+
+async def test_user_generation_error_records_invalid_reason_when_fallback_disabled(monkeypatch) -> None:
+    server = make_server(fallback_first_user_message=False)
     request = RequestStub()
 
     await server.seed_session(


### PR DESCRIPTION
When the user simulator raised while generating the first user message, or produced a first message that already carried ###STOP###/###TRANSFER###, the server ended the trajectory before the agent ever spoke. The agent then returned a response with an empty output list, which NeMo RL cannot represent (no trainable tokens) and turned into a whole-batch rollout failure.

Fall back to the scenario's reason_for_contact (or a generic request when that is empty or itself carries a stop indicator) so the conversation always reaches the agent. Record each fallback under source_artifacts.first_user_message_fallbacks so the simulator failure rate stays observable. Later-turn failures keep the existing invalid/terminal behavior. Controlled by the new fallback_first_user_message config flag (default true).

<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
