### PR TITLE
Fix competitive coding shared-directory environment variable

### DIFF
--- a/resources_servers/competitive_coding_challenges/README.md
+++ b/resources_servers/competitive_coding_challenges/README.md
@@ -23,11 +23,11 @@ competitive_coding_challenges
     test_batch_size: 32
     num_parallel_requests: 16
     time_scale: 2.0
-    shared_dir: ${oc.env:SHARED_TEMP_DIR,/tmp}
+    shared_dir: ${oc.env:CCC_SHARED_TEMP_DIR,/tmp}
 ```
 
 You must set the following at runtime:
-- `export SHARED_TEMP_DIR=` local directory for code execution to store compilation files and share between ray instances and nodes
+- `export CCC_SHARED_TEMP_DIR=` local directory for code execution to store compilation files and share between ray instances and nodes
 - `export CCC_TEST_FILE=` path to metadata.jsonl file which contains data test cases and necessary execution artifacts
 
 and optionally can set to following:

--- a/resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml
+++ b/resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml
@@ -9,7 +9,7 @@ competitive_coding_challenges_resources_server:
       test_batch_size: 32
       num_parallel_requests: 16
       time_scale: 2.0
-      shared_dir: ${oc.env:SHARED_TEMP_DIR,/tmp}
+      shared_dir: ${oc.env:CCC_SHARED_TEMP_DIR,/tmp}
       reward_mode: binary
       verified: false
 competitive_coding_challenges_simple_agent:


### PR DESCRIPTION
## Summary
- rename the competitive coding shared-directory variable from the generic `SHARED_TEMP_DIR` to `CCC_SHARED_TEMP_DIR`
- update the resource-server configuration and README together

## Testing
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run --frozen --extra dev pytest -q resources_servers/competitive_coding_challenges/tests/test_app.py` (25 passed)