### PR TITLE
feat(server_utils): opt-in CRLF heartbeat so long HTTP/1.1 model calls survive Global Accelerator's 340s idle timeout

### DIFF
--- a/nemo_gym/aiohttp_heartbeat.py
+++ b/nemo_gym/aiohttp_heartbeat.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+CRLF heartbeat for the global aiohttp client.
+
+Some network intermediaries drop TCP connections that carry no payload for a fixed
+period and do not count TCP keepalive probes (for example AWS Global Accelerator, whose
+idle timeout is fixed at 340 seconds). A non-streaming model call that takes longer than
+that to produce its first response byte fails with ``ServerDisconnectedError`` when the
+intermediary closes the connection.
+
+HTTP/2 clients solve this with PING frames. aiohttp speaks HTTP/1.1 only, so this module
+uses the HTTP/1.1 equivalent: while a request is in flight, write a bare CRLF on the
+connection every ``heartbeat`` seconds. The bytes travel as encrypted TLS records, so the
+intermediary sees payload and resets its idle timer. HTTP/1.1 servers must ignore empty
+lines received before a request-line (RFC 9112 section 2.2), so the origin discards them
+once the pending response has been sent and the connection stays reusable. The same idea
+is standardised for SIP as the "CRLF keep-alive technique" (RFC 5626 section 4.4.1).
+
+Enabled with ``global_aiohttp_crlf_heartbeat_seconds`` in the global config (default 0,
+off). Only connections with a request in flight receive heartbeats.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Optional
+
+from aiohttp import TCPConnector
+
+
+CRLF = b"\r\n"
+_LOG = logging.getLogger(__name__)
+
+
+class HeartbeatTCPConnector(TCPConnector):
+    """aiohttp.TCPConnector that writes CRLF on every in-flight connection periodically.
+
+    Args:
+        heartbeat: seconds between heartbeats. Keep it well below the intermediary's idle
+            timeout (for example 60 s for a 340 s intermediary timeout). 0 disables the
+            heartbeat; the connector is then identical to TCPConnector.
+        on_heartbeat: optional callback receiving the number of connections written to,
+            for metrics.
+        **kwargs: forwarded to TCPConnector.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        heartbeat: float = 0.0,
+        on_heartbeat: Optional[Callable[[int], None]] = None,
+        **kwargs: Any,
+    ) -> None:
+        if heartbeat < 0:
+            raise ValueError("heartbeat must be >= 0")
+        super().__init__(*args, **kwargs)
+        self._hb_every = float(heartbeat)
+        self._hb_cb = on_heartbeat
+        self._hb_task: Optional[asyncio.Task[None]] = None
+        self.heartbeats_sent = 0
+
+    async def _create_connection(self, req: Any, traces: Any, timeout: Any) -> Any:  # type: ignore[override]
+        proto = await super()._create_connection(req, traces, timeout)
+        self._ensure_task()
+        return proto
+
+    def _ensure_task(self) -> None:
+        if self._hb_every <= 0 or self._closed:
+            return
+        if self._hb_task is None or self._hb_task.done():
+            self._hb_task = asyncio.get_running_loop().create_task(
+                self._heartbeat_loop(), name="aiohttp-crlf-heartbeat"
+            )
+
+    async def _heartbeat_loop(self) -> None:
+        try:
+            while not self._closed:
+                await asyncio.sleep(self._hb_every)
+                n = self._beat_once()
+                if n and self._hb_cb is not None:
+                    try:
+                        self._hb_cb(n)
+                    except Exception:
+                        _LOG.exception("on_heartbeat callback raised")
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            _LOG.exception("CRLF heartbeat loop crashed; it restarts on the next new connection")
+
+    def _beat_once(self) -> int:
+        """Write CRLF on each acquired (request in flight) connection; return how many."""
+        n = 0
+        for proto in list(self._acquired):
+            transport = getattr(proto, "transport", None)
+            if transport is None or transport.is_closing():
+                continue
+            try:
+                transport.write(CRLF)
+                n += 1
+            except Exception:
+                _LOG.debug("CRLF heartbeat write failed", exc_info=True)
+        self.heartbeats_sent += n
+        return n
+
+    async def close(self) -> Any:  # type: ignore[override]
+        if self._hb_task is not None:
+            self._hb_task.cancel()
+            self._hb_task = None
+        return await super().close()

--- a/nemo_gym/aiohttp_heartbeat.py
+++ b/nemo_gym/aiohttp_heartbeat.py
@@ -37,8 +37,11 @@ connections exist; it is started lazily on the first connection and cancelled in
 ``close()``. Every ``heartbeat`` seconds that task makes one pass over the connector's
 acquired set (connections with a request in flight) and calls ``transport.write(b"\r\n")``
 on each. No per-connection tasks, timers or callbacks are created, and idle pooled
-connections are never touched. The per-interval work is therefore one synchronous loop
-of N small writes, where N is the number of requests in flight at that moment.
+connections are never touched. The per-interval work is therefore one loop of N small
+writes, where N is the number of requests in flight at that moment. The loop yields to the
+event loop after every ``batch_size`` writes so a large N cannot stall other coroutines:
+measured at 16,000 in-flight TLS connections, an unbatched pass blocks the loop for ~260 ms,
+a batched one for at most one batch (a few milliseconds).
 """
 
 from __future__ import annotations
@@ -66,6 +69,9 @@ class HeartbeatTCPConnector(TCPConnector):
             heartbeat; the connector is then identical to TCPConnector.
         on_heartbeat: optional callback receiving the number of connections written to,
             for metrics.
+        batch_size: number of connections written per event-loop iteration during a
+            heartbeat pass; the pass yields between batches. Lower values reduce the
+            worst-case stall, higher values reduce overhead. Default 128.
         **kwargs: forwarded to TCPConnector.
     """
 
@@ -74,13 +80,17 @@ class HeartbeatTCPConnector(TCPConnector):
         *args: Any,
         heartbeat: float = 0.0,
         on_heartbeat: Optional[Callable[[int], None]] = None,
+        batch_size: int = 128,
         **kwargs: Any,
     ) -> None:
         if heartbeat < 0:
             raise ValueError("heartbeat must be >= 0")
+        if batch_size < 1:
+            raise ValueError("batch_size must be >= 1")
         super().__init__(*args, **kwargs)
         self._hb_every = float(heartbeat)
         self._hb_cb = on_heartbeat
+        self._hb_batch = int(batch_size)
         self._hb_task: Optional[asyncio.Task[None]] = None
         self.heartbeats_sent = 0
 
@@ -101,7 +111,7 @@ class HeartbeatTCPConnector(TCPConnector):
         try:
             while not self._closed:
                 await asyncio.sleep(self._hb_every)
-                n = self._beat_once()
+                n = await self._beat_once()
                 if n and self._hb_cb is not None:
                     try:
                         self._hb_cb(n)
@@ -112,18 +122,19 @@ class HeartbeatTCPConnector(TCPConnector):
         except Exception:
             _LOG.exception("CRLF heartbeat loop crashed; it restarts on the next new connection")
 
-    def _beat_once(self) -> int:
-        """Write CRLF on each acquired (request in flight) connection; return how many."""
+    async def _beat_once(self) -> int:
+        """Write CRLF on each acquired connection, yielding to the event loop every ``batch_size`` writes."""
         n = 0
-        for proto in list(self._acquired):
+        for i, proto in enumerate(list(self._acquired)):  # connections with a request in flight
             transport = getattr(proto, "transport", None)
-            if transport is None or transport.is_closing():
-                continue
-            try:
-                transport.write(CRLF)
-                n += 1
-            except Exception:
-                _LOG.debug("CRLF heartbeat write failed", exc_info=True)
+            if transport is not None and not transport.is_closing():
+                try:
+                    transport.write(CRLF)
+                    n += 1
+                except Exception:
+                    _LOG.debug("CRLF heartbeat write failed", exc_info=True)
+            if (i + 1) % self._hb_batch == 0:
+                await asyncio.sleep(0)
         self.heartbeats_sent += n
         return n
 

--- a/nemo_gym/aiohttp_heartbeat.py
+++ b/nemo_gym/aiohttp_heartbeat.py
@@ -31,6 +31,14 @@ is standardised for SIP as the "CRLF keep-alive technique" (RFC 5626 section 4.4
 
 Enabled with ``global_aiohttp_crlf_heartbeat_seconds`` in the global config (default 0,
 off). Only connections with a request in flight receive heartbeats.
+
+Cost model. The connector runs exactly **one** background task, regardless of how many
+connections exist; it is started lazily on the first connection and cancelled in
+``close()``. Every ``heartbeat`` seconds that task makes one pass over the connector's
+acquired set (connections with a request in flight) and calls ``transport.write(b"\r\n")``
+on each. No per-connection tasks, timers or callbacks are created, and idle pooled
+connections are never touched. The per-interval work is therefore one synchronous loop
+of N small writes, where N is the number of requests in flight at that moment.
 """
 
 from __future__ import annotations
@@ -48,6 +56,9 @@ _LOG = logging.getLogger(__name__)
 
 class HeartbeatTCPConnector(TCPConnector):
     """aiohttp.TCPConnector that writes CRLF on every in-flight connection periodically.
+
+    One background task per connector (not per connection) performs the writes; see the
+    module docstring for the cost model.
 
     Args:
         heartbeat: seconds between heartbeats. Keep it well below the intermediary's idle

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -41,7 +41,6 @@ from aiohttp import (
     ClientTimeout,
     DummyCookieJar,
     ServerDisconnectedError,
-    TCPConnector,
 )
 from aiohttp.client import _RequestOptions
 from anyio import create_task_group
@@ -57,6 +56,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from nemo_gym import WORKING_DIR
+from nemo_gym.aiohttp_heartbeat import HeartbeatTCPConnector
 from nemo_gym.config_types import (
     ROLLOUT_PATH_PREFIX,
     TOKEN_CAPTURE_PATH_SEGMENT,
@@ -116,6 +116,16 @@ class GlobalAIOHTTPAsyncClientConfig(BaseModel):
         description=("TCP_KEEPCNT: number of unanswered probes before the kernel drops the connection."),
     )
 
+    global_aiohttp_crlf_heartbeat_seconds: float = Field(
+        default=0,
+        description=(
+            "If > 0, write a bare CRLF on every in-flight HTTP/1.1 connection this often (seconds) so that "
+            "intermediaries with fixed idle timeouts (e.g. AWS Global Accelerator, 340s, which ignores TCP "
+            "keepalives) do not drop long-running requests. 60 is a sensible value for such endpoints. "
+            "0 disables it. See nemo_gym/aiohttp_heartbeat.py."
+        ),
+    )
+
 
 def get_global_aiohttp_client(
     global_config_dict_parser_config: Optional[GlobalConfigDictParserConfig] = None,
@@ -164,7 +174,8 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
 
     num_workers = get_nemo_gym_fastapi_num_workers()
     client_session = ClientSession(
-        connector=TCPConnector(
+        connector=HeartbeatTCPConnector(
+            heartbeat=cfg.global_aiohttp_crlf_heartbeat_seconds,
             limit=cfg.global_aiohttp_connector_limit // num_workers,
             limit_per_host=cfg.global_aiohttp_connector_limit_per_host // num_workers,
             keepalive_timeout=15.0,

--- a/tests/unit_tests/test_aiohttp_heartbeat.py
+++ b/tests/unit_tests/test_aiohttp_heartbeat.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import json
+import time
+
+from aiohttp import ClientSession, ClientTimeout
+
+from nemo_gym.aiohttp_heartbeat import CRLF, HeartbeatTCPConnector
+from nemo_gym.server_utils import GlobalAIOHTTPAsyncClientConfig
+
+
+async def _slow_echo_server(stats: dict):
+    """Minimal HTTP/1.1 server: skips+counts empty lines before a request-line (RFC 9112 §2.2),
+    delays by the JSON 'delay' field, and keeps the connection open for the next request."""
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        stats["conns"] += 1
+        try:
+            while True:
+                line = await reader.readline()
+                while line in (b"\r\n", b"\n"):
+                    stats["stray_crlf"] += 1
+                    line = await reader.readline()
+                if not line:
+                    return
+                head = line
+                while True:
+                    nxt = await reader.readline()
+                    head += nxt
+                    if nxt in (b"\r\n", b""):
+                        break
+                cl = [h for h in head.split(b"\r\n") if h.lower().startswith(b"content-length:")]
+                body = await reader.readexactly(int(cl[0].split(b":")[1])) if cl else b""
+                req = json.loads(body or b"{}")
+                stats["requests"] += 1
+                await asyncio.sleep(req.get("delay", 0))
+                payload = json.dumps({"echo": req.get("message"), "n": stats["requests"]}).encode()
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n" % len(payload)
+                )
+                writer.write(payload)
+                await writer.drain()
+        finally:
+            writer.close()
+
+    return await asyncio.start_server(handle, "127.0.0.1", 0)
+
+
+async def test_heartbeat_keeps_writing_while_request_in_flight_and_connection_stays_reusable():
+    stats = {"stray_crlf": 0, "requests": 0, "conns": 0}
+    server = await _slow_echo_server(stats)
+    port = server.sockets[0].getsockname()[1]
+    beats = []
+    connector = HeartbeatTCPConnector(heartbeat=0.2, on_heartbeat=beats.append, limit=4, keepalive_timeout=30)
+    async with server, ClientSession(connector=connector, timeout=ClientTimeout()) as session:
+        t0 = time.monotonic()
+        async with session.post(f"http://127.0.0.1:{port}/", json={"message": "slow", "delay": 1.0}) as r1:
+            assert await r1.json() == {"echo": "slow", "n": 1}
+        assert 1.0 <= time.monotonic() - t0 < 2.5
+
+        # Heartbeats were written while the response was pending, and the server ignored them.
+        assert connector.heartbeats_sent >= 3
+        assert stats["stray_crlf"] >= 3
+        assert beats and all(isinstance(b, int) and b >= 1 for b in beats)
+
+        # Same connection is still good for the next request.
+        async with session.post(f"http://127.0.0.1:{port}/", json={"message": "fast", "delay": 0}) as r2:
+            assert await r2.json() == {"echo": "fast", "n": 2}
+        assert stats["conns"] == 1
+
+        # No request in flight -> no heartbeats.
+        sent_before_idle = connector.heartbeats_sent
+        await asyncio.sleep(0.5)
+        assert connector.heartbeats_sent == sent_before_idle
+
+
+async def test_heartbeat_disabled_by_default_behaves_like_plain_connector():
+    stats = {"stray_crlf": 0, "requests": 0, "conns": 0}
+    server = await _slow_echo_server(stats)
+    port = server.sockets[0].getsockname()[1]
+    connector = HeartbeatTCPConnector(heartbeat=GlobalAIOHTTPAsyncClientConfig().global_aiohttp_crlf_heartbeat_seconds)
+    async with server, ClientSession(connector=connector, timeout=ClientTimeout()) as session:
+        async with session.post(f"http://127.0.0.1:{port}/", json={"message": "x", "delay": 0.3}) as r:
+            assert r.status == 200
+    assert connector.heartbeats_sent == 0
+    assert stats["stray_crlf"] == 0
+    assert connector._hb_task is None
+
+
+def test_config_default_is_off():
+    assert GlobalAIOHTTPAsyncClientConfig().global_aiohttp_crlf_heartbeat_seconds == 0
+    assert (
+        GlobalAIOHTTPAsyncClientConfig.model_validate(
+            {"global_aiohttp_crlf_heartbeat_seconds": 60}
+        ).global_aiohttp_crlf_heartbeat_seconds
+        == 60
+    )
+
+
+def test_negative_heartbeat_rejected():
+    try:
+        HeartbeatTCPConnector(heartbeat=-1)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
+def test_crlf_constant():
+    assert CRLF == b"\r\n"

--- a/tests/unit_tests/test_aiohttp_heartbeat.py
+++ b/tests/unit_tests/test_aiohttp_heartbeat.py
@@ -110,6 +110,52 @@ def test_config_default_is_off():
     )
 
 
+async def test_beat_yields_between_batches():
+    """A heartbeat pass over many connections must yield to the event loop between batches."""
+    connector = HeartbeatTCPConnector(heartbeat=0, batch_size=4)
+
+    class FakeTransport:
+        writes = 0
+
+        def is_closing(self):
+            return False
+
+        def write(self, data):
+            assert data == CRLF
+            FakeTransport.writes += 1
+
+    class FakeProto:
+        transport = FakeTransport()
+
+    connector._acquired.update(FakeProto() for _ in range(40))  # 40 connections, batch 4 -> 10 batches
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0)
+            ticks += 1
+
+    t = asyncio.create_task(ticker())
+    await asyncio.sleep(0)
+    before = ticks
+    written = await connector._beat_once()
+    t.cancel()
+    assert written == 40 and FakeTransport.writes == 40
+    assert connector.heartbeats_sent == 40
+    assert ticks - before >= 9, f"pass yielded only {ticks - before} times; expected one per batch"
+    connector._acquired.clear()  # fakes are not real protocols; do not let close() touch them
+    await connector.close()
+
+
+def test_batch_size_rejected_below_one():
+    try:
+        HeartbeatTCPConnector(heartbeat=0, batch_size=0)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
 def test_negative_heartbeat_rejected():
     try:
         HeartbeatTCPConnector(heartbeat=-1)


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in CRLF heartbeat** to the global aiohttp client so that long-running, non-streaming model calls survive network intermediaries that drop idle TCP connections. Default off; no behaviour change unless `global_aiohttp_crlf_heartbeat_seconds` is set.

## Why

Some hosted-inference endpoints sit behind intermediaries that close any TCP connection carrying no payload for a fixed period and that ignore TCP keepalive probes. AWS Global Accelerator is the common example: its idle timeout is fixed at 340 s and not configurable ([AWS docs](https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html#about-idle-timeout)). A judge or reward-model call that takes longer than that to produce its first response byte fails with `ServerDisconnectedError` at ~340 s on every retry. Gym already enables TCP keepalive on its sockets; that does not help here because the intermediary does not count keepalive probes.

HTTP/2 clients handle this with PING frames. aiohttp is HTTP/1.1-only, and Gym intentionally standardises on aiohttp (`CLAUDE.md`). The HTTP/1.1 equivalent is to write a bare `CRLF` on the connection while the request is in flight:

- The bytes travel as encrypted TLS records, so the intermediary sees payload and resets its idle timer.
- RFC 9112 §2.2 requires servers to ignore empty lines received before a request-line, so the origin discards them once the pending response is sent and the connection stays reusable. RFC 5626 §4.4.1 standardises the same "CRLF keep-alive technique" for SIP over TCP; nginx, HAProxy and llhttp all skip leading CR/LF.

## How

- `nemo_gym/aiohttp_heartbeat.py`: `HeartbeatTCPConnector(TCPConnector)`. **Exactly one background task per connector, not per connection.** Every `heartbeat` seconds it makes a single pass over the connector's acquired set (requests in flight, including the wait before response headers) and calls `transport.write(b"\r\n")` on each, **yielding to the event loop after every `batch_size` writes (default 128)** so a large pass cannot stall other coroutines. No per-connection tasks, timers or callbacks; idle pooled connections are untouched. `heartbeat=0` makes it identical to `TCPConnector`.
- `nemo_gym/server_utils.py`: new config field `global_aiohttp_crlf_heartbeat_seconds: float = 0`; `set_global_aiohttp_client` builds `HeartbeatTCPConnector(heartbeat=cfg....)` instead of `TCPConnector`. Everything else (socket factory, limits, `request()`, retries, tracing) is unchanged.
- `tests/unit_tests/test_aiohttp_heartbeat.py`: local slow HTTP/1.1 server that counts and skips stray CRLFs. Asserts heartbeats are written while a response is pending, the server ignores them, the body is intact, the same connection serves the next request, nothing is written while idle, and the default is off.

Enable with:

```yaml
global_aiohttp_crlf_heartbeat_seconds: 60
```

## Evidence

Measured against a generic echo endpoint behind AWS Global Accelerator with a 400 s server-side delay, aiohttp 3.14.x, `ClientTimeout()` with no limits (Gym's configuration):

| Client | Result |
|---|---|
| aiohttp HTTP/1.1, unchanged | `ServerDisconnectedError` at 340 s |
| aiohttp HTTP/1.1 + `HeartbeatTCPConnector(heartbeat=60)` | **200 OK** at ~401 s |
| Gym `request()` from this branch, `global_aiohttp_crlf_heartbeat_seconds: 0` (default) | `ServerDisconnectedError` at 340.1 s |
| Gym `request()` from this branch, `global_aiohttp_crlf_heartbeat_seconds: 60` | **200 OK** at 401.2 s, 6 heartbeats sent |
| raw HTTP/1.1 socket + CRLF every 60 s (mechanism check) | 200 OK at 401 s |

Connection reuse was verified after single CRLFs and after a burst of ten CRLFs on the same connection (next request 200). A bare space instead of CRLF breaks the next request (400), so the connector only ever writes CRLF.


## Evidence: instrumented traces

Raw HTTP/1.1 over TLS to an NVCF echo function behind a generic AWS Global Accelerator endpoint (anycast IP redacted), server-side delay 400 s, `nvcf-poll-seconds: 1200`. After each heartbeat the client reads the kernel's `TCP_INFO.bytes_sent` for the socket: each CRLF leaves the host as one 31-byte TLS record. Times are UTC.

**Heartbeat every 60 s: response arrives at 401 s**

```text
00:59:58 connected peer=<Global Accelerator anycast IP> tls=TLSv1.2 alpn=http/1.1 heartbeat=every 60s server_delay=400s
00:59:58 request sent: tcp bytes_sent=1002
01:00:58 t+  60s heartbeat #1: CRLF written; tcp bytes_sent 1002->1033 (+31)
01:01:59 t+ 121s heartbeat #2: CRLF written; tcp bytes_sent 1033->1064 (+31)
01:02:59 t+ 181s heartbeat #3: CRLF written; tcp bytes_sent 1064->1095 (+31)
01:03:59 t+ 241s heartbeat #4: CRLF written; tcp bytes_sent 1095->1126 (+31)
01:05:00 t+ 302s heartbeat #5: CRLF written; tcp bytes_sent 1126->1157 (+31)
01:06:00 t+ 362s heartbeat #6: CRLF written; tcp bytes_sent 1157->1188 (+31)
01:06:39 t+ 401s RESULT: HTTP/1.1 200 OK nvcf-reqid: 0776ae15-20fa-48f7-8a45-910b322bc7f3 body=b'"proof-hb60"' heartbeats=6
```

**Heartbeat off: the accelerator closes the connection at 340 s**

```text
01:06:39 connected peer=<Global Accelerator anycast IP> tls=TLSv1.2 alpn=http/1.1 heartbeat=OFF server_delay=400s
01:06:39 request sent: tcp bytes_sent=1001
01:12:19 t+ 340s RESULT: connection closed by peer (EOF), no response. heartbeats=0
```

Same endpoint, same delay, same client; the only difference is the heartbeat.

## Evidence: does the CRLF ever corrupt a response or the next request?

A concern raised during evaluation was that a CRLF written while a response is still streaming could be read by an intermediary as a pipelined request and cut the body, or make the next request on that connection fail with HTTP 400. Tested end to end against a second production gateway path (a Go `net/http` origin behind an AWS ALB and Global Accelerator; Go's server itself does answer `400` to a bare CRLF ahead of a request-line, so this path is the adversarial case), aiohttp 3.14 + this connector, **one pooled connection** so every request follows the previous request's CRLFs, heartbeat every **0.2 s** (300x the recommended cadence, so CRLFs land mid-body on every request), non-streaming chat completions from a 235B model:

| Arm | Requests | Body size | CRLFs written per request | Complete 200 + valid JSON | Cut bodies / stray 400s / disconnects |
|---|---|---|---|---|---|
| heartbeat 0.2 s | 10 | 25–31 KB | 201–249 | 10 / 10 | 0 |
| heartbeat 0.2 s, top-5 logprobs | 8 | 2.1–2.7 MB | 218–319 | 8 / 8 | 0 |
| control, heartbeat off | 6 | 24–32 KB | 0 | 6 / 6 | 0 |
| control, heartbeat off, logprobs | 4 | 2.1–2.4 MB | 0 | 4 / 4 | 0 |

4,313 CRLFs landed mid-body or ahead of the next request-line on reused connections; every chunked body arrived complete and the following request on the same connection was always accepted. The load balancer discards the empty line before it reaches the origin, as RFC 9112 §2.2 intends.

**Known side effect on AWS ALB (found in the load balancer's own access logs, not visible to the client).** The ALB does not discard a CRLF that arrives while a request is pending; it holds it as the first byte of the *next* request. A real request that follows is accepted (1,947 connection reuses in the 600-concurrent run all returned 200). If the client instead closes that connection while idle, the ALB logs the dangling CRLF as an incomplete request: `elb_status_code 400`, no target, 0 bytes. In the 600-concurrent heartbeat run (2,420 requests, 0 client-side errors) the ALB logged 616 such entries, all when connections went idle at the end of the run and aiohttp's keep-alive cleanup closed them. Nobody receives these 400s; they show up only in the load balancer's 4xx metrics. Operators of an ALB-fronted endpoint should expect roughly one per heartbeat-carrying connection that is closed idle.

## Benchmark: event-loop cost of the heartbeat pass at scale

Addresses the review question about the cost of the pass under load (the earlier "negligible at 16k" wording was not measured; this is).

**Setup.** Client and server in separate pods on separate nodes of a Kubernetes dev cluster, TLS 1.3 over the pod network. The server accepts HTTP/1.1 requests and never answers, so every connection stays acquired (worst case for the heartbeat). The client opens N concurrent `POST`s through the connector and then, for 130 s, an independent coroutine sleeps 10 ms in a loop and records how late it wakes (event-loop lag). Heartbeat interval 60 s (the production value), so two full passes fall in the window. Three variants: heartbeat off (baseline), the unbatched single synchronous pass as first pushed in this PR (since replaced), and the batched pass now in the PR (`batch_size=128`). Passes that ran while connections were still being established are excluded from the pass-time figures. Numbers are from one run each; RSS is the client process's peak resident set after all connections are up.

| In-flight TLS connections | Variant | Process CPU (share of one core) | Loop lag p99 | **Loop lag max** | Steady-state pass time | Client RSS |
|---|---|---|---|---|---|---|
| 16,000 | heartbeat off | 0.4 % | 0.14 ms | 0.7 ms | – | 4.9 GiB |
| 16,000 | unbatched pass (as in commit 1, since replaced) | 0.8 % | 0.15 ms | **257 ms** | 262 ms (blocking) | 4.9 GiB |
| 16,000 | **batched (this PR)** | 0.9 % | 0.14 ms | **8.1 ms** | 320 ms (cooperative) | 4.9 GiB |
| 50,000 | heartbeat off | 0.4 % | 0.15 ms | 1.2 ms | – | 15.2 GiB |
| 50,000 | unbatched pass (as in commit 1, since replaced) | 1.7 % | 0.14 ms | **879 ms** | 763 ms (blocking) | 15.2 GiB |
| 50,000 | **batched (this PR)** | 1.8 % | 0.17 ms | **7.8 ms** | 962 ms (cooperative) | 15.2 GiB |
| 100,000 | heartbeat off | 0.4 % | 0.14 ms | 0.3 ms | – | 30.4 GiB |
| 100,000 | unbatched pass (as in commit 1, since replaced) | 3.5 % | 0.14 ms | **2,095 ms** | 2,064 ms (blocking) | 30.4 GiB |
| 100,000 | **batched (this PR)** | 3.4 % | 6.07 ms | **7.7 ms** | 1,975 ms (cooperative) | 30.4 GiB |

**Reading it.**
- CPU cost is the same for both variants and small: about 3 percentage points of one core at 100k in-flight connections with a 60 s interval (≈ 20 µs of TLS write per connection per pass).
- The unbatched pass blocks the event loop for its whole duration, which grows linearly with concurrency: a quarter second at 16k, over two seconds at 100k. The batched pass caps the stall at one batch, ≈ 8 ms, at every scale tested; the pass itself takes the same total time but other coroutines keep running through it. At 100k the p99 rises to 6 ms because a 2 s pass of 780 slices covers ~3 % of the observation window.
- **Memory: the heartbeat adds no measurable memory.** RSS is identical across off/original/batched at every scale (differences of a few MiB). The ~300 KiB per idle TLS connection is aiohttp plus OpenSSL state and is present with the heartbeat off. The connector holds one task and one counter per connector and no per-connection state.
- Where it broke: only the test harness, on memory. Client and server together exceed 40 GiB at 100k, which is why they were split into two pods; the heartbeat itself ran to 100k without error.

**Machine.** Client pod on a `c5.9xlarge` node (Intel Xeon Platinum 8124M @ 3.00 GHz, 36 logical CPUs; pod limited to 16 CPUs / 52 GiB), Ubuntu 24.04, kernel 6.14, Kubernetes 1.34. Python 3.13.15, aiohttp 3.14.3, OpenSSL 3.5.7. Loop lag sampled by a 10 ms ticker on the same event loop as the connector, as it would be in a Gym server process.

Benchmark scripts (`bench_beat.py`, `tls_hold_server.py`) are available on request.

## Notes for reviewers

- Uses three aiohttp internals: `BaseConnector._create_connection`, `BaseConnector._acquired`, `ResponseHandler.transport`. Verified on 3.14.x; the unit test guards them.
- Cost: see the benchmark section above. One pass per interval, ~16–20 µs of TLS write per in-flight connection; the batching keeps the worst-case event-loop stall to one batch (~8 ms measured) instead of the whole pass.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally (`tests/unit_tests/test_aiohttp_heartbeat.py`; passes together with `test_server_utils.py`).
- [x] Pre-commit checks pass locally (`pre-commit run --files ...`: end-of-file, trailing whitespace, ruff, ruff-format all Passed).
- [x] All commits have DCO sign-off (`git commit -s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




