### PR TITLE
perf: use ORJSONResponse by default on hot-path servers

### DIFF
--- a/nemo_gym/base_resources_server.py
+++ b/nemo_gym/base_resources_server.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -146,7 +147,7 @@ class SimpleResourcesServer(BaseResourcesServer, AggregateMetricsMixin, SimpleSe
     config: BaseResourcesServerConfig
 
     def setup_webserver(self) -> FastAPI:
-        app = FastAPI()
+        app = FastAPI(default_response_class=ORJSONResponse)
 
         self.setup_session_middleware(app)
         app.add_middleware(RolloutContextMiddleware)

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -43,7 +43,7 @@ from uuid import uuid4
 import orjson
 from fastapi import Body, FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import StreamingResponse
+from fastapi.responses import ORJSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from nemo_gym.anthropic_converter import AnthropicConverter
@@ -195,7 +195,7 @@ class BaseResponsesAPIModel(BaseServer):
 
 class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
     def setup_webserver(self) -> FastAPI:
-        app = FastAPI()
+        app = FastAPI(default_response_class=ORJSONResponse)
 
         self.setup_session_middleware(app)
         capture_config = ModelCallCaptureConfig.model_validate(self.server_client.global_config_dict)

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -48,7 +48,7 @@ from anyio import create_task_group
 from fastapi import FastAPI, Request, Response
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, ORJSONResponse
 from multidict import CIMultiDict
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
@@ -1097,7 +1097,7 @@ class HeadServer(BaseServer):
     _cached_yaml: Optional[str] = None
 
     def setup_webserver(self) -> FastAPI:
-        app = FastAPI()
+        app = FastAPI(default_response_class=ORJSONResponse)
 
         self.setup_liveness(app)
         app.get("/global_config_dict_yaml")(self.global_config_dict_yaml)


### PR DESCRIPTION
## Summary
- Sets `default_response_class=ORJSONResponse` on the FastAPI apps for `HeadServer`, `SimpleResourcesServer` (verify) and `SimpleResponsesAPIModel` (chat_completions/responses) so non-streaming JSON responses serialize with `orjson` instead of stdlib `json`.
- `orjson` is already a project dependency and `get_response_json()` already parses every client-side response with `orjson.loads`, so this makes the server side symmetric with the client rather than introducing a new dependency.
- Streaming responses (`StreamingResponse`/SSE) are unaffected — `default_response_class` only applies to handlers that don't explicitly return a `Response`.

## Test plan
- [x] `pytest tests/unit_tests/test_server_utils.py tests/unit_tests/test_base_resources_server.py tests/unit_tests/test_base_responses_api_model.py` — 122/122 pass
- [ ] Confirm no downstream consumer relies on the exact byte-for-byte formatting of stdlib `json` output (e.g. key ordering, NaN/Infinity floats — `orjson` rejects non-finite floats where stdlib `json` silently emits non-standard `NaN`/`Infinity` tokens)