### PR TITLE
release: drop pre-release tag for v0.6.0

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -17,7 +17,7 @@
 MAJOR = 0
 MINOR = 6
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
## Summary

- Drops `PRE_RELEASE = "rc0"` → `""` in `nemo_gym/package_info.py` so the version resolves to `0.6.0`
