### PR TITLE
fix(environments): preserve Hugging Face cache during prepare

### DIFF
--- a/environments/calendar/prepare.py
+++ b/environments/calendar/prepare.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 import argparse
+import shutil
 from pathlib import Path
 
 
@@ -43,7 +44,7 @@ def prepare(split: str) -> None:
     output_path = Path(__file__).parent / "data" / ARTIFACTS[split]
     output_path.parent.mkdir(parents=True, exist_ok=True)
     downloaded = hf_hub_download(repo_id=REPO_ID, filename=ARTIFACTS[split], repo_type="dataset")
-    Path(downloaded).rename(output_path)
+    shutil.copyfile(downloaded, output_path)
     print(f"Wrote {output_path}")
 
 

--- a/environments/calendar_v2/prepare.py
+++ b/environments/calendar_v2/prepare.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 import argparse
+import shutil
 from pathlib import Path
 
 
@@ -43,7 +44,7 @@ def prepare(split: str) -> None:
     output_path = Path(__file__).parent / "data" / ARTIFACTS[split]
     output_path.parent.mkdir(parents=True, exist_ok=True)
     downloaded = hf_hub_download(repo_id=REPO_ID, filename=ARTIFACTS[split], repo_type="dataset")
-    Path(downloaded).rename(output_path)
+    shutil.copyfile(downloaded, output_path)
     print(f"Wrote {output_path}")
 
 

--- a/environments/code_gen/prepare.py
+++ b/environments/code_gen/prepare.py
@@ -20,6 +20,7 @@ Usage:
 """
 
 import argparse
+import shutil
 from pathlib import Path
 
 
@@ -46,7 +47,7 @@ def prepare(split: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     downloaded = hf_hub_download(repo_id=REPO_ID, filename=ARTIFACTS[split], repo_type="dataset")
-    Path(downloaded).rename(output_path)
+    shutil.copyfile(downloaded, output_path)
     print(f"Wrote {output_path}")
 
 

--- a/tests/unit_tests/test_environment_prepare.py
+++ b/tests/unit_tests/test_environment_prepare.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module_name", "split", "artifact", "output_name"),
+    [
+        ("environments.calendar.prepare", "train", "train.jsonl", "train.jsonl"),
+        ("environments.calendar_v2.prepare", "validation", "validation.jsonl", "validation.jsonl"),
+        (
+            "environments.code_gen.prepare",
+            "validation",
+            "validation.jsonl",
+            "livecodebench_v5_2024-07-01_2025-02-01_validation.jsonl",
+        ),
+    ],
+)
+def test_huggingface_prepare_copies_without_consuming_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    split: str,
+    artifact: str,
+    output_name: str,
+) -> None:
+    source = tmp_path / "cache" / artifact
+    source.parent.mkdir()
+    source.write_text('{"task": 1}\n', encoding="utf-8")
+    download = Mock(return_value=str(source))
+    monkeypatch.setitem(sys.modules, "huggingface_hub", SimpleNamespace(hf_hub_download=download))
+    module = importlib.import_module(module_name)
+    monkeypatch.setattr(module, "__file__", str(tmp_path / "environment" / "prepare.py"))
+    output = tmp_path / "environment" / "data" / output_name
+
+    module.prepare(split)
+
+    assert output.read_bytes() == source.read_bytes()
+    assert source.read_text(encoding="utf-8") == '{"task": 1}\n'
+    source.write_text('{"task": 2}\n', encoding="utf-8")
+
+    module.prepare(split)
+
+    assert output.read_text(encoding="utf-8") == '{"task": 2}\n'
+    assert source.read_text(encoding="utf-8") == '{"task": 2}\n'
+    assert download.call_count == 2
+    download.assert_called_with(repo_id=module.REPO_ID, filename=artifact, repo_type="dataset")


### PR DESCRIPTION
## Summary

- audit `environments/` configuration, preparation entrypoints, source-row shape, and representative simple/stateful/external-harness compositions for [MB-1553](https://linear.app/nvidia/issue/MB-1553/nemo-gym-repository-worktree-reorganization-proposal)
- preserve Hugging Face Hub cache artifacts in the `calendar`, `calendar_v2`, and `code_gen` preparation paths by copying downloads into the environment data directory instead of moving cache files
- add behavior-level regression coverage for cache preservation, destination content, repeat preparation, split-to-artifact mapping, and `code_gen`'s differing remote/local validation filenames

## Audit scope and findings

Representative review covered:

- simple single-turn verifier: `environments/code_gen`
- stateful/tool environment: `environments/calendar_v2`
- external harness/agent compositions: `environments/aviary_bixbench` and `environments/codex_math`

Systematic checks covered all 47 YAML files, all 49 `prepare.py` entrypoints, and 226 rows across the 45 committed source JSONL files under `environments/`:

- strict duplicate-key YAML load: no failures
- component `entrypoint` references: all referenced files exist
- dataset paths: committed examples exist; missing generated/remote datasets are gitignored
- source JSONL: all rows parse and have a supported string/list `responses_create_params.input`
- Python compilation: every Python file under `environments/` compiles under the available Python 3.12.10 fallback

The actionable uncovered defect was three uses of `Path.rename()` on the path returned by `hf_hub_download()`. That path belongs to Hugging Face's shared cache. Moving it consumes the cache artifact, and a cache located on another filesystem raises `EXDEV`. `shutil.copyfile()` preserves the source/cache contract and retains the existing destination filenames and CLI behavior.

## Related in-flight work

This PR intentionally avoids duplicating two broad existing efforts:

- #2732 owns dataset-to-agent decoupling, including `agent_ref` removal and dataset ownership moves throughout `environments/`.
- #3123 updates the stale repo-local `add-benchmark` skill to the current manifest-backed onboarding flow and adds semantic consistency tests. The current main-branch skill and the #3123 version both pass `skill-creator` structural validation; semantic review confirms #3123 is the needed contract update.

Neither PR covers the Hugging Face cache-consumption bug fixed here.

## Validation

- `PYTHONPATH=. /home/yuya/mypython/bin/python -m pytest tests/unit_tests/test_environment_prepare.py tests/unit_tests/test_environment_tombstones.py -q` — **9 passed**
- `pre-commit run --files environments/calendar/prepare.py environments/calendar_v2/prepare.py environments/code_gen/prepare.py tests/unit_tests/test_environment_prepare.py` — **passed**
- `/home/yuya/mypython/bin/python -m compileall -q environments` — **passed**
- `ruff check` and `ruff format --check` on all changed files — **passed**
- `skill-creator/scripts/quick_validate.py` against both main's and #3123's `add-benchmark` skill — **passed** structurally
- live unauthenticated Hugging Face validation downloads for both calendar datasets — prepared outputs were byte-identical to cached artifacts and both cache artifacts remained present (2,156,971 and 3,443,738 bytes)

Attempted broader registry tests could not collect because the fallback environment does not contain Ray. The repository pins Python 3.13.14, which is unavailable on this machine (`uv` cannot locate it); the available Python 3.12.10 fallback was used for the focused checks above. CI remains authoritative for the supported Python version and full suite.

## Rollouts

No model rollout was run: this change affects only dataset preparation before rollout, and a model rollout over committed examples does not execute the modified download path. The modified external call/result path was instead exercised directly against two real Hugging Face datasets, in addition to mocked repeatable behavior tests.

## Independent review

- Compared the branch with `origin/main`, the MB-1553 cache-preservation requirement, sibling preparation scripts, and the Hugging Face Hub cache contract. No additional code/API/result-contract finding was found.
- The repository's rollout gate is **not yet satisfied**: no usable model endpoint or OpenAI/NVIDIA credential is available locally, so no representative model rollout was run or inspected. Live Hugging Face download/preparation checks are I/O evidence only and are not a rollout.
- Keep this PR in draft until a representative real-model rollout and agent/verifier inspection are attached.
