### PR TITLE
[ApexAgents] Serve GLM-5.2 with CUDA graphs, pin replicas to one rack, tolerate partial readiness

### DIFF
--- a/scripts/launch_apex_agents_glm52_bf16_unified.sh
+++ b/scripts/launch_apex_agents_glm52_bf16_unified.sh
@@ -41,11 +41,14 @@ export APEX_GYM_DIR
 # This is a model-specific launcher: never inherit another launcher's profile.
 export PROFILE=${APEX_GYM_DIR}/scripts/profiles/apex-glm52-bf16.env
 export GLM52_NUM_NODES=${NODES}
-# Eager execution is the validated path for this launcher. It avoids both the
-# Blackwell TorchInductor autotuning failure seen at DP16 and the compiled/
-# CUDA-graph rank divergence seen in the reduced-node canary. Callers may set
-# GLM52_ENFORCE_EAGER=false explicitly for a separate performance experiment.
-export GLM52_ENFORCE_EAGER=${GLM52_ENFORCE_EAGER:-true}
+# Default: CUDA graphs without Inductor (GLM52_CUDAGRAPH_MODE=PIECEWISE in the
+# serve script). Eager execution avoided the Blackwell TorchInductor autotuning
+# failure, but decodes at ~4.8 tok/s per stream and turned most rollouts into
+# 12600 s timeouts; PIECEWISE graphs skip Inductor entirely and measured ~20 tok/s
+# per stream on the full 452 x 3 benchmark. Set GLM52_ENFORCE_EAGER=true to fall
+# back to the eager path.
+export GLM52_ENFORCE_EAGER=${GLM52_ENFORCE_EAGER:-false}
+export GLM52_CUDAGRAPH_MODE=${GLM52_CUDAGRAPH_MODE:-PIECEWISE}
 export DATASET=${DATASET:-${APEX_GYM_DIR}/benchmarks/apex_agents/data/apex_agents_benchmark.jsonl}
 export GYM_CONFIG=${GYM_CONFIG:-${APEX_GYM_DIR}/env.yaml}
 export CONCURRENCY NUM_REPEATS
@@ -72,6 +75,22 @@ unset NEMO_GYM_CONFIG_DICT NEMO_GYM_CONFIG_PATH SBATCH_DEPENDENCY
 
 mkdir -p "${RUN_DIR}/logs" "${APEX_GYM_DIR}/results/slurm-logs"
 
+# Rack locality: --segment=<nodes per replica> makes Slurm place the replica's
+# node group inside one NVL72 block. --switches=1 alone is a soft preference that
+# Slurm drops after its wait budget, and every rack-straddling replica we ran died
+# at its first decode step (sample_tokens RPC timeout, engine dead) while rack-local
+# replicas stayed healthy. This launcher runs one Ray-DP replica across all nodes,
+# so the segment defaults to NODES; SBATCH_SEGMENT=none disables it.
+SBATCH_SEGMENT=${SBATCH_SEGMENT:-${NODES}}
+[[ "${SBATCH_SEGMENT}" == "none" || "${SBATCH_SEGMENT}" =~ ^[1-9][0-9]*$ ]] || {
+    echo "ERROR: SBATCH_SEGMENT must be a positive integer or 'none'" >&2
+    exit 64
+}
+placement_args=(--switches=1)
+if [[ "${SBATCH_SEGMENT}" != "none" ]]; then
+    placement_args+=(--segment="${SBATCH_SEGMENT}")
+fi
+
 bash "${BATCH_SCRIPT}" --validate
 if [[ "${VALIDATE_ONLY:-false}" == "true" ]]; then
     echo "Validation-only mode passed; no Slurm job was submitted."
@@ -90,7 +109,7 @@ job_id=$(
         --partition="${SBATCH_PARTITION:-batch}" \
         --qos="${SBATCH_QOS:-normal}" \
         --time="${WALLTIME:-04:00:00}" \
-        --switches=1 \
+        "${placement_args[@]}" \
         --output="${RUN_DIR}/logs/%j_rollout.out" \
         --error="${RUN_DIR}/logs/%j_rollout.err" \
         --export=ALL \

--- a/scripts/run_apex_agents_k3_unified.sbatch
+++ b/scripts/run_apex_agents_k3_unified.sbatch
@@ -552,8 +552,15 @@ run_main() {
         (( alive > 0 )) || die "all ${POLICY_LABEL} serving processes exited before readiness"
         sleep 10
     done
-    (( ${#policy_urls[@]} == N_REPLICAS )) ||
-        die "${POLICY_LABEL} readiness timed out (${#policy_urls[@]}/${N_REPLICAS} replicas ready)"
+    if (( ${#policy_urls[@]} == 0 )); then
+        die "${POLICY_LABEL} readiness timed out (0/${N_REPLICAS} replicas ready)"
+    elif (( ${#policy_urls[@]} < N_REPLICAS )); then
+        # A replica that never initializes (NCCL init timeout on one node group, a
+        # stale listener on a reused node) used to kill the whole rotation after the
+        # full wait. The balancer only routes to the ready backends, so continue on
+        # that subset and let the requeue path pick up the rest.
+        log "WARNING: ${POLICY_LABEL} readiness timed out with ${#policy_urls[@]}/${N_REPLICAS} replicas ready; continuing on the ready subset."
+    fi
 
     local url served
     for url in "${policy_urls[@]}"; do

--- a/scripts/serve_apex_glm52_bf16_replica.sh
+++ b/scripts/serve_apex_glm52_bf16_replica.sh
@@ -48,6 +48,7 @@ VLLM_CACHE_ROOT=${VLLM_CACHE_ROOT:-${CACHE_ROOT}/vllm}
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-300}
 GLM52_WARMUP_MAX_TOKENS=${GLM52_WARMUP_MAX_TOKENS:-256}
 GLM52_ENFORCE_EAGER=${GLM52_ENFORCE_EAGER:-false}
+GLM52_CUDAGRAPH_MODE=${GLM52_CUDAGRAPH_MODE:-PIECEWISE}
 
 require_positive_int API_PORT "${API_PORT}"
 require_positive_int BASE_RAY_PORT "${BASE_RAY_PORT}"
@@ -63,6 +64,8 @@ require_positive_int VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS "${VLLM_EXECUTE_MODEL_TI
 require_positive_int GLM52_WARMUP_MAX_TOKENS "${GLM52_WARMUP_MAX_TOKENS}"
 [[ "${GLM52_ENFORCE_EAGER}" == "true" || "${GLM52_ENFORCE_EAGER}" == "false" ]] ||
     die "GLM52_ENFORCE_EAGER must be true or false; got ${GLM52_ENFORCE_EAGER}"
+[[ "${GLM52_CUDAGRAPH_MODE}" == "PIECEWISE" || "${GLM52_CUDAGRAPH_MODE}" == "FULL_DECODE_ONLY" ]] ||
+    die "GLM52_CUDAGRAPH_MODE must be PIECEWISE or FULL_DECODE_ONLY; got ${GLM52_CUDAGRAPH_MODE}"
 
 (( DATA_PARALLEL_SIZE % DATA_PARALLEL_SIZE_LOCAL == 0 )) ||
     die "DATA_PARALLEL_SIZE must be divisible by DATA_PARALLEL_SIZE_LOCAL"
@@ -95,7 +98,7 @@ rm -f "${server_info_file}" "${server_info_file}.tmp" "${head_ip_file}"
 export API_PORT API_SERVER_COUNT BASE_RAY_PORT CACHE_ROOT CONTAINER_IMAGE DATA_PARALLEL_SIZE
 export DATA_PARALLEL_SIZE_LOCAL GPU_MEMORY_UTILIZATION HF_HOME MAX_MODEL_LEN MODEL_NAME MODEL_PATH
 export OUTPUT_DIR PIPELINE_PARALLEL_SIZE RAY_PORT="${ray_port}" TENSOR_PARALLEL_SIZE VLLM_CACHE_ROOT
-export GLM52_ENFORCE_EAGER GLM52_WARMUP_MAX_TOKENS VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+export GLM52_ENFORCE_EAGER GLM52_CUDAGRAPH_MODE GLM52_WARMUP_MAX_TOKENS VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
 export VLLM_LOG="${vllm_log}"
 
 step_pid=""
@@ -113,7 +116,7 @@ trap cleanup EXIT INT TERM
 
 log "nodes=${REPLICA_NODES}; head=${head_host} (${head_ip}); API=${server_url}"
 log "TP=${TENSOR_PARALLEL_SIZE}, PP=${PIPELINE_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, DPL=${DATA_PARALLEL_SIZE_LOCAL}"
-log "eager=${GLM52_ENFORCE_EAGER}; execute-model timeout=${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS}s; warm-up tokens=${GLM52_WARMUP_MAX_TOKENS}"
+log "eager=${GLM52_ENFORCE_EAGER}; cudagraph mode=${GLM52_CUDAGRAPH_MODE}; execute-model timeout=${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS}s; warm-up tokens=${GLM52_WARMUP_MAX_TOKENS}"
 
 srun --overlap --exact \
     --nodes="${node_count}" \
@@ -208,15 +211,39 @@ srun --overlap --exact \
             unset VLLM_PORT
             echo "Starting GLM-5.2 BF16 vLLM server on port ${serve_port}"
             # Blackwell startup has independent FlashInfer and TorchInductor
-            # autotuners. Disable both problematic benchmark paths while
-            # retaining ordinary Inductor compilation and CUDA graphs.
-            compilation_config="{\"inductor_compile_config\": {\"combo_kernels\": false, "
-            compilation_config+="\"benchmark_combo_kernel\": false}, "
-            compilation_config+="\"pass_config\": {\"fuse_allreduce_rms\": false}}"
+            # autotuners. GLM52_ENFORCE_EAGER=true keeps the eager path: no CUDA
+            # graphs, ~4.8 tok/s per stream at batch 4-5, and most 12600 s rollout
+            # timeouts come from that speed. The default captures CUDA graphs
+            # WITHOUT Inductor; GLM52_CUDAGRAPH_MODE selects how:
+            #   PIECEWISE        torch.compile with the eager backend (no Inductor
+            #                    codegen); attention and the MoE all-to-all stay
+            #                    outside the graphs, so DP+EP ranks never capture a
+            #                    cross-rank collective. ~20 tok/s per stream on
+            #                    TP=4 x DP=4 replicas.
+            #   FULL_DECODE_ONLY no compile, whole decode step captured. Faster
+            #                    still, but hung a DP=4+EP replica on its first
+            #                    step (sample_tokens RPC timeout, NCCL timeout).
             execution_args=()
             if [[ "${GLM52_ENFORCE_EAGER}" == "true" ]]; then
                 echo "DP=${DATA_PARALLEL_SIZE}: forcing eager execution"
+                compilation_config="{\"inductor_compile_config\": {\"combo_kernels\": false, "
+                compilation_config+="\"benchmark_combo_kernel\": false}, "
+                compilation_config+="\"pass_config\": {\"fuse_allreduce_rms\": false}}"
                 execution_args+=(--enforce-eager)
+            else
+                echo "DP=${DATA_PARALLEL_SIZE}: CUDA graphs without Inductor (${GLM52_CUDAGRAPH_MODE})"
+                case "${GLM52_CUDAGRAPH_MODE}" in
+                    PIECEWISE)
+                        compilation_config="{\"mode\": 3, \"backend\": \"eager\", \"cudagraph_mode\": \"PIECEWISE\", "
+                        compilation_config+="\"pass_config\": {\"fuse_allreduce_rms\": false}}" ;;
+                    FULL_DECODE_ONLY)
+                        compilation_config="{\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\", "
+                        compilation_config+="\"pass_config\": {\"fuse_allreduce_rms\": false}}" ;;
+                    *)
+                        echo "ERROR: GLM52_CUDAGRAPH_MODE must be PIECEWISE or FULL_DECODE_ONLY; got ${GLM52_CUDAGRAPH_MODE}" >&2
+                        ray stop || true
+                        exit 1 ;;
+                esac
             fi
             vllm serve "${MODEL_PATH}" \
                 --enable-log-requests \


### PR DESCRIPTION
Three operational changes from running the full Apex Agents benchmark (452 tasks x 3) against GLM-5.2 BF16 on HSG.

**`scripts/serve_apex_glm52_bf16_replica.sh`**: when `GLM52_ENFORCE_EAGER=false`, capture CUDA graphs without Inductor instead of the Inductor compile path. New `GLM52_CUDAGRAPH_MODE` (`PIECEWISE` default, `FULL_DECODE_ONLY` opt-in). PIECEWISE uses `torch.compile` with the eager backend, so attention and the MoE all-to-all stay outside the graphs and DP+EP ranks never capture a cross-rank collective. FULL_DECODE_ONLY is faster on paper but hung a DP=4+EP replica on its first decode step (`sample_tokens` RPC timeout, then NCCL timeout).

**`scripts/launch_apex_agents_glm52_bf16_unified.sh`**: default `GLM52_ENFORCE_EAGER=false` and add `--segment` (env `SBATCH_SEGMENT`, default `NODES`, `none` to disable) next to `--switches=1`. `--switches` is a soft preference that Slurm drops after its wait budget; every replica that ended up straddling two NVL72 racks died at its first decode step, every rack-local one stayed healthy.

**`scripts/run_apex_agents_k3_unified.sbatch`**: after the readiness wait, continue on the ready replica subset and only `die` when zero replicas came up. A replica that never initializes (NCCL init timeout on one node group, stale listener on a reused node) used to kill the whole rotation after the full 3600 s wait; the balancer already routes only to ready backends.

**Measured** (same harness, same judge, PIECEWISE vs `--enforce-eager`, TP=4 x DP=4 replicas):

| | eager | PIECEWISE graphs |
|---|---|---|
| decode per stream | 4.8 tok/s | 20 tok/s |
| median LLM turn | 98 s | 27 s |
| median rollout wall | 170 min | 48 min |
| attempts ending in the 12600 s timeout | 44% | 12% |
| completed rollouts per node-hour | 0.6 | 3.5 |
