### PR TITLE
docs: standardize verification task data convention

### DIFF
--- a/fern/versions/latest/pages/data/index.mdx
+++ b/fern/versions/latest/pages/data/index.mdx
@@ -27,7 +27,11 @@ Each JSONL line requires a `responses_create_params` field following the [OpenAI
 {"responses_create_params": {"input": [{"role": "user", "content": "What is 2+2?"}]}}
 ```
 
-Additional fields like `expected_answer` vary by resources server—the component that provides tools and reward signals.
+Task-owned fields such as `expected_answer` vary by resources server—the component that provides tools and reward signals. Inspect that server's typed schema instead of copying another environment's row shape:
+
+```bash
+gym env schema --resources-server <name>
+```
 
 ### Required Fields
 
@@ -36,18 +40,22 @@ Additional fields like `expected_answer` vary by resources server—the componen
 | `responses_create_params` | User | Input to the model during training. Contains `input` (messages) and optional `tools`, `temperature`, etc. |
 | `agent_ref` | `gym dataset collate` | Routes each row to its agent server. Auto-generated during data preparation. |
 
-### Optional Fields
+### Task-Owned Fields
 
-| Field | Description |
-|-------|-------------|
-| `expected_answer` | Ground truth for verification (task-specific). |
-| `question` | Original question text (for reference). |
-| `id` | Tracking identifier. |
+Fields such as `expected_answer`, `question`, and task identifiers are not globally defined optional fields. Each resources server declares its own flat `TaskData` schema in `resources_servers/<name>/task_data.py`. The schema describes types and required fields regardless of how an older runtime request carries them.
 
-<Tip>
-Check `resources_servers/<name>/README.md` for fields required by each resources server's `verify()` method.
+Use the placement shown by the selected server's data and schema:
 
-</Tip>
+- Put fields at the row top level when the server request model reads them there.
+- Use `verifier_metadata` only when the current server contract reads those fields exclusively from that legacy container.
+- Do not provide the same field in both locations. Equal duplicates are unnecessary; conflicting values are ambiguous and fail task-data validation.
+- Do not infer one server's contract from another server. Run `gym env schema --resources-server <name>` before preparing data.
+
+During migration, a field read exclusively from `verifier_metadata` is marked `legacy_location: verifier_metadata` in the flat `TaskData` schema. This marker lets validation detect a top-level field that the current server would not receive. It does not make `verifier_metadata` the default for new fields.
+
+<Note>
+`verifier_metadata` describes task-owned inputs to verification, not rollout provenance or framework control data. Keep framework-owned fields such as `responses_create_params` and `agent_ref` outside it.
+</Note>
 
 ### The `agent_ref` Field
 

--- a/fern/versions/latest/pages/data/prepare-validate.mdx
+++ b/fern/versions/latest/pages/data/prepare-validate.mdx
@@ -65,7 +65,13 @@ NeMo Gym uses JSONL files. Each line requires a `responses_create_params` field 
 
 ### With Verification Fields
 
-Most resources servers add fields for reward computation:
+Verification fields are task-owned and specific to the selected resources server. Inspect its typed schema first:
+
+```bash
+gym env schema --resources-server <name>
+```
+
+A server that reads `question` and `expected_answer` at the row top level accepts rows such as:
 
 ```json
 {
@@ -77,9 +83,21 @@ Most resources servers add fields for reward computation:
 }
 ```
 
-<Tip>
-Check `resources_servers/<name>/README.md` for required fields specific to each resources server.
+Some existing servers instead read task fields from the legacy `verifier_metadata` container. Their schema marks those fields with `legacy_location: verifier_metadata`, and their committed data uses this form:
 
+```json
+{
+  "responses_create_params": {
+    "input": [{"role": "user", "content": "What is the weather in Paris?"}]
+  },
+  "verifier_metadata": {"expected_city": "Paris"}
+}
+```
+
+Do not duplicate a field at the top level and inside `verifier_metadata`. Conflicting duplicates fail validation; equal duplicates add no information. Use the placement required by the selected server until its runtime request contract is migrated.
+
+<Tip>
+The flat schema is authoritative for field names, types, and requiredness. The `legacy_location` annotation records only where the current wire contract expects a field.
 </Tip>
 
 ### Key Properties

--- a/fern/versions/latest/pages/environment-tutorials/resources-server-apis.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/resources-server-apis.mdx
@@ -103,8 +103,52 @@ async def verify(
 - **`body` in `seed_session()`** contains fields used to initialize an episode. Define a `BaseSeedSessionRequest` subclass for fields such as an initial board, task ID, or sandbox image. The default implementation is a no-op.
 - **`body.responses_create_params` in `verify()`** is the original model request.
 - **`body.response` in `verify()`** is the completed `NeMoGymResponse`, including the trajectory assembled by the Agent Server.
-- **Custom task metadata** requires a `BaseVerifyRequest` subclass. Declare fields such as `answer` or `expected_state`; undeclared fields are not retained by the base Pydantic model.
+- **Custom task data** requires a `BaseVerifyRequest` subclass. Declare fields such as `answer` or `expected_state`; undeclared fields are not retained by the base Pydantic model. Also declare the dataset-facing fields once in a flat `TaskData` schema so data tooling can validate them without starting the server.
 - **`request: Request`**, when added to either method signature, provides access to the per-rollout session ID.
+
+### Verification Data Convention
+
+A resources server owns the schema for task-specific inputs used by `seed_session()`, tools, or `verify()`. Define that schema in `resources_servers/<name>/task_data.py` as a Pydantic model named `TaskData`:
+
+```python
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    expected_answer: str = Field(
+        description="Reference answer used by verify().",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+```
+
+Keep `TaskData` flat even if an existing wire request receives a field inside `verifier_metadata`. A server whose current request model reads a field exclusively from that legacy container records the placement explicitly:
+
+```python
+expected_answer: str = Field(
+    json_schema_extra={
+        "consumed_by": ["verify"],
+        "legacy_location": "verifier_metadata",
+    }
+)
+```
+
+Use these rules:
+
+1. Define field names, types, and requiredness once in the flat `TaskData` schema.
+2. Put new task fields at the row top level unless an existing request contract requires the legacy `verifier_metadata` container.
+3. Add `legacy_location: verifier_metadata` only when the current wire reads the field exclusively there. Do not add it if a request validator accepts both placements.
+4. Never choose between conflicting top-level and nested values. Task-data validation reports the row as ambiguous.
+5. Keep framework fields such as `responses_create_params` out of `TaskData`, and keep runtime-generated values out of dataset rows.
+
+Dataset authors can inspect the contract without importing the resources server's runtime dependencies:
+
+```bash
+gym env schema --resources-server <name>
+```
+
+The legacy marker is a migration map, not a second definition of the field. This keeps current servers usable while providing one typed shape for collation, schema inspection, and future row-format migration.
 
 ### Direct HTTP Tool-Calling Protocol
 


### PR DESCRIPTION
## Summary

- define one verification task-data convention for dataset and resources-server authors
- document flat `TaskData` as the authoritative field/type schema
- limit `verifier_metadata` to existing wire contracts that read fields exclusively from that legacy container
- document `legacy_location`, duplicate/conflict behavior, and `gym env schema`

Closes #1342.

## Why this generalizes

The previous docs presented `expected_answer`, `question`, and `id` as globally optional top-level fields while other guides used `verifier_metadata`. That ambiguity applies to every verifier and forces users to inspect server implementation details.

Current `main` already provides the general contract through #2795, #2827, and #2800: every shipped resources server has a dependency-light flat `TaskData` schema; normalization understands current top-level, legacy-nested, and future `task_data` forms; `legacy_location` records the current wire placement; and validation detects misplaced or conflicting fields. This PR documents those existing mechanics rather than adding a competing schema or changing environment behavior.

Independent integration evidence also found that verifier behavior and inputs need explicit identity for reliable offline replay. A single typed task-data definition is a prerequisite for that work, but this PR does not prescribe any benchmark's scoring policy.

## Compatibility

Documentation only. Existing datasets and request models are unchanged. The guidance explicitly preserves legacy `verifier_metadata` placement where a current server requires it.

## Validation

- `cd fern && npm run check` — **0 errors** (one pre-existing/unspecified warning)
- `uv run --extra dev pytest tests/unit_tests/test_task_data.py -q` — **305 passed**
- `git diff --check` — **passed**
- `uv run pre-commit run --files <three changed MDX files>` — **passed** (hooks skip MDX as configured)

The focused unit suite validates the documented properties, including flat-schema normalization, legacy nested rows, conflicting duplicates, misplaced legacy fields, dependency-light schema imports, all shipped schemas, and all committed rows.
