### PR TITLE
fix(swe_pivot): a tool call missing its command argument is not a match

### DIFF
--- a/resources_servers/swe_pivot/app.py
+++ b/resources_servers/swe_pivot/app.py
@@ -317,6 +317,11 @@ def verify_target_match(
         # Check editor sub-command first (view vs str_replace vs create)
         r_cmd = extract_editor_command(rollout_args)
         e_cmd = extract_editor_command(expected_args)
+        if bool(r_cmd) != bool(e_cmd):
+            # One side has an editor command and the other lost it (e.g. the
+            # tool parser dropped a '<parametercommand>' header): not the same
+            # action. See the bash branch below.
+            return False
         if r_cmd and e_cmd and r_cmd != e_cmd:
             return False
         # Check target file (last 2 path components to avoid basename collisions)
@@ -343,6 +348,12 @@ def verify_target_match(
     if rollout_cat == "bash" and expected_cat == "bash":
         r_cmd = extract_command(rollout_args)
         e_cmd = extract_command(expected_args)
+        # A bash call whose command argument is missing cannot be the same
+        # action as one that has a command. vLLM's tool parser silently drops
+        # a parameter whose header lost its '=' ('<parametercommand>'), which
+        # used to fall through every check below and score full credit.
+        if bool(r_cmd) != bool(e_cmd):
+            return False
         # Check command verb matches (grep vs pytest vs cd)
         r_verb = extract_command_verb(r_cmd)
         e_verb = extract_command_verb(e_cmd)
@@ -431,7 +442,9 @@ def compute_argument_similarity(
         e_cmd = extract_command(expected_args)
         if r_cmd and e_cmd:
             return _capped_similarity(r_cmd, e_cmd)
-        return 1.0
+        # Both empty: nothing to compare. One empty: the rollout dropped (or
+        # invented) the command, which must not score as a perfect match.
+        return 1.0 if not r_cmd and not e_cmd else 0.0
 
     return 1.0  # non-edit/bash, similarity not applicable
 

--- a/resources_servers/swe_pivot/tests/test_verifier.py
+++ b/resources_servers/swe_pivot/tests/test_verifier.py
@@ -708,3 +708,40 @@ class TestEdgeCases:
 
         paths = _extract_paths_from_command("echo hello world")
         assert paths == []
+
+
+class TestMissingArgumentIsNotAMatch:
+    """Regression: vLLM's qwen3_coder parser silently drops a parameter whose
+    header lost its '=' ('<parametercommand>'), producing e.g.
+    execute_bash({"security_risk": "LOW"}) with no command. The verifier used
+    to give such a call full target and similarity credit, which RL learned
+    to exploit (malformed-command calls out-scored well-formed ones)."""
+
+    def test_bash_missing_rollout_command_fails_target_match(self):
+        r_args = {"security_risk": "LOW"}
+        e_args = {"command": "cd /repo && pytest tests/"}
+        assert not verify_target_match("bash", r_args, "bash", e_args)
+
+    def test_bash_missing_rollout_command_scores_zero_similarity(self):
+        r_args = {"security_risk": "LOW"}
+        e_args = {"command": "cd /repo && pytest tests/"}
+        assert compute_argument_similarity("bash", r_args, "bash", e_args) == 0.0
+
+    def test_bash_missing_expected_command_fails_target_match(self):
+        r_args = {"command": "ls -la"}
+        e_args = {"security_risk": "LOW"}
+        assert not verify_target_match("bash", r_args, "bash", e_args)
+
+    def test_bash_both_commands_missing_is_neutral(self):
+        assert verify_target_match("bash", {}, "bash", {})
+        assert compute_argument_similarity("bash", {}, "bash", {}) == 1.0
+
+    def test_edit_missing_rollout_command_fails_target_match(self):
+        r_args = {"path": "/workspace/foo.py"}
+        e_args = {"path": "/workspace/foo.py", "command": "view"}
+        assert not verify_target_match("edit", r_args, "edit", e_args)
+
+    def test_edit_both_commands_present_and_equal_still_matches(self):
+        r_args = {"path": "/workspace/foo.py", "command": "view"}
+        e_args = {"path": "/workspace/foo.py", "command": "view"}
+        assert verify_target_match("edit", r_args, "edit", e_args)


### PR DESCRIPTION
## What does this PR do?

Fixes a reward leak in the `swe_pivot` verifier: a tool call whose `command` argument is missing could not fail Level 1 (target match) or Level 2 (argument similarity), so it scored the same as, or better than, a well-formed call.

### How the leak works

vLLM's `qwen3_coder` tool parser silently drops a parameter whose header lost its `=`. A model emitting

```
<function=execute_bash>
<parametercommand>
pytest tests/
</parameter>
<parameter=security_risk>
LOW
</parameter>
</function>
```

is parsed as `execute_bash({"security_risk": "LOW"})` with no `command` at all (the leftover text is not surfaced). Every comparison in the bash branch of `verify_target_match` is guarded by "only compare when both sides have a command" (`if r_verb and e_verb`, `if r_paths and e_paths`, `if r_cmd and e_cmd`), so an empty rollout command skipped every check and passed L1. `compute_argument_similarity` then returned `1.0` for the same reason. The editor sub-command (`str_replace_editor`'s `command`) had the same guard.

We hit this in RL training against this server: the policy discovered the malformed header and adopted it. Between two nearby weight versions, bash calls with a dropped `command` went from 1% to 29% of samples and out-scored well-formed calls (mean reward 0.85 vs 0.77), because the malformed form can never fail the command checks.

### The fix

- `verify_target_match`, bash branch: if exactly one side has a command, return `False`. Both empty stays neutral (tools whose shell argument uses a key other than `command`/`cmd` are unchanged).
- `verify_target_match`, edit branch: same rule for the editor sub-command.
- `compute_argument_similarity`, bash branch: one side empty scores `0.0` instead of `1.0`; both empty still `1.0`.

The rule is symmetric on purpose: a call with a command and a call without one are different actions regardless of which side is which. One behavioral consequence worth noting for reviewers: in the edit branch, a category-equivalent tool pair where only one tool has a `command` parameter (e.g. expected `str_replace_editor(command="create", ...)` vs rollout `create_file(...)`) now fails L1 where it previously passed on path match alone. Within a single episode the rollout sees the same tool set as the reference call, so this only affects cross-harness comparisons.

### Tests

`resources_servers/swe_pivot/tests/test_verifier.py` gains `TestMissingArgumentIsNotAMatch` (6 cases): rollout missing command fails L1 and scores 0.0; expected missing command fails L1; both missing stays neutral; editor sub-command missing on one side fails L1; both present and equal still matches. Four of the six fail against the unfixed `app.py` (the two "neutral" cases pass either way, by design). Full file: 190 passed. `ruff` lint, isort, and format at the pre-commit pinned version (0.9.9) pass on the touched files.

### Not in this PR

A dropped `path` on edit/read calls is guarded the same way (`if r_file and e_file`) and could leak similarly; we have not observed the policy exploit it. Happy to follow up if maintainers want the presence rule extended there too.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
