### PR TITLE
fix: align resources server runtime contracts

### DIFF
--- a/resources_servers/google_search/app.py
+++ b/resources_servers/google_search/app.py
@@ -12,12 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import re
 from typing import Optional
 
-import requests
 import trafilatura
+from aiohttp import ClientTimeout
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -28,6 +29,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from nemo_gym.server_utils import raise_for_status, request
 
 
 class GoogleSearchResourcesServerConfig(BaseResourcesServerConfig):
@@ -61,7 +63,7 @@ class GoogleSearchVerifyRequest(GoogleSearchRunRequest, BaseVerifyRequest):
 
 
 class GoogleSearchVerifyResponse(BaseVerifyResponse):
-    parsed_option: str
+    parsed_option: Optional[str] = None
 
 
 def box_parser(output_str: str) -> Optional[str]:
@@ -80,11 +82,11 @@ def box_parser(output_str: str) -> Optional[str]:
 
 
 def _extract_last_assistant_text(body: GoogleSearchVerifyRequest) -> str:
-    last_message = body.response.output[-1]
-    if last_message.type == "message" and last_message.role == "assistant":
-        return last_message.content
-    else:
-        return None
+    for output_item in reversed(body.response.output):
+        if output_item.type != "message" or output_item.role != "assistant":
+            continue
+        return "".join(content_item.text for content_item in output_item.content if content_item.type == "output_text")
+    return ""
 
 
 class GoogleSearchResourcesServer(SimpleResourcesServer):
@@ -106,23 +108,26 @@ class GoogleSearchResourcesServer(SimpleResourcesServer):
             "q": body.query,
         }
         try:
-            response = requests.get(
-                "https://www.googleapis.com/customsearch/v1",
+            response = await request(
+                method="GET",
+                url="https://www.googleapis.com/customsearch/v1",
                 params=request_params,
-                timeout=10,
+                timeout=ClientTimeout(total=10),
             )
-            response.raise_for_status()
-            json_str = json.dumps(response.json())
+            await raise_for_status(response)
+            json_str = json.dumps(await response.json())
             return BaseGetSearchQueryResponse(search_results=json_str)
         except Exception as e:
             return BaseGetSearchQueryResponse(search_results=f"Error: Unexpected error - {str(e)}")
 
     async def browse(self, body: BaseGetPageContentRequest) -> BaseGetPageContentResponse:
         try:
-            html = trafilatura.fetch_url(body.url)
+            response = await request(method="GET", url=body.url, timeout=ClientTimeout(total=10))
+            await raise_for_status(response)
+            html = await response.text(errors="replace")
             if html:
-                text = trafilatura.extract(html)
-                if len(text.split()) > 10000:
+                text = await asyncio.to_thread(trafilatura.extract, html)
+                if text and len(text.split()) > 10000:
                     text = text[:5000] + "..." + text[-5000:]
                 if text:
                     return BaseGetPageContentResponse(page_content=text)

--- a/resources_servers/google_search/tests/test_app.py
+++ b/resources_servers/google_search/tests/test_app.py
@@ -12,18 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.server_utils import ServerClient
 from resources_servers.google_search.app import (
+    BaseGetPageContentRequest,
+    BaseSearchQueryRequest,
     GoogleSearchResourcesServer,
     GoogleSearchResourcesServerConfig,
+    GoogleSearchVerifyRequest,
     box_parser,
 )
 
 
 class TestApp:
-    def test_sanity(self) -> None:
+    @staticmethod
+    def _make_server() -> GoogleSearchResourcesServer:
         config = GoogleSearchResourcesServerConfig(
             host="0.0.0.0",
             port=8080,
@@ -32,7 +38,29 @@ class TestApp:
             google_api_key="dummy_key",  # pragma: allowlist secret
             google_cx="dummy_cx",
         )
-        GoogleSearchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        return GoogleSearchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    @staticmethod
+    def _make_verify_request(output: list[dict]) -> GoogleSearchVerifyRequest:
+        response = NeMoGymResponse(
+            id="resp_test",
+            created_at=0.0,
+            model="dummy",
+            object="response",
+            output=output,
+            parallel_tool_calls=True,
+            tool_choice="auto",
+            tools=[],
+        )
+        return GoogleSearchVerifyRequest(
+            responses_create_params={"input": [{"role": "user", "content": "Question"}]},
+            response=response,
+            expected_answer="B",
+            task_difficulty_qwen3_32b_avg_8=0.5,
+        )
+
+    def test_sanity(self) -> None:
+        self._make_server()
 
     def test_box_parser_valid_content(self) -> None:
         """Test box_parser with valid boxed content"""
@@ -51,3 +79,72 @@ class TestApp:
         # Test with empty string
         result = box_parser("")
         assert result is None
+
+    async def test_verify_extracts_standard_response_content(self) -> None:
+        request = self._make_verify_request(
+            [
+                {
+                    "id": "msg_test",
+                    "content": [
+                        {"annotations": [], "text": "Reasoning. ", "type": "output_text"},
+                        {"annotations": [], "text": "\\boxed{B}", "type": "output_text"},
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ]
+        )
+
+        result = await self._make_server().verify(request)
+
+        assert result.reward == 1.0
+        assert result.parsed_option == "B"
+
+    async def test_verify_returns_zero_for_unparseable_output(self) -> None:
+        request = self._make_verify_request(
+            [
+                {
+                    "id": "msg_test",
+                    "content": [{"annotations": [], "text": "No boxed answer", "type": "output_text"}],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ]
+        )
+
+        result = await self._make_server().verify(request)
+
+        assert result.reward == 0.0
+        assert result.parsed_option is None
+
+    async def test_verify_returns_zero_for_empty_output(self) -> None:
+        result = await self._make_server().verify(self._make_verify_request([]))
+
+        assert result.reward == 0.0
+        assert result.parsed_option is None
+
+    async def test_search_uses_shared_async_client(self) -> None:
+        response = MagicMock(ok=True)
+        response.json = AsyncMock(return_value={"items": [{"title": "result"}]})
+
+        with patch("resources_servers.google_search.app.request", AsyncMock(return_value=response)) as mock_request:
+            result = await self._make_server().search(BaseSearchQueryRequest(query="test query"))
+
+        assert json.loads(result.search_results) == {"items": [{"title": "result"}]}
+        assert mock_request.await_args.kwargs["method"] == "GET"
+        assert mock_request.await_args.kwargs["params"]["q"] == "test query"
+
+    async def test_browse_fetches_page_without_blocking_event_loop(self) -> None:
+        response = MagicMock(ok=True)
+        response.text = AsyncMock(return_value="<html><body>Page</body></html>")
+
+        with (
+            patch("resources_servers.google_search.app.request", AsyncMock(return_value=response)) as mock_request,
+            patch("resources_servers.google_search.app.trafilatura.extract", return_value="Page text"),
+        ):
+            result = await self._make_server().browse(BaseGetPageContentRequest(url="https://example.com"))
+
+        assert result.page_content == "Page text"
+        assert mock_request.await_args.kwargs["url"] == "https://example.com"

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -47,7 +47,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ResourcesServerRef
-from nemo_gym.server_utils import SESSION_ID_KEY
+from nemo_gym.server_utils import SESSION_ID_KEY, raise_for_status
 
 
 logger = logging.getLogger(__name__)
@@ -438,7 +438,9 @@ class NSToolsResourcesServer(SimpleResourcesServer):
                 server_name=verifier_ref.name,
                 url_path="/verify",
                 json=body.model_dump(),
+                cookies=request.cookies if request else None,
             )
+            await raise_for_status(response)
 
             result = await response.json()
 

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -102,6 +102,7 @@ class TestApp:
         server.tool_manager = MagicMock(spec_set=ToolManager)
         request = MagicMock()
         request.session = {SESSION_ID_KEY: "rollout-123"}
+        request.cookies = {"session": "rollout-123"}
 
         # Mock the server_client.post to return a successful verification
         mock_response = AsyncMock()
@@ -157,6 +158,37 @@ class TestApp:
         call_args = server.server_client.post.call_args
         assert call_args.kwargs["server_name"] == "math_with_judge"
         assert call_args.kwargs["url_path"] == "/verify"
+        assert call_args.kwargs["cookies"] == {"session": "rollout-123"}
+        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
+
+    async def test_verify_propagates_verifier_http_errors(self) -> None:
+        verifiers = {
+            "math_with_judge": ResourcesServerRef(type="resources_servers", name="math_with_judge"),
+        }
+        config = NSToolsConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="ns_tools",
+            verifiers=verifiers,
+            default_verifier="math_with_judge",
+        )
+        server = NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        server.tool_manager = MagicMock(spec_set=ToolManager)
+        response = AsyncMock()
+        server.server_client.post = AsyncMock(return_value=response)
+        request = MagicMock()
+        request.session = {SESSION_ID_KEY: "rollout-123"}
+        verify_request = MagicMock(spec=NSToolsVerifyRequest)
+        verify_request.verifier_type = None
+
+        with (
+            patch("app.raise_for_status", AsyncMock(side_effect=RuntimeError("verifier returned 500"))),
+            pytest.raises(RuntimeError, match="verifier returned 500"),
+        ):
+            await server.verify(request, verify_request)
+
+        response.json.assert_not_awaited()
         server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
 
     async def test_verify_cleans_up_when_verifier_fails(self) -> None:

--- a/resources_servers/spider2_lite/eval_utils.py
+++ b/resources_servers/spider2_lite/eval_utils.py
@@ -82,18 +82,14 @@ async def execute_sqlite_async(
     semaphore: asyncio.Semaphore,
     timeout_s: float = 30.0,
 ) -> Optional[ResultSet]:
-    """Execute SQL asynchronously via thread executor, bounded by semaphore."""
+    """Execute SQL asynchronously via Ray, bounded by semaphore."""
     async with semaphore:
         task = execute_sqlite_remote.remote(db_path, sql)
-        fut: asyncio.Future = asyncio.wrap_future(task.future())
-
-        _, in_progress = await asyncio.wait([fut], timeout=timeout_s)
-
-        if in_progress:
+        try:
+            return await asyncio.wait_for(task, timeout=timeout_s)
+        except TimeoutError:
             ray.cancel(task)
             return None
-        else:
-            return ray.get(task)
 
 
 def _col_vector(rows: ResultSet, col_idx: int) -> list[Any]:

--- a/resources_servers/spider2_lite/tests/test_app.py
+++ b/resources_servers/spider2_lite/tests/test_app.py
@@ -148,11 +148,12 @@ class TestEvalUtils:
     def test_execute_sqlite_bad_sql(self, tiny_db):
         assert execute_sqlite(tiny_db, "NOT VALID SQL") == None
 
-    def test_execute_sqlite_async_ok(self, tiny_db):
+    async def test_execute_sqlite_async_ok(self, tiny_db):
         sem = asyncio.Semaphore(1)
-        rows = asyncio.get_event_loop().run_until_complete(
-            execute_sqlite_async(tiny_db, "SELECT id FROM items ORDER BY id", sem)
-        )
+        with patch(
+            "resources_servers.spider2_lite.eval_utils.ray.get", side_effect=AssertionError("blocking ray.get")
+        ):
+            rows = await execute_sqlite_async(tiny_db, "SELECT id FROM items ORDER BY id", sem)
         assert rows == [(1,), (2,)]
 
     def test_compare_result_sets_exact(self):
@@ -223,35 +224,31 @@ class TestEvalUtils:
     def test_compare_multi_empty_gold(self):
         assert not compare_multi_result_sets([], [(1,)])
 
-    def test_execute_and_compare_match(self, tiny_db):
+    async def test_execute_and_compare_match(self, tiny_db):
         sem = asyncio.Semaphore(4)
-        match, gold, pred, err = asyncio.get_event_loop().run_until_complete(
-            execute_and_compare(tiny_db, "SELECT id FROM items ORDER BY id", "SELECT id FROM items ORDER BY id", sem)
+        match, gold, pred, err = await execute_and_compare(
+            tiny_db, "SELECT id FROM items ORDER BY id", "SELECT id FROM items ORDER BY id", sem
         )
         assert match is True
         assert err is None
 
-    def test_execute_and_compare_mismatch(self, tiny_db):
+    async def test_execute_and_compare_mismatch(self, tiny_db):
         sem = asyncio.Semaphore(4)
-        match, gold, pred, err = asyncio.get_event_loop().run_until_complete(
-            execute_and_compare(tiny_db, "SELECT id FROM items", "SELECT name FROM items", sem)
+        match, gold, pred, err = await execute_and_compare(
+            tiny_db, "SELECT id FROM items", "SELECT name FROM items", sem
         )
         assert match is False
         assert err is None
 
-    def test_execute_and_compare_gold_error(self, tiny_db):
+    async def test_execute_and_compare_gold_error(self, tiny_db):
         sem = asyncio.Semaphore(4)
-        match, gold, pred, err = asyncio.get_event_loop().run_until_complete(
-            execute_and_compare(tiny_db, "INVALID SQL", "SELECT 1", sem)
-        )
+        match, gold, pred, err = await execute_and_compare(tiny_db, "INVALID SQL", "SELECT 1", sem)
         assert match is False
         assert err is not None and "gold_sql_error" in err
 
-    def test_execute_and_compare_pred_error(self, tiny_db):
+    async def test_execute_and_compare_pred_error(self, tiny_db):
         sem = asyncio.Semaphore(4)
-        match, gold, pred, err = asyncio.get_event_loop().run_until_complete(
-            execute_and_compare(tiny_db, "SELECT id FROM items", "INVALID SQL", sem)
-        )
+        match, gold, pred, err = await execute_and_compare(tiny_db, "SELECT id FROM items", "INVALID SQL", sem)
         assert match is False
         assert err is not None and "pred_sql_error" in err
 


### PR DESCRIPTION
## What does this PR do?

Audits resources-server runtime behavior against the current repository contracts, including the corrections proposed in #3123.

- routes Google Search outbound HTTP through Gym shared aiohttp client, moves HTML extraction off the event loop, and handles standard Responses content plus empty or unparseable verifier output
- preserves request cookies when ns_tools delegates verification and raises downstream HTTP failures before parsing a response body
- awaits Spider2-Lite Ray ObjectRefs directly with an async timeout instead of calling ray.get() in async code; updates its async tests for supported Python versions

The change is intentionally limited to these concrete runtime inconsistencies. It does not rename directories or migrate benchmark layouts.

## Validation

- 68 targeted server tests pass on Python 3.14.3 (google_search: 7, ns_tools: 15, spider2_lite: 46)
- pre-commit run --all-files
- git diff --check

A credentialed model rollout was not run: Google Search requires external API credentials, and the full ns_tools flow requires its configured sandbox/verifier stack. The PR remains draft pending that integration validation.

## Checklist

- [x] I have read the contributing guidelines.
- [x] The change is focused; unrelated drive-by edits are excluded.
- [x] Tests added or updated and pass locally.
- [x] Pre-commit checks pass locally (pre-commit run --all-files).
- [x] All commits have DCO sign-off (git commit -s).