### PR TITLE
[Super 3.5 evals] Update Sep 06, 2026

### DIFF
--- a/benchmarks/deepswe/opencode.yaml
+++ b/benchmarks/deepswe/opencode.yaml
@@ -27,4 +27,4 @@ deepswe_opencode_sandboxed_agent:
           type: benchmark
           jsonl_fpath: benchmarks/deepswe/data/deepswe_benchmark.jsonl
           prepare_script: benchmarks/deepswe/prepare.py
-          num_repeats: 5
+          num_repeats: 10

--- a/benchmarks/nemotron_3.5_super/README.md
+++ b/benchmarks/nemotron_3.5_super/README.md
@@ -1,6 +1,8 @@
 # Nemotron 3.5 Super Evaluation setup
 - [Nemotron 3.5 Super Evaluation setup](#nemotron-35-super-evaluation-setup)
   - [Run production evals](#run-production-evals)
+    - [Typical job shapes](#typical-job-shapes)
+    - [Open problems](#open-problems)
   - [Development commands](#development-commands)
     - [vllm-router patch (decode-node cache imbalance)](#vllm-router-patch-decode-node-cache-imbalance)
       - [Measured effect](#measured-effect)
@@ -11,10 +13,28 @@
 
 
 ## Run production evals
-TODO @bxyu-nvidia: Will publish these by Thu Jul 30
-
 Results will appear in that checkpoint folder.
 
+### Typical job shapes
+These job shapes have been tuned to finish evaluation on Nemotron 3.5 Super checkpoints within a 4 hour Slurm timeout window. All compute numbers assume GB200 NVL72.
+
+|Name|Argument|
+|---|---|
+|Prefill nodes|`NUM_PREFILL_NODES=<>`|
+|Decode nodes|`NUM_DECODE_NODES=<>`|
+|Concurrency|`++num_samples_in_parallel=<>`|
+
+|Benchmark|Harness|Prefill nodes|Decode nodes|Concurrency|
+|---|---|---|---|
+|SWE Bench Verified + Multilingual|OpenCode|2|2|1024|
+|SWE Bench Pro|OpenCode|4|6|1024|
+|DeepSWE (1 repeat)|OpenCode|2|2|1024|
+|Terminal Bench 2.1|Terminus 2|2|8|512|
+|Terminal Bench 2.1|OpenCode|?|?|?|
+
+### Open problems
+1. We can't reduce the number of prefill nodes because the TRT LLM kernel isn't large enough to support higher max_num_batched_tokens
+2. Once MTP is functional with PD-disagg / async scheduling / prefix caching / etc, we should be able to reduce the decode nodes as well.
 
 ## Development commands
 

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -757,13 +757,18 @@ class ClientDisconnectCancellationMiddleware:
 
         received_messages: asyncio.Queue[Message] = asyncio.Queue()
         client_disconnected = asyncio.Event()
+        response_complete = asyncio.Event()
 
         async def receive_message() -> Message:
             return await received_messages.get()
 
         async def send_message(message: Message) -> None:
-            if not client_disconnected.is_set():
-                await send(message)
+            if client_disconnected.is_set():
+                return
+
+            await send(message)
+            if message["type"] == "http.response.body" and not message.get("more_body", False):
+                response_complete.set()
 
         # The listener is the sole reader of the original ASGI receive channel.
         # Forwarding request messages keeps the body available to the app while
@@ -779,10 +784,17 @@ class ClientDisconnectCancellationMiddleware:
             async def listen_for_disconnect() -> None:
                 while True:
                     message = await receive()
-                    await received_messages.put(message)
                     if message["type"] != "http.disconnect":
+                        await received_messages.put(message)
                         continue
 
+                    # Uvicorn returns http.disconnect from receive() once the response is complete,
+                    # even if the peer did not disconnect early. Only cancel requests whose response
+                    # has not finished being sent.
+                    if response_complete.is_set():
+                        return
+
+                    await received_messages.put(message)
                     client_disconnected.set()
                     self.num_cancelled += 1
                     if is_global_aiohttp_client_request_debug_enabled() or self.num_cancelled % 100 == 0:

--- a/resources_servers/terminal_bench_2_1/README.md
+++ b/resources_servers/terminal_bench_2_1/README.md
@@ -16,6 +16,8 @@ gym env start \
 ### Full Terminal Bench 2.1 golden patch smoke test
 In a separate terminal:
 ```bash
+gym eval prepare --config benchmarks/terminal_bench_2_1/terminus_2.yaml
+
 python resources_servers/terminal_bench_2_1/apply_golden_patch.py \
     +benchmark_jsonl=benchmarks/terminal_bench_2_1/data/benchmark.jsonl \
     +limit=...  # No limit for full samples

--- a/resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
+++ b/resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
@@ -15,6 +15,10 @@ terminal_bench_2_1_resources_server:          # instance name — how agents/CLI
         ttl_s: 18000
         ready_timeout_s: 1200
         derive_cpu_env: true
+        env:
+          # execd holds each finished command's response open for this long (default 1s);
+          # a short grace keeps every command and the readiness probe from paying that tail.
+          EXECD_API_GRACE_SHUTDOWN: "50ms"
         resources:
           cpu: 4
           memory_mib: 16384

--- a/responses_api_agents/terminus_2_sandboxed_agent/README.md
+++ b/responses_api_agents/terminus_2_sandboxed_agent/README.md
@@ -10,14 +10,17 @@ gym env start \
     --config responses_api_models/vllm_model/configs/vllm_model.yaml \
     --config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml \
     --config responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml \
-    --config resources_servers/swebench/configs/swebench.yaml
+    --config resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml \
+    ++terminus_2_sandboxed_agent.responses_api_agents.terminus_2_sandboxed_agent.resources_server.name=terminal_bench_2_1_resources_server
 ```
 
 To run one row from a benchmark JSONL after starting the servers:
 
 ```bash
+gym eval prepare --config benchmarks/terminal_bench_2_1/terminus_2.yaml
+
 python responses_api_agents/terminus_2_sandboxed_agent/client.py \
-    +benchmark_jsonl=benchmarks/swebench/data/swebench_verified_benchmark.jsonl
+    +benchmark_jsonl=benchmarks/terminal_bench_2_1/data/benchmark.jsonl
 ```
 
 The agent calls the configured model server exclusively through the Responses

--- a/responses_api_agents/terminus_2_sandboxed_agent/app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/app.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 from fastapi import Request
 from harbor.agents.terminus_2 import Terminus2
-from harbor.llms.base import BaseLLM, LLMResponse
+from harbor.llms.base import BaseLLM, ContextLengthExceededError, LLMResponse
 from harbor.models.agent.context import AgentContext
 from harbor.models.metric.usage_info import UsageInfo
 from harbor.utils.logger import logger as harbor_logger
@@ -60,8 +60,10 @@ class Terminus2AgentConfig(BaseResponsesAPIAgentConfig):
     tmux_pane_height: int
     dump_trajectory: bool = False
     debug: bool = False
-    model_context_limit: int = 1_000_000
-    model_output_limit: int | None = None
+    model_context_limit: int
+    model_output_limit: int | None
+
+    llm_request_timeout: int
 
     sandbox_provider: str
     sandbox_config: dict[str, Any] = Field(default_factory=dict)
@@ -91,7 +93,10 @@ class Terminus2AgentVerifyResponse(BaseVerifyResponse):
     model_call_time_pct: float
     terminus2_time_taken: float
     model_calls_gt_10min: int
+    usages: List[Optional[NeMoGymResponseUsage]]
+    num_proactive_compactions: int
     num_compactions: int
+    error: Optional[str]
 
 
 class NeMoGymSandboxEnvironment:
@@ -153,16 +158,23 @@ class NeMoGymLLM(BaseLLM):
         model_name: str,
         model_context_limit: int,
         model_output_limit: int | None,
+        llm_request_timeout: int,
     ):
         super().__init__()
         self._client = client
         self._model_name = model_name
         self._model_context_limit = model_context_limit
         self._model_output_limit = model_output_limit
+        self._llm_request_timeout = llm_request_timeout
         self.trajectory: list[NeMoGymResponseOutputItem] = []
+        self.usages: list[NeMoGymResponseUsage] = []
         self._times_spent = []
         self._last_input_items = []
         self._model_calls_gt_10min = 0
+        self._num_compactions = 0
+
+        self._is_compacting = False
+        self._just_compacted = False
 
     @staticmethod
     def _input_items(message_history: list[dict[str, Any]], prompt: str) -> list[NeMoGymEasyInputMessage]:
@@ -193,10 +205,10 @@ class NeMoGymLLM(BaseLLM):
         input_items = self._input_items(message_history, prompt)
         response = None
         start_time = perf_counter()
-        max_attempts = 3  # Hardcode 3 attempts for now
-        for attempt in range(max_attempts):
+        max_attempts = 10  # Harbor does 3 by default and Litellm does 3 by default. Hardcode 10 attempts for now.
+        for _ in range(max_attempts):
             try:
-                async with asyncio.timeout(delay=60 * 10):  # Hardcoded to match litellm default timeout
+                async with asyncio.timeout(delay=self._llm_request_timeout):
                     response = NeMoGymResponse.model_validate(
                         await self._client.create_response(
                             model=self._model_name,
@@ -206,19 +218,21 @@ class NeMoGymLLM(BaseLLM):
                     break
             except TimeoutError:
                 self._model_calls_gt_10min += 1
-                print(
-                    f"Hit LiteLLM default 10min timeout on model call, attempt {attempt + 1} / {max_attempts}",
-                    file=sys.stderr,
-                )
+
         self._times_spent.append(perf_counter() - start_time)
         if not response:
             raise TimeoutError(f"Failed to query model endpoint due to timeouts after {max_attempts} attempts!")
 
-        if len(self._last_input_items) >= len(input_items):
-            # Compacted
+        if self._is_compacting:
+            self.trajectory.extend([input_items[-1], *response.output])
+            self._just_compacted = True
+        elif self._just_compacted:
             self.trajectory.extend([*input_items, *response.output])
+            self._just_compacted = False
         else:
             self.trajectory.extend([input_items[-1], *response.output])
+
+        self.usages.append(response.usage)
         self._last_input_items = input_items.copy()
 
         usage = response.usage
@@ -231,6 +245,12 @@ class NeMoGymLLM(BaseLLM):
                 cost_usd=0.0,
             )
         content, reasoning_content = self._response_text(response)
+
+        # @bxyu-nvidia: Gym will return an empty model response when context length is exceeded
+        if not (content or reasoning_content) or response.incomplete_details:
+            self._num_compactions += 1
+            raise ContextLengthExceededError
+
         return LLMResponse(
             content=content,
             reasoning_content=reasoning_content,
@@ -253,14 +273,12 @@ class NeMoGymTerminus2(Terminus2):
         self._nemo_gym_llm = llm
         self._dump_trajectory_enabled = dump_trajectory
         self._times_spent = []
-        self._num_compactions = 0
+        self._num_proactive_compactions = 0
+        self._is_check_proactive_summarization = False
         super().__init__(*args, **kwargs)
 
     def _init_llm(self, *args: Any, **kwargs: Any) -> BaseLLM:
         return self._nemo_gym_llm
-
-    def _count_total_tokens(self, chat: Any) -> int:
-        return sum(len(str(message.get("content", ""))) // 4 for message in chat.messages)
 
     def _dump_trajectory_with_continuation_index(self, continuation_index: int) -> None:
         if self._dump_trajectory_enabled:
@@ -273,10 +291,23 @@ class NeMoGymTerminus2(Terminus2):
 
         return res
 
+    def _count_total_tokens(self, *args, **kwargs):
+        if self._is_check_proactive_summarization and self._nemo_gym_llm.usages:
+            return self._nemo_gym_llm.usages[-1].total_tokens
+        return super()._count_total_tokens(*args, **kwargs)
+
     async def _check_proactive_summarization(self, *args, **kwargs):
+        self._is_check_proactive_summarization = True
         res = await super()._check_proactive_summarization(*args, **kwargs)
+        self._is_check_proactive_summarization = False
         if res:
-            self._num_compactions += 1
+            self._num_proactive_compactions += 1
+        return res
+
+    async def _summarize(self, *args, **kwargs):
+        self._nemo_gym_llm._is_compacting = True
+        res = await super()._summarize(*args, **kwargs)
+        self._nemo_gym_llm._is_compacting = False
         return res
 
 
@@ -313,6 +344,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             model_name=self.config.model_server.name,
             model_context_limit=self.config.model_context_limit,
             model_output_limit=self.config.model_output_limit,
+            llm_request_timeout=self.config.llm_request_timeout,
         )
 
         with tempfile.TemporaryDirectory(prefix="nemo-gym-terminus-2-") as log_dir:
@@ -354,10 +386,13 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
                 async with asyncio.timeout(self.config.sandbox_timeout):
                     await agent.run(instruction, environment, context)
                 terminus2_completed = True
+                error = None
             except TimeoutError:
                 terminus2_completed = False
+                error = format_exc()
             except:
                 terminus2_completed = False
+                error = format_exc()
                 print(f"Hit exception while running Terminus2: {format_exc()}", file=sys.stderr)
             finally:
                 pass
@@ -396,7 +431,10 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             "model_call_time_pct": 100 * total_model_call_time / total_time,
             "terminus2_time_taken": total_time,
             "model_calls_gt_10min": llm._model_calls_gt_10min,
-            "num_compactions": agent._num_compactions,
+            "num_proactive_compactions": agent._num_proactive_compactions,
+            "num_compactions": llm._num_compactions,
+            "error": error,
+            "usages": llm.usages,
         }
         return response, metrics
 

--- a/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
+++ b/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
@@ -17,9 +17,10 @@ terminus_2_sandboxed_agent:
       tmux_pane_width: 160
       tmux_pane_height: 40
       dump_trajectory: false
-      debug: false
+      debug: true
       model_context_limit: 262144
       model_output_limit: null
+      llm_request_timeout: 600  # 10 mins, Litellm default
 
       sandbox_provider: sandbox
       sandbox_timeout: 10800  # 3 hrs

--- a/responses_api_agents/terminus_2_sandboxed_agent/infra_error_analysis_rollouts.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/infra_error_analysis_rollouts.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+from collections import Counter
+from contextlib import nullcontext
+from os import stat
+
+import orjson
+from tqdm.auto import tqdm
+
+
+parser = ArgumentParser()
+parser.add_argument("--fpath", type=str, required=True)
+parser.add_argument("--group-to-write-out", type=str, default=None)
+args = parser.parse_args()
+
+
+f_out_path = "temp.jsonl"
+num_wrote_out = 0
+failed_counts = Counter()
+success_counts = Counter()
+with open(args.fpath, "rb") as f, open(f_out_path, "wb") if args.group_to_write_out else nullcontext() as f_out:
+    for i, line in tqdm(enumerate(f)):
+        row = orjson.loads(line)
+
+        count = 0
+        stuck_count = 0
+        technical_difficulties_count = 0
+        for output_item in row["response"]["output"]:
+            if output_item.get("role") == "user":
+                content = output_item["content"]
+                count += "No valid JSON found in response" in content
+            elif output_item.get("type") == "reasoning":
+                content = output_item["summary"][0]["text"]
+                stuck_count += "stuck" in content or "unresponsive" in content
+            elif output_item.get("type") == "message":
+                if isinstance(output_item["content"], str):
+                    content = output_item["content"]
+                elif isinstance(output_item["content"], list):
+                    content = output_item["content"][0]["text"]
+                else:
+                    raise NotImplementedError
+
+                technical_difficulties_count += "Technical difficulties" in content
+
+        is_errored = bool(row["error"])
+        is_timeout = is_errored and "raise TimeoutError from exc_val" in row["error"]
+
+        count_dict = {
+            "Long model calls": row["model_calls_gt_10min"] >= 6,
+            "Model claims to be stuck": stuck_count > 10,
+            "No valid JSON found in response": count > 10,
+            "Technical difficulties": technical_difficulties_count > 0,
+            "Errored (excluding timeout)": is_errored - is_timeout,
+            "Timed out": is_timeout,
+            "Total samples with reward=0": 1,
+        }
+        count_dict["Samples covered by the above errors"] = (
+            count_dict["Long model calls"] or count_dict["Model claims to be stuck"] or count_dict["Long model calls"]
+        )
+
+        if row["reward"]:
+            success_counts.update(count_dict)
+        else:
+            failed_counts.update(count_dict)
+
+        if row["reward"] != 0.0:
+            continue
+
+        if args.group_to_write_out and count_dict[args.group_to_write_out]:
+            num_wrote_out += 1
+            row = row | count_dict
+            f_out.write(orjson.dumps(row) + b"\n")
+
+
+def print_counts(counts: Counter):
+    print_str = ""
+    for k, v in counts.items():
+        print_str += f"{k}: {v} ({int(100 * v / counts['Total samples with reward=0'])}%)\n"
+    print(print_str)
+
+
+print("Successful samples:")
+print_counts(success_counts)
+print("\nFailed samples:")
+print_counts(failed_counts)
+
+if args.group_to_write_out:
+    print(
+        f"Wrote out {num_wrote_out} rows ({stat(f_out_path).st_size / 1024**2} MB) for `{args.group_to_write_out}` to {f_out_path}"
+    )

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -114,7 +115,13 @@ async def test_nemo_gym_llm_records_every_responses_request_and_output():
             )
 
     client = Client()
-    llm = NeMoGymLLM(client=client, model_name="policy_model", model_context_limit=32_000, model_output_limit=4_000)
+    llm = NeMoGymLLM(
+        client=client,
+        model_name="policy_model",
+        model_context_limit=32_000,
+        model_output_limit=4_000,
+        llm_request_timeout=60,
+    )
 
     first = await llm.call("first")
     second = await llm.call(
@@ -153,7 +160,6 @@ async def test_nemo_gym_llm_records_every_responses_request_and_output():
     assert [item.content for item in llm.trajectory if isinstance(item, NeMoGymEasyInputMessage)] == [
         "first",
         "second",
-        "compacted summary",
         "third",
     ]
 
@@ -176,6 +182,9 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         tmux_pane_height=40,
         dump_trajectory=dump_trajectory,
         debug=debug,
+        model_context_limit=32_000,
+        model_output_limit=4_000,
+        llm_request_timeout=60,
         sandbox_provider="opensandbox",
         sandbox_timeout=10,
         remote_tmux_binary_path=None,
@@ -198,6 +207,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
             self.kwargs = kwargs
             self._session = SimpleNamespace(stop=self.stop)
             self._times_spent = [1.0, 3.0]
+            self._num_proactive_compactions = 0
             self._num_compactions = 2
 
         async def stop(self):
@@ -211,6 +221,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
             assert self.kwargs["dump_trajectory"] is dump_trajectory
             await environment.exec("tmux run")
             self.kwargs["llm"]._times_spent.extend([2.0, 4.0])
+            self.kwargs["llm"]._num_compactions = 2
             context.n_input_tokens = 4
             context.n_output_tokens = 3
             self.kwargs["llm"].trajectory.append(
@@ -258,7 +269,10 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         "model_call_time_pct": 60.0,
         "terminus2_time_taken": 10.0,
         "model_calls_gt_10min": 0,
+        "num_proactive_compactions": 0,
         "num_compactions": 2,
+        "error": None,
+        "usages": [],
     }
     assert response.output[-1].content[0].text == "done"
     assert response.usage.input_tokens == 4
@@ -272,3 +286,59 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         ("tmux setup", {"timeout_s": None, "cwd": None, "user": None, "env": None}),
         ("tmux run", {"timeout_s": None, "cwd": None, "user": None, "env": None}),
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_propagates_cancellation_without_printing_error(monkeypatch, capsys):
+    config = Terminus2AgentConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="app.py",
+        name="terminus_2_1_agent",
+        resources_server=ResourcesServerRef(type="resources_servers", name="swebench_resources_server"),
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        max_turns=100,
+        enable_summarize=True,
+        proactive_summarization_threshold=8000,
+        tmux_pane_width=160,
+        tmux_pane_height=40,
+        model_context_limit=32_000,
+        model_output_limit=4_000,
+        llm_request_timeout=60,
+        sandbox_provider="opensandbox",
+        sandbox_timeout=10,
+        remote_tmux_binary_path=None,
+    )
+    server = Terminus2Agent(config=config, server_client=MagicMock(spec=ServerClient))
+
+    async def sandbox_exec(command, **kwargs):
+        return SimpleNamespace(stdout="", stderr="", return_code=0)
+
+    class FakeTerminus:
+        session = SimpleNamespace()
+
+        def __init__(self, **kwargs):
+            pass
+
+        async def setup(self, environment):
+            pass
+
+        async def run(self, instruction, environment, context):
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(app_module, "NeMoGymTerminus2", FakeTerminus)
+    monkeypatch.setattr(Terminus2Agent, "base_url_for_run", lambda *_args, **_kwargs: "http://model")
+    monkeypatch.setattr(app_module, "get_server_url", lambda _: "http://model")
+
+    async def request_json():
+        return {"task_id": "task"}
+
+    request = SimpleNamespace(json=request_json, session={app_module.SESSION_ID_KEY: "session-1"})
+    with pytest.raises(asyncio.CancelledError):
+        await server._execute(
+            request,
+            NeMoGymResponseCreateParamsNonStreaming(input="solve this"),
+            SimpleNamespace(exec=sandbox_exec),
+        )
+
+    assert "Hit exception while running Terminus2" not in capsys.readouterr().err

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -286,59 +285,3 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         ("tmux setup", {"timeout_s": None, "cwd": None, "user": None, "env": None}),
         ("tmux run", {"timeout_s": None, "cwd": None, "user": None, "env": None}),
     ]
-
-
-@pytest.mark.asyncio
-async def test_execute_propagates_cancellation_without_printing_error(monkeypatch, capsys):
-    config = Terminus2AgentConfig(
-        host="0.0.0.0",
-        port=8080,
-        entrypoint="app.py",
-        name="terminus_2_1_agent",
-        resources_server=ResourcesServerRef(type="resources_servers", name="swebench_resources_server"),
-        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
-        max_turns=100,
-        enable_summarize=True,
-        proactive_summarization_threshold=8000,
-        tmux_pane_width=160,
-        tmux_pane_height=40,
-        model_context_limit=32_000,
-        model_output_limit=4_000,
-        llm_request_timeout=60,
-        sandbox_provider="opensandbox",
-        sandbox_timeout=10,
-        remote_tmux_binary_path=None,
-    )
-    server = Terminus2Agent(config=config, server_client=MagicMock(spec=ServerClient))
-
-    async def sandbox_exec(command, **kwargs):
-        return SimpleNamespace(stdout="", stderr="", return_code=0)
-
-    class FakeTerminus:
-        session = SimpleNamespace()
-
-        def __init__(self, **kwargs):
-            pass
-
-        async def setup(self, environment):
-            pass
-
-        async def run(self, instruction, environment, context):
-            raise asyncio.CancelledError
-
-    monkeypatch.setattr(app_module, "NeMoGymTerminus2", FakeTerminus)
-    monkeypatch.setattr(Terminus2Agent, "base_url_for_run", lambda *_args, **_kwargs: "http://model")
-    monkeypatch.setattr(app_module, "get_server_url", lambda _: "http://model")
-
-    async def request_json():
-        return {"task_id": "task"}
-
-    request = SimpleNamespace(json=request_json, session={app_module.SESSION_ID_KEY: "session-1"})
-    with pytest.raises(asyncio.CancelledError):
-        await server._execute(
-            request,
-            NeMoGymResponseCreateParamsNonStreaming(input="solve this"),
-            SimpleNamespace(exec=sandbox_exec),
-        )
-
-    assert "Hit exception while running Terminus2" not in capsys.readouterr().err

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -36,6 +36,7 @@ from nemo_gym.server_utils import (
     NEMO_GYM_MODEL_SERVER_NAME_ENV_VAR_NAME,
     BaseServer,
     BaseServerConfig,
+    ClientDisconnectCancellationMiddleware,
     ConnectionError,
     DictConfig,
     GlobalAIOHTTPAsyncClientConfig,
@@ -660,6 +661,69 @@ class TestServerUtils:
 
         assert handler_cancelled.is_set()
         assert sent_messages == []
+
+    async def test_cancellation_middleware_ignores_disconnect_after_response_completion(self) -> None:
+        response_sent = asyncio.Event()
+        finish_cleanup = asyncio.Event()
+        cleanup_completed = asyncio.Event()
+        handler_cancelled = asyncio.Event()
+
+        async def inner_app(scope, receive, send) -> None:
+            assert await receive() == {"type": "http.request", "body": b"", "more_body": False}
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+            try:
+                await finish_cleanup.wait()
+            except asyncio.CancelledError:
+                handler_cancelled.set()
+                raise
+            cleanup_completed.set()
+
+        middleware = ClientDisconnectCancellationMiddleware(inner_app)
+        request_delivered = False
+
+        async def receive():
+            nonlocal request_delivered
+            if not request_delivered:
+                request_delivered = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            await response_sent.wait()
+            return {"type": "http.disconnect"}
+
+        sent_messages = []
+
+        async def send(message):
+            sent_messages.append(message)
+            if message["type"] == "http.response.body" and not message.get("more_body", False):
+                response_sent.set()
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/work",
+            "raw_path": b"/work",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+        app_task = asyncio.create_task(middleware(scope, receive, send))
+        await asyncio.wait_for(response_sent.wait(), timeout=1)
+        await asyncio.sleep(0)
+        finish_cleanup.set()
+        await asyncio.wait_for(app_task, timeout=1)
+
+        assert cleanup_completed.is_set()
+        assert not handler_cancelled.is_set()
+        assert middleware.num_cancelled == 0
+        assert sent_messages == [
+            {"type": "http.response.start", "status": 200, "headers": []},
+            {"type": "http.response.body", "body": b"ok", "more_body": False},
+        ]
 
     def test_upstream_error_log_has_bounded_body_and_redacted_url(self) -> None:
         request_info = RequestInfo(


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. Terminus 2 additional logging and compaction fixes: responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml, responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py, responses_api_agents/terminus_2_sandboxed_agent/app.py, responses_api_agents/terminus_2_sandboxed_agent/infra_error_analysis_rollouts.py
2. Fix client disconnected stats: nemo_gym/server_utils.py, tests/unit_tests/test_server_utils.py
3. Add Super 3.5 evals job shapes: benchmarks/nemotron_3.5_super/README.md
4. Misc/cleanup: benchmarks/deepswe/opencode.yaml,responses_api_agents/terminus_2_sandboxed_agent/README.md, resources_servers/terminal_bench_2_1/README.md, resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
