### PR TITLE
feat(opensandbox): derive connection.protocol from a scheme in connection.domain

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox-best-practices.mdx
@@ -46,7 +46,7 @@ correctly; if you copy or override it, keep them.
 | `connection.transport_backend` | `aiohttp` | httpx's connection pool degrades badly at high concurrency; the aiohttp bridge (`httpx-aiohttp`, in the `sandbox` extra) does not. If the bridge is missing the provider falls back to httpx with a warning — treat that warning as a setup error. |
 | `connection.max_connections` | `null` | The pool is shared, so this also caps in-flight sandbox operations per process. The httpx default of 100 silently serializes a 1,000-sandbox run. |
 | `connection.keepalive_expiry_s` | below the server's idle timeout (shipped: `3.0`) | A pooled socket reused after the server closed it hangs the SDK. If a load balancer reaps idle connections anyway, set `disable_connection_pooling: true` and pay a handshake per request. |
-| `connection.protocol` | `http` unless you need TLS | TLS load-balancer listeners often have a fixed, short idle timeout that resets multi-minute streams. If you must use `https`, `background_exec: true` (below) is what keeps long commands alive. |
+| `connection.protocol` | `http` unless you need TLS | TLS load-balancer listeners often have a fixed, short idle timeout that resets multi-minute streams. If you must use `https`, `background_exec: true` (below) is what keeps long commands alive. A scheme in `connection.domain` (`OPENSANDBOX_DOMAIN=https://...`) sets the protocol and overrides this field. |
 
 ## Requests are not limits
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -29,7 +29,7 @@ Set connection values through the provider config. The shipped config reads thes
 
 | Variable | Purpose |
 | --- | --- |
-| `OPENSANDBOX_DOMAIN` | OpenSandbox server domain. Defaults to the in-cluster service name in the shipped config. |
+| `OPENSANDBOX_DOMAIN` | OpenSandbox server domain, optionally with its scheme (`https://host` sets `connection.protocol`). Defaults to the in-cluster service name in the shipped config. |
 | `OPENSANDBOX_API_KEY` | API key passed to the OpenSandbox SDK connection config. |
 
 ## Provider Config
@@ -246,4 +246,4 @@ Create retries handle transient allocation, connection, image pull, and server-s
 
 execd, the exec daemon inside each sandbox, holds every command response open for `EXECD_API_GRACE_SHUTDOWN` (default 1s) after the command's last event, which is fixed latency on each command and on the readiness probe. Set it in the sandbox spec's `env` to shorten it; the shipped SWE-bench and OpenCode configs use `50ms`, and the provider's `operations.background_poll_initial_s` (0.5) is sized to that.
 
-`connection.tls_verify` (default `false`) controls certificate verification on every connection the provider opens, both the SDK transport and PTY WebSockets. The default skips verification so that `https://` endpoints with a certificate the client cannot verify, such as a validation cluster behind a self-signed load balancer, work without extra setup; set `tls_verify: true` for endpoints with a verifiable certificate. Pair `https` endpoints with `connection.protocol: https`. The `cleanup_sandboxes.py` helper mirrors the setting with `--tls-verify` and reads `tls_verify` from `--connection-config`.
+`connection.tls_verify` (default `false`) controls certificate verification on every connection the provider opens, both the SDK transport and PTY WebSockets. The default skips verification so that `https://` endpoints with a certificate the client cannot verify, such as a validation cluster behind a self-signed load balancer, work without extra setup; set `tls_verify: true` for endpoints with a verifiable certificate. For `https` endpoints, either set `connection.protocol: https` or include the scheme in the domain (`connection.domain: https://sandbox.example`, or `OPENSANDBOX_DOMAIN=https://sandbox.example`): a scheme in the domain sets the protocol and takes precedence over `connection.protocol`. The `cleanup_sandboxes.py` helper mirrors the setting with `--tls-verify` and reads `tls_verify` from `--connection-config`.

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -21,6 +21,7 @@ sandbox:
     sandbox-api: opensandbox-sdk
   opensandbox:
     connection:
+      # May include the scheme (https://host): it then sets `protocol` and takes precedence over it.
       domain: ${oc.env:OPENSANDBOX_DOMAIN,opensandbox-server.opensandbox-system.svc.cluster.local}
       api_key: ${oc.env:OPENSANDBOX_API_KEY}
       protocol: http

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -393,7 +393,33 @@ def _to_sandbox_status(state: Any) -> SandboxStatus:
     return SandboxStatus.UNKNOWN
 
 
-@dataclass(frozen=True)
+def split_domain_scheme(domain: str) -> tuple[str, str | None]:
+    """Split a configured OpenSandbox domain into ``(domain, scheme)``.
+
+    ``"https://sandbox.example:8080/prefix/"`` -> ``("sandbox.example:8080/prefix", "https")``;
+    a bare host is returned unchanged with scheme ``None``. Surrounding whitespace
+    is stripped either way. Only ``scheme://host[:port][/path-prefix]`` is accepted:
+    other schemes, a missing host, or a query string / fragment raise ``ValueError``.
+    """
+    domain = domain.strip()
+    if "://" not in domain:
+        return domain, None
+    parts = urlsplit(domain)
+    scheme = parts.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError(f"connection.domain {domain!r} has unsupported scheme {parts.scheme!r}; use http or https")
+    if not parts.netloc:
+        raise ValueError(f"connection.domain {domain!r} has no host")
+    if parts.query or parts.fragment:
+        raise ValueError(
+            f"connection.domain {domain!r} must not carry a query string or fragment; "
+            "use scheme://host[:port][/path-prefix]"
+        )
+    # Keep any path prefix (a reverse proxy may mount the server under one); the SDK appends /v1.
+    return parts.netloc + parts.path.rstrip("/"), scheme
+
+
+@dataclass
 class OpenSandboxConnectionConfig:
     """OpenSandbox server connection settings.
 
@@ -406,6 +432,14 @@ class OpenSandboxConnectionConfig:
     operations per process; null means no cap. ``tls_verify`` applies to every
     connection the provider opens (SDK transport and PTY sockets) and is off by
     default; set it for endpoints whose certificate the client can verify.
+    ``domain`` may carry its scheme (``https://sandbox.example``). The scheme is
+    moved into ``protocol`` and takes precedence over a configured ``protocol``,
+    so every URL the provider builds itself (the PTY WebSocket target) agrees
+    with the SDK's base URL; the SDK receives the host plus any path prefix
+    (``sandbox.example:8080/prefix``). The SDK would accept a scheme in
+    ``domain`` on its own, but the provider reads ``protocol`` directly, hence
+    the normalization here. Only ``scheme://host[:port][/path-prefix]`` is
+    accepted: a query string or fragment is a configuration error.
     """
 
     domain: str | None = None
@@ -423,6 +457,13 @@ class OpenSandboxConnectionConfig:
     connect_retries: int = 2
     transport_backend: str = "httpx"
     tls_verify: bool = False
+
+    def __post_init__(self) -> None:
+        if self.domain is None:
+            return
+        self.domain, scheme = split_domain_scheme(self.domain)
+        if scheme is not None:
+            self.protocol = scheme
 
 
 @dataclass(frozen=True)

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -327,7 +327,9 @@ async def test_pool_create_uses_sdk_compatibility_image_and_proxy_auth(
     assert FakeSandbox.created_kwargs["metadata"]["purpose"] == "osworld"
     assert FakeSandbox.created_kwargs["skip_health_check"] is True
     create_connection = FakeSandbox.created_kwargs["connection_config"]
-    assert create_connection.kwargs["domain"] == "http://sandbox.example"
+    # A scheme in the configured domain is split into protocol + bare host before it reaches the SDK.
+    assert create_connection.kwargs["domain"] == "sandbox.example"
+    assert create_connection.kwargs["protocol"] == "http"
     assert create_connection.kwargs["headers"] == {
         "OPEN-SANDBOX-API-KEY": "pool-api-key"  # pragma: allowlist secret
     }
@@ -1895,3 +1897,62 @@ async def test_pty_http_client_follows_tls_verify(fake_opensandbox_sdk: None) ->
         assert verified.connector._ssl is True
     finally:
         await verified.close()
+
+
+def test_split_domain_scheme() -> None:
+    split = opensandbox_provider.split_domain_scheme
+    assert split("sandbox.example") == ("sandbox.example", None)
+    assert split(" sandbox.example\n") == ("sandbox.example", None)
+    assert split("https://sandbox.example/") == ("sandbox.example", "https")
+    assert split("HTTP://sandbox.example:8080/prefix/") == ("sandbox.example:8080/prefix", "http")
+    for bad, message in (
+        ("ftp://sandbox.example", "unsupported scheme"),
+        ("https://", "no host"),
+        ("https://sandbox.example/prefix?token=abc", "query string or fragment"),
+        ("https://sandbox.example#staging", "query string or fragment"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            split(bad)
+
+
+def test_connection_config_derives_protocol_from_domain_scheme() -> None:
+    ConnectionConfig = opensandbox_provider.OpenSandboxConnectionConfig
+
+    https = ConnectionConfig(domain="https://sandbox.example/")
+    assert (https.domain, https.protocol) == ("sandbox.example", "https")
+
+    # The shipped yaml always sets protocol (http), so a scheme in the domain must win over it.
+    override = ConnectionConfig(domain="HTTP://sandbox.example:8080/prefix/", protocol="https")
+    assert (override.domain, override.protocol) == ("sandbox.example:8080/prefix", "http")
+
+    bare = ConnectionConfig(domain="sandbox.example", protocol="https")
+    assert (bare.domain, bare.protocol) == ("sandbox.example", "https")
+    assert ConnectionConfig().domain is None
+
+    # Whitespace is normalized for every domain, not only scheme-carrying ones.
+    padded = ConnectionConfig(domain=" sandbox.example\n", protocol="http")
+    assert (padded.domain, padded.protocol) == ("sandbox.example", "http")
+
+    with pytest.raises(ValueError, match="unsupported scheme"):
+        ConnectionConfig(domain="ftp://sandbox.example")
+    with pytest.raises(ValueError, match="no host"):
+        ConnectionConfig(domain="https://")
+    with pytest.raises(ValueError, match="query string or fragment"):
+        ConnectionConfig(domain="https://sandbox.example/prefix?token=abc")
+    with pytest.raises(ValueError, match="query string or fragment"):
+        ConnectionConfig(domain="https://sandbox.example#staging")
+
+
+def test_scheme_in_domain_reaches_sdk_and_pty_protocol(fake_opensandbox_sdk: None) -> None:
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={
+            "domain": "https://sandbox.example/",
+            "api_key": "key",  # pragma: allowlist secret
+            "protocol": "http",
+        }
+    )
+    kwargs = provider._connection_config().kwargs
+    assert kwargs["domain"] == "sandbox.example"
+    assert kwargs["protocol"] == "https"
+    # The PTY WebSocket URL is built from the provider's own protocol, not the SDK's base URL.
+    assert provider._connection.protocol == "https"


### PR DESCRIPTION
## What does this PR do?

Lets `sandbox.opensandbox.connection.domain` carry its scheme. When the domain is `https://sandbox.example` (or `OPENSANDBOX_DOMAIN=https://sandbox.example`), the provider now derives `connection.protocol: https` from it and hands the SDK the bare host, so an `https` endpoint no longer needs a separate `++sandbox.opensandbox.connection.protocol=https` override on top of #3104's `tls_verify`.

Behaviour:
- A scheme in the domain **takes precedence** over `connection.protocol`. The shipped `opensandbox.yaml` always sets `protocol: http`, so precedence the other way would make the common case (yaml default + `https://` domain) silently talk plain HTTP.
- Any path prefix in the domain is kept (`https://host/prefix` → domain `host/prefix`, protocol `https`); the SDK appends `/v1` as before.
- Only `scheme://host[:port][/path-prefix]` is accepted: schemes other than `http`/`https`, scheme-only domains (`https://`), and domains carrying a query string or fragment raise a `ValueError` at config time (before this change a `?token=...` in the domain reached the SDK and produced an unroutable `.../prefix?token=abc/v1`).
- Surrounding whitespace is stripped from every domain, scheme or not (an `OPENSANDBOX_DOMAIN` read with a trailing newline previously reached the SDK verbatim and failed URL parsing on the first request; `cleanup_sandboxes.py` already did this).
- Bare hosts are otherwise unchanged: `protocol` still applies as before.

Why normalize in Gym rather than rely on the SDK: the OpenSandbox SDK already lets a scheme in *its* domain override `protocol` when it builds its own base URL, but the provider builds the PTY WebSocket URL from `connection.protocol` directly, so a scheme-in-domain config previously produced an `https` REST transport and an `http` PTY URL. Normalizing once in `OpenSandboxConnectionConfig.__post_init__` keeps the SDK transport, the PTY path and `cleanup_sandboxes.py` (which already accepted a scheme in `--domain`) consistent.

Files: `provider.py` (new module-level helper `split_domain_scheme(domain) -> (domain, scheme)` used by a three-line `__post_init__`; `OpenSandboxConnectionConfig` drops `frozen=True` so it can assign its own fields — nothing hashes or replaces it), `opensandbox.yaml` (comment), `opensandbox.mdx` and `opensandbox-best-practices.mdx` (docs), `test_opensandbox_provider.py` (new tests; one existing assertion updated from pass-through to normalized form).

## Usage

```bash
export OPENSANDBOX_DOMAIN=https://sandbox.example.internal   # scheme included
export OPENSANDBOX_API_KEY=...
gym run \
    --config resources_servers/swebench/configs/swebench.yaml \
    --config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml \
    ++sandbox.opensandbox.connection.tls_verify=false          # self-signed endpoint; default
```
Previously this also required `++sandbox.opensandbox.connection.protocol=https`.

## Testing

- `pytest tests/unit_tests/test_opensandbox_provider.py` — 59 passed (3 new tests: the helper directly, normalization/precedence/whitespace/error cases, and the derived protocol reaching the SDK kwargs and the provider's PTY protocol).
- Reviewed with an adversarial two-dimension pass (correctness, design); the four confirmed low-severity findings (query/fragment silently dropped, whitespace stripped only for scheme'd domains, docstring rationale, sibling docs page) are addressed in this revision.
- `pre-commit run --files <changed files>` clean.
- End-to-end on a live OpenSandbox cluster behind a self-signed `https://` load balancer (SWE-bench Verified, 1024 parallel, this branch): `OPENSANDBOX_DOMAIN=https://<host>`, the shipped `protocol: http`, **no** `++sandbox.opensandbox.connection.protocol=https` override. Sandbox creation: 0 failures, 0 SSL errors, 0 connection errors; rollouts progressed normally. The same launch on a tree without this change fails every create on port 80 within a minute.

## Checklist

- [x] The change is focused.
- [x] Tests added or updated and pass locally.
- [x] Pre-commit checks pass locally.
- [x] All commits have DCO sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
