### PR TITLE
fix(simple_agent): bound consecutive stalled turns

### DIFF
--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -60,6 +60,7 @@ class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
     max_steps: int = None
+    max_consecutive_stalled_steps: int = 4
 
 
 class SimpleAgentRunRequest(BaseRunRequest):
@@ -100,6 +101,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         new_outputs = []
         usage = None
         step = 0
+        consecutive_stalled_steps = 0
         invocation_status = "completed"
         model_server_cookies = None
 
@@ -170,6 +172,15 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             ]
             if not all_fn_calls and all_output_messages:
                 break
+
+            # A reasoning-only turn is legitimate; an unbounded run of them is not.
+            if not all_fn_calls and not all_output_messages:
+                consecutive_stalled_steps += 1
+                if consecutive_stalled_steps >= self.config.max_consecutive_stalled_steps:
+                    invocation_status = "incomplete"
+                    break
+            else:
+                consecutive_stalled_steps = 0
 
             for output_function_call in all_fn_calls:
                 if collect_trajectory:

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -684,6 +684,60 @@ class TestApp:
         }
         assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
+    async def test_responses_stops_on_endless_reasoning_only(self) -> None:
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my server name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="",
+            ),
+            max_consecutive_stalled_steps=3,
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_response_reasoning_data = {
+            "id": "resp_stalled",
+            "created_at": 1753983920.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_stalled",
+                    "summary": [
+                        {
+                            "text": "I'm still thinking",
+                            "type": "summary_text",
+                        }
+                    ],
+                    "status": "completed",
+                    "type": "reasoning",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        dotjson_mock = AsyncMock()
+        dotjson_mock.read.return_value = json.dumps(mock_response_reasoning_data)
+        dotjson_mock.cookies = MagicMock()
+        server.server_client.post.return_value = dotjson_mock
+
+        res = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hello"}]})
+        assert res.status_code == 200
+
+        # A model that never emits an assistant message must not loop forever.
+        assert server.server_client.post.call_count == 3
+
     async def test_usage_sanity(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(
             host="0.0.0.0",


### PR DESCRIPTION
## Problem

`SimpleAgent.__call__` runs `while True` and leaves the loop only on:

- `incomplete_details`,
- a turn with an assistant message and no tool call (`app.py`, the `not all_fn_calls and all_output_messages` break),
- `max_steps` — which defaults to `None`, so this guard is off unless a benchmark opts in.

A turn with **neither** a function call **nor** an assistant message matches none
of these. Continuing on such a turn is deliberate — `test_responses_continues_on_reasoning_only`
pins it, and it is correct: a reasoning model may think in one turn and answer in
the next. What is missing is a bound.

If the model keeps producing reasoning and never an assistant message, the agent
re-calls it until something external kills the job. Because each dud turn is
appended to the conversation (`new_outputs.extend(output)`), every retry is more
expensive than the last.

## Impact observed

On an internal 388-row vision benchmark with no tools, one rollout made **225
sequential model calls across three 4-hour Slurm jobs — 12 of the run's 16.4 h**.
Effective concurrency was 1 against a configured 512. `prompt_tokens` grew
41050 -> 56057 -> 57489 as the conversation accumulated stalled turns. Every
serving-side metric looked healthy throughout, so this is invisible from the
engine: the waste is entirely agent-side.

## Change

Bound only the stalled case:

- new `SimpleAgentConfig.max_consecutive_stalled_steps`, default `4`;
- a turn with no function call and no assistant message increments a counter and
  breaks with `invocation_status = "incomplete"` once the bound is reached;
- **the counter resets whenever a turn makes progress**, so multi-step tool-using
  agents (`tau2` at 200 steps, `osworld` at 15, and so on) are unaffected.

Existing continue-on-reasoning behaviour is preserved:
`test_responses_continues_on_reasoning_only` still passes unchanged.

## Tests

`test_responses_stops_on_endless_reasoning_only` — a model server that always
returns a reasoning-only response must be called exactly
`max_consecutive_stalled_steps` times, not indefinitely.

```
$ pytest responses_api_agents/simple_agent/tests/test_app.py -q
13 passed
```
`pre-commit run --files` on both touched files: clean.

## Notes for reviewers

- The default of `4` is a judgement call: high enough that a genuine
  think-then-answer sequence is never cut (the existing test needs 1), low enough
  that the pathology above costs minutes instead of hours. Happy to change it.
- An alternative would be to give `max_steps` a non-`None` default, but that
  changes behaviour for every multi-step agent in the repo, so I avoided it.
- Benchmarks that are genuinely single-turn are still better off setting
  `max_steps: 1` explicitly, as `lmarena_v2`, `lmarena_v3` and `brevbench` do.
  This change is the backstop for the ones that have not.
