### PR TITLE
feat(aalcr): move to dataset v1.1 and select data and judge protocol together

### DIFF
--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -3,6 +3,17 @@
 gym eval prepare --benchmark aalcr
 ```
 
+The upstream HuggingFace dataset is pinned to a fixed revision (`HF_REVISION` in `prepare.py`, currently
+dataset v1.0) so that scores stay reproducible when upstream publishes a new revision. To prepare against a
+different dataset version, override the revision:
+
+```bash
+gym eval prepare --benchmark aalcr ++prepare_script_args.revision=<commit-sha-or-tag>
+```
+
+Note that scores are not comparable across upstream dataset versions — v1.1 changed 16 of the 100 answer
+keys and revised the judge protocol.
+
 # Run
 ```bash
 gym eval run \

--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -3,16 +3,25 @@
 gym eval prepare --benchmark aalcr
 ```
 
-The upstream HuggingFace dataset is pinned to a fixed revision (`HF_REVISION` in `prepare.py`, currently
-dataset v1.0) so that scores stay reproducible when upstream publishes a new revision. To prepare against a
-different dataset version, override the revision:
+# Dataset version
+
+The benchmark tracks a pinned upstream version, currently **v1.1**, rather than resolving `main` — upstream
+publishes breaking revisions in place, and v1.1 corrected 16 of the 100 answer keys.
+
+Upstream versions the answer keys and the judge protocol *together*, so `resources_servers/aalcr/versions.py`
+selects them together: one `version` fixes the dataset revision, the judge system prompt, the user prompt and
+the verdict format. Choosing them independently grades v1.1 keys under the v1.0 protocol (or the reverse),
+which matches no published version and yields a plausible but meaningless score.
+
+To reproduce results from an older version, move both selectors together:
 
 ```bash
-gym eval prepare --benchmark aalcr ++prepare_script_args.revision=<commit-sha-or-tag>
+gym eval prepare --benchmark aalcr ++prepare_script_args.version=1.0
+gym eval run --benchmark aalcr ... '++aalcr_benchmark_resources_server.resources_servers.aalcr.dataset_version=1.0'
 ```
 
-Note that scores are not comparable across upstream dataset versions — v1.1 changed 16 of the 100 answer
-keys and revised the judge protocol.
+Scores are **not comparable across upstream versions** — results produced under v1.0 must be re-run, not
+compared.
 
 # Run
 ```bash

--- a/benchmarks/aalcr/config.yaml
+++ b/benchmarks/aalcr/config.yaml
@@ -18,6 +18,9 @@ aalcr_benchmark_resources_server:
         type: responses_api_models
         name: Qwen3-235B-A22B-Instruct-2507-FP8
       judge_responses_create_params_overrides: {}
+      # Selects the upstream answer keys and the judge protocol together; keep in step with
+      # `++prepare_script_args.version`. See resources_servers/aalcr/versions.py.
+      dataset_version: "1.1"
 
 aalcr_benchmark_simple_agent:
   responses_api_agents:

--- a/benchmarks/aalcr/prepare.py
+++ b/benchmarks/aalcr/prepare.py
@@ -32,6 +32,11 @@ BENCHMARK_DIR = Path(__file__).parent
 DATA_DIR = BENCHMARK_DIR / "data"
 OUTPUT_FPATH = DATA_DIR / "aalcr_benchmark.jsonl"
 
+HF_REPO_ID = "ArtificialAnalysis/AA-LCR"
+# Pinned HuggingFace dataset revision. Upstream publishes breaking revisions to `main` (v1.1 rewrote 16
+# of the 100 answer keys), so resolving `main` silently changes scores. This pin is dataset v1.0.
+HF_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"  # pragma: allowlist secret
+
 
 # From https://github.com/NVIDIA-NeMo/Skills/blob/54d2e113c2f64bf74bda72e15f23f01b524850da/nemo_skills/dataset/aalcr/prepare.py#L94-L105
 def _dirty_filename(fname: str) -> str:
@@ -51,12 +56,23 @@ def _dirty_filename(fname: str) -> str:
     return filename_with_artifacts
 
 
-def prepare() -> Path:
+def prepare(revision: str = HF_REVISION) -> Path:
+    """Prepare the AA-LCR benchmark data at a pinned upstream dataset revision.
+
+    Args:
+        revision: HuggingFace revision (commit sha, tag or branch) for both the answer keys and the
+            source documents. Defaults to dataset v1.0. Override via
+            `++prepare_script_args.revision=<sha>` to evaluate against a different dataset version.
+    """
     DATA_DIR.mkdir(parents=True, exist_ok=True)
 
-    data = load_dataset("ArtificialAnalysis/AA-LCR", split="test", token=get_hf_token())
+    print(f"Preparing {HF_REPO_ID} at revision {revision}")
 
-    documents_url = "https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR/resolve/main/extracted_text/AA-LCR_extracted-text.zip"
+    data = load_dataset(HF_REPO_ID, split="test", revision=revision, token=get_hf_token())
+
+    documents_url = (
+        f"https://huggingface.co/datasets/{HF_REPO_ID}/resolve/{revision}/extracted_text/AA-LCR_extracted-text.zip"
+    )
     response = requests.get(documents_url)
     response.raise_for_status()
     zip_file = ZipFile(BytesIO(response.content))

--- a/benchmarks/aalcr/prepare.py
+++ b/benchmarks/aalcr/prepare.py
@@ -26,6 +26,7 @@ import requests
 from datasets import load_dataset
 
 from nemo_gym.global_config import get_hf_token
+from resources_servers.aalcr.versions import DEFAULT_VERSION, get_version
 
 
 BENCHMARK_DIR = Path(__file__).parent
@@ -33,9 +34,6 @@ DATA_DIR = BENCHMARK_DIR / "data"
 OUTPUT_FPATH = DATA_DIR / "aalcr_benchmark.jsonl"
 
 HF_REPO_ID = "ArtificialAnalysis/AA-LCR"
-# Pinned HuggingFace dataset revision. Upstream publishes breaking revisions to `main` (v1.1 rewrote 16
-# of the 100 answer keys), so resolving `main` silently changes scores. This pin is dataset v1.0.
-HF_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"  # pragma: allowlist secret
 
 
 # From https://github.com/NVIDIA-NeMo/Skills/blob/54d2e113c2f64bf74bda72e15f23f01b524850da/nemo_skills/dataset/aalcr/prepare.py#L94-L105
@@ -56,17 +54,18 @@ def _dirty_filename(fname: str) -> str:
     return filename_with_artifacts
 
 
-def prepare(revision: str = HF_REVISION) -> Path:
+def prepare(version: str = DEFAULT_VERSION) -> Path:
     """Prepare the AA-LCR benchmark data at a pinned upstream dataset revision.
 
-    Args:
-        revision: HuggingFace revision (commit sha, tag or branch) for both the answer keys and the
-            source documents. Defaults to dataset v1.0. Override via
-            `++prepare_script_args.revision=<sha>` to evaluate against a different dataset version.
+    Upstream publishes breaking revisions to `main` (v1.1 corrected 16 of the 100 answer keys), so the
+    revision is pinned rather than resolved. `version` selects the answer keys *and* the judge protocol
+    that grades them, which upstream versions together; set it via `++prepare_script_args.version=1.0`
+    and the matching `dataset_version` on the resources server to reproduce older results.
     """
     DATA_DIR.mkdir(parents=True, exist_ok=True)
 
-    print(f"Preparing {HF_REPO_ID} at revision {revision}")
+    revision = get_version(version).revision
+    print(f"Preparing {HF_REPO_ID} v{version} at revision {revision}")
 
     data = load_dataset(HF_REPO_ID, split="test", revision=revision, token=get_hf_token())
 

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import re
 from typing import Any, Dict, Optional
 
 from nemo_gym.base_resources_server import (
@@ -24,11 +26,50 @@ from nemo_gym.base_resources_server import (
 from nemo_gym.config_types import ModelServerRef
 from nemo_gym.judge import JudgeError, call_judge
 from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from resources_servers.aalcr.versions import DEFAULT_VERSION, get_version
+
+
+VERDICT_CORRECT = "CORRECT"
+VERDICT_INCORRECT = "INCORRECT"
+
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _parse_json_verdict(judge_response_text: str) -> Optional[str]:
+    """Extract the verdict from a JSON judge reply, or None if it is unusable.
+
+    The upstream prompt asks for "JSON, with a verdict of CORRECT or INCORRECT" without fixing a schema,
+    so accept any JSON object carrying a `verdict` key, tolerating a code fence or surrounding prose.
+    """
+    match = _JSON_OBJECT_RE.search(judge_response_text)
+    if match is None:
+        return None
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    for key, value in parsed.items():
+        if isinstance(key, str) and key.strip().lower() == "verdict" and isinstance(value, str):
+            verdict = value.strip().upper()
+            if verdict in (VERDICT_CORRECT, VERDICT_INCORRECT):
+                return verdict
+    return None
+
+
+def _parse_bare_verdict(judge_response_text: str) -> Optional[str]:
+    if judge_response_text in (VERDICT_CORRECT, VERDICT_INCORRECT):
+        return judge_response_text
+    return None
 
 
 class AalcrResourcesServerConfig(BaseResourcesServerConfig):
     judge_model_server: ModelServerRef
     judge_responses_create_params_overrides: Dict[str, Any]
+    # Selects the upstream answer keys *and* the judge protocol that grades them; see versions.py.
+    dataset_version: str = DEFAULT_VERSION
 
 
 class AALCRVerifyRequest(BaseVerifyRequest):
@@ -81,16 +122,14 @@ class AalcrResourcesServer(SimpleResourcesServer):
                 **{input_tokens_band_key: reward},
             )
 
-        judge_prompt = f"""Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
-For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+        version = get_version(self.config.dataset_version)
+        judge_prompt = version.judge_user_prompt.format(
+            question=body.question, official_answer=body.answer, candidate_answer=candidate_answer
+        )
 
-The question, for reference only: {body.question}
-The OFFICIAL ANSWER: {body.answer}
-CANDIDATE ANSWER TO ASSESS: {candidate_answer}
-
-Reply only with CORRECT or INCORRECT."""
-
-        judge_responses_create_params = dict(input=[{"role": "user", "content": judge_prompt}])
+        judge_responses_create_params: Dict[str, Any] = dict(input=[{"role": "user", "content": judge_prompt}])
+        if version.judge_system_prompt is not None:
+            judge_responses_create_params["instructions"] = version.judge_system_prompt
         judge_responses_create_params |= self.config.judge_responses_create_params_overrides
 
         judge_response = await call_judge(
@@ -104,15 +143,10 @@ Reply only with CORRECT or INCORRECT."""
         if not judge_response_text:
             raise JudgeError("empty judge response")
 
-        if judge_response_text == "CORRECT":
-            invalid_judge_response = False
-            reward = 1.0
-        elif judge_response_text == "INCORRECT":
-            invalid_judge_response = False
-            reward = 0.0
-        else:
-            invalid_judge_response = True
-            reward = 0.0
+        parse = _parse_json_verdict if version.judge_replies_json else _parse_bare_verdict
+        verdict = parse(judge_response_text)
+        invalid_judge_response = verdict is None
+        reward = 1.0 if verdict == VERDICT_CORRECT else 0.0
 
         return AALCRVerifyResponse(
             **body.model_dump(),

--- a/resources_servers/aalcr/configs/aalcr.yaml
+++ b/resources_servers/aalcr/configs/aalcr.yaml
@@ -8,6 +8,9 @@ aalcr_resources_server:
         type: responses_api_models
         name: Qwen3-235B-A22B-Instruct-2507-FP8
       judge_responses_create_params_overrides: {}
+      # Selects the upstream answer keys and the judge protocol together; keep in step with
+      # `++prepare_script_args.version`. See resources_servers/aalcr/versions.py.
+      dataset_version: "1.1"
 aalcr_simple_agent:
   responses_api_agents:
     simple_agent:

--- a/resources_servers/aalcr/tests/test_app.py
+++ b/resources_servers/aalcr/tests/test_app.py
@@ -12,14 +12,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.server_utils import ServerClient
-from resources_servers.aalcr.app import AalcrResourcesServer, AalcrResourcesServerConfig
+from resources_servers.aalcr.app import (
+    AalcrResourcesServer,
+    AalcrResourcesServerConfig,
+    AALCRVerifyRequest,
+    _parse_bare_verdict,
+    _parse_json_verdict,
+)
+from resources_servers.aalcr.versions import DEFAULT_VERSION, VERSIONS, get_version
 
 
-def _config() -> AalcrResourcesServerConfig:
+def _config(dataset_version: str = DEFAULT_VERSION) -> AalcrResourcesServerConfig:
     return AalcrResourcesServerConfig(
+        dataset_version=dataset_version,
         host="0.0.0.0",
         port=8080,
         entrypoint="",
@@ -35,3 +47,208 @@ def _config() -> AalcrResourcesServerConfig:
 class TestApp:
     def test_sanity(self) -> None:
         AalcrResourcesServer(config=_config(), server_client=MagicMock(spec=ServerClient))
+
+
+class FakeHTTPResponse:
+    ok = True
+
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    async def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def _make_response(text: str) -> dict:
+    return NeMoGymResponse(
+        id="judge_response",
+        created_at=0.0,
+        model="test-judge",
+        object="response",
+        output=[
+            {
+                "id": "message_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    ).model_dump()
+
+
+def _server(judge_reply: str, dataset_version: str = DEFAULT_VERSION) -> AalcrResourcesServer:
+    server_client = MagicMock(spec=ServerClient)
+    server_client.post = AsyncMock(return_value=FakeHTTPResponse(_make_response(judge_reply)))
+    return AalcrResourcesServer(config=_config(dataset_version), server_client=server_client)
+
+
+def _request(candidate_answer: str = "65.8%") -> AALCRVerifyRequest:
+    return AALCRVerifyRequest(
+        responses_create_params={"input": [{"role": "user", "content": "BEGIN INPUT DOCUMENTS..."}]},
+        response=NeMoGymResponse(
+            id="policy_response",
+            created_at=0.0,
+            model="test-policy",
+            object="response",
+            output=[
+                {
+                    "id": "message_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": candidate_answer, "annotations": []}],
+                }
+            ],
+            parallel_tool_calls=True,
+            tool_choice="auto",
+            tools=[],
+        ),
+        document_category="Company_Reports",
+        document_set_id="set_1",
+        question_id=28,
+        question="What was the margin?",
+        answer="65.8%",
+        data_source_filenames="a.txt",
+        data_source_urls="https://example.invalid/a",
+        input_tokens=90000,
+        input_tokens_band="80k-100k",
+    )
+
+
+class TestJudgePrompts:
+    """The prompts must stay byte-faithful to the upstream dataset card at each pinned revision."""
+
+    def test_v1_1_adds_a_system_prompt_with_the_four_grading_rules(self) -> None:
+        system_prompt = VERSIONS["1.1"].judge_system_prompt
+        assert system_prompt.startswith(
+            "Decide whether the CANDIDATE ANSWER is correct or incorrect against the OFFICIAL ANSWER."
+        )
+        assert system_prompt.count("\n- ") == 4
+        assert '0.675, "67.5%" and "67.5 percentage points" all match' in system_prompt
+
+    def test_v1_0_has_no_system_prompt(self) -> None:
+        assert VERSIONS["1.0"].judge_system_prompt is None
+
+    def test_v1_1_user_prompt_uses_delimited_blocks_and_asks_for_json(self) -> None:
+        prompt = VERSIONS["1.1"].judge_user_prompt.format(question="Q?", official_answer="A", candidate_answer="C")
+        for marker in (
+            "START QUESTION Q?",
+            "END QUESTION",
+            "The OFFICIAL ANSWER: A",
+            "END OFFICIAL ANSWER",
+            "BEGIN CANDIDATE ANSWER TO ASSESS",
+            "END CANDIDATE ANSWER TO ASSESS",
+        ):
+            assert marker in prompt
+        assert prompt.endswith("Reply as JSON, with a verdict of CORRECT or INCORRECT.")
+        # The superseded instruction must not linger; it is what makes a judge emit a bare verdict.
+        assert "Reply only with CORRECT or INCORRECT." not in prompt
+
+    def test_v1_0_user_prompt_is_unchanged(self) -> None:
+        prompt = VERSIONS["1.0"].judge_user_prompt.format(question="Q?", official_answer="A", candidate_answer="C")
+        assert "The question, for reference only: Q?" in prompt
+        assert "CANDIDATE ANSWER TO ASSESS: C" in prompt
+        assert prompt.endswith("Reply only with CORRECT or INCORRECT.")
+
+
+class TestVersionTable:
+    def test_each_version_pairs_a_revision_with_a_protocol(self) -> None:
+        assert set(VERSIONS) == {"1.0", "1.1"}
+        assert VERSIONS["1.0"].revision != VERSIONS["1.1"].revision
+        assert VERSIONS["1.0"].judge_replies_json is False
+        assert VERSIONS["1.1"].judge_replies_json is True
+
+    def test_unknown_version_is_rejected_by_name(self) -> None:
+        with pytest.raises(ValueError, match="Unknown AA-LCR version"):
+            get_version("1.2")
+
+
+class TestParseJudgeVerdict:
+    @pytest.mark.parametrize(
+        "reply, expected",
+        [
+            ('{"verdict": "CORRECT"}', "CORRECT"),
+            ('{"verdict": "INCORRECT"}', "INCORRECT"),
+            ('```json\n{"verdict": "CORRECT"}\n```', "CORRECT"),
+            ('Here is my assessment:\n{"verdict": "INCORRECT"}\nDone.', "INCORRECT"),
+            ('{"verdict": "correct"}', "CORRECT"),
+            ('{"Verdict": " CORRECT "}', "CORRECT"),
+            ('{"reasoning": "matches after unit conversion", "verdict": "CORRECT"}', "CORRECT"),
+        ],
+    )
+    def test_json_parser_accepts_json_verdicts(self, reply: str, expected: str) -> None:
+        assert _parse_json_verdict(reply) == expected
+
+    @pytest.mark.parametrize(
+        "reply",
+        [
+            "CORRECT",  # the superseded v1.0 bare-verdict format
+            "INCORRECT",
+            "",
+            "The answer looks right to me.",
+            '{"verdict": "MAYBE"}',
+            '{"result": "CORRECT"}',
+            '{"verdict": true}',
+            '["CORRECT"]',
+            '{"verdict": "CORRECT"',  # truncated JSON
+        ],
+    )
+    def test_json_parser_rejects_everything_else(self, reply: str) -> None:
+        assert _parse_json_verdict(reply) is None
+
+    @pytest.mark.parametrize("reply, expected", [("CORRECT", "CORRECT"), ("INCORRECT", "INCORRECT")])
+    def test_bare_parser_accepts_v1_0_verdicts(self, reply: str, expected: str) -> None:
+        assert _parse_bare_verdict(reply) == expected
+
+    @pytest.mark.parametrize("reply", ['{"verdict": "CORRECT"}', "", "Correct", "CORRECT."])
+    def test_bare_parser_rejects_everything_else(self, reply: str) -> None:
+        assert _parse_bare_verdict(reply) is None
+
+
+class TestVerify:
+    async def test_correct_verdict_scores_one_and_sends_the_system_prompt(self) -> None:
+        response = await _server('{"verdict": "CORRECT"}').verify(_request())
+        assert response.reward == 1.0
+        assert response.invalid_judge_response is False
+        assert response.invalid_model_response is False
+        assert response.reward_80k_100k == 1.0
+        assert response.judge_responses_create_params.instructions == VERSIONS["1.1"].judge_system_prompt
+
+    async def test_incorrect_verdict_scores_zero_and_is_not_flagged(self) -> None:
+        response = await _server('{"verdict": "INCORRECT"}').verify(_request())
+        assert response.reward == 0.0
+        assert response.invalid_judge_response is False
+
+    async def test_unparseable_judge_reply_is_flagged_not_silently_zero(self) -> None:
+        """A judge that ignores the JSON instruction must be visible in `invalid_judge_response`.
+
+        `nemo_gym.judge` reserves exceptions for failed judge *calls*; a received-but-unparseable reply is
+        scored, so the flag is the only signal that a run was mis-graded rather than merely answered badly.
+        A bare `CORRECT` is exactly what a v1.0-shaped judge returns, so this also covers the prompt/parser
+        mismatch that would otherwise drive every rollout to zero.
+        """
+        response = await _server("CORRECT").verify(_request())
+        assert response.reward == 0.0
+        assert response.invalid_judge_response is True
+
+    async def test_selecting_v1_0_restores_the_whole_v1_0_protocol(self) -> None:
+        """One selector moves the data and the protocol together, so v1.0 grades v1.0 the way it did."""
+        server = _server("CORRECT", dataset_version="1.0")
+        response = await server.verify(_request())
+        assert response.reward == 1.0
+        assert response.invalid_judge_response is False
+        assert response.judge_responses_create_params.instructions is None
+
+    async def test_v1_0_rejects_a_json_reply(self) -> None:
+        response = await _server('{"verdict": "CORRECT"}', dataset_version="1.0").verify(_request())
+        assert response.reward == 0.0
+        assert response.invalid_judge_response is True
+
+    async def test_empty_candidate_answer_short_circuits_the_judge(self) -> None:
+        server = _server('{"verdict": "CORRECT"}')
+        response = await server.verify(_request(candidate_answer="   "))
+        assert response.reward == 0.0
+        assert response.invalid_model_response is True
+        server.server_client.post.assert_not_called()

--- a/resources_servers/aalcr/versions.py
+++ b/resources_servers/aalcr/versions.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Upstream AA-LCR versions: dataset revision and its matching judge protocol.
+
+Upstream versions the answer keys and the scoring protocol *together*, so they are selected together
+here. Mixing them silently mis-grades: several v1.1 keys carry grading instructions addressed to the
+judge (question 26 offers two acceptable values, question 78 permits either alphabetical ordering), and
+nine more are notation rewrites (`0.16` to `16%`) whose equivalence only the v1.1 system prompt declares.
+Graded by the v1.0 protocol those keys produce a plausible but meaningless number, so `revision` is
+deliberately not exposed on its own -- callers pick a `version`, and the protocol follows it.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+# Verbatim from the upstream dataset card ("Scoring Approach") at revision REVISION_V1_1.
+_JUDGE_SYSTEM_PROMPT_V1_1 = """Decide whether the CANDIDATE ANSWER is correct or incorrect against the OFFICIAL ANSWER.
+Note the following points when assessing correctness:
+
+- Numbers should still match when they are the same value written differently, e.g., a
+  percentage, a count of percentage points, and the equivalent decimal fraction are the same
+  value: 0.675, "67.5%" and "67.5 percentage points" all match. So do different scales
+  (thousand, million, bn) and different notations (thousands separators, currency symbols,
+  LaTeX markup, and numbers written as words).
+- Where the question asks for a particular format (e.g., a percentage, a number of decimal
+  places, a unit, a rounding, or an ordering) the CANDIDATE ANSWER must meet it. If the
+  question asks for no particular format, accept any equivalent form.
+- In cases where the question asks for an ordered list, a title, honorific or article added
+  to an entry in the CANDIDATE ANSWER can change where that entry sorts. Accept the ordering
+  if it is correct either with those additions or without them.
+- Grade the value the CANDIDATE ANSWER finally commits to, and it must commit to one. Values
+  reached while working, and alternatives it considers and sets aside, do not count. If it
+  offers several values without selecting one, it is incorrect even if one of them is right.
+  Hedging is fine as long as one clearly definitive answer is given."""
+
+_JUDGE_USER_PROMPT_V1_1 = """Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
+For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+
+The question, for reference only: START QUESTION {question}
+
+END QUESTION
+
+The OFFICIAL ANSWER: {official_answer}
+
+END OFFICIAL ANSWER
+
+BEGIN CANDIDATE ANSWER TO ASSESS
+
+{candidate_answer}
+
+END CANDIDATE ANSWER TO ASSESS
+
+Reply as JSON, with a verdict of CORRECT or INCORRECT."""
+
+# The v1.0 dataset card documents this compact prompt, and it is what this server has always sent. The
+# v1.1 card retroactively describes v1.0 as having used the delimited blocks above; it did not, so this
+# is kept as-is to reproduce results actually produced under v1.0 rather than the later description.
+_JUDGE_USER_PROMPT_V1_0 = """Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
+For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+
+The question, for reference only: {question}
+The OFFICIAL ANSWER: {official_answer}
+CANDIDATE ANSWER TO ASSESS: {candidate_answer}
+
+Reply only with CORRECT or INCORRECT."""
+
+
+@dataclass(frozen=True)
+class AalcrVersion:
+    """A published AA-LCR version: the data and the protocol that grades it."""
+
+    revision: str
+    judge_user_prompt: str
+    judge_system_prompt: Optional[str]
+    judge_replies_json: bool
+
+
+VERSIONS: Dict[str, AalcrVersion] = {
+    "1.0": AalcrVersion(
+        revision="bdae010bbce259820c0e34c1d7cce210d966fb75",  # pragma: allowlist secret
+        judge_user_prompt=_JUDGE_USER_PROMPT_V1_0,
+        judge_system_prompt=None,
+        judge_replies_json=False,
+    ),
+    "1.1": AalcrVersion(
+        revision="9a77ef56b717057ade24ceab4d273712a0b4f19e",  # pragma: allowlist secret
+        judge_user_prompt=_JUDGE_USER_PROMPT_V1_1,
+        judge_system_prompt=_JUDGE_SYSTEM_PROMPT_V1_1,
+        judge_replies_json=True,
+    ),
+}
+
+DEFAULT_VERSION = "1.1"
+
+
+def get_version(version: str) -> AalcrVersion:
+    if version not in VERSIONS:
+        raise ValueError(f"Unknown AA-LCR version {version!r}. Known versions: {sorted(VERSIONS)}")
+    return VERSIONS[version]

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -35,6 +36,26 @@ def test_pinchbench_tavily_key_is_derived_from_environment() -> None:
 
     assert benchmark["tavily_api_key"] == "${oc.env:PINCHBENCH_TAVILY_API_KEY,null}"
     assert agent["pinchbench_agent"]["responses_api_agents"]["pinchbench"]["tavily_api_key"] == ("${tavily_api_key}")
+
+
+def test_aalcr_dataset_revision_is_pinned() -> None:
+    """AA-LCR must resolve a fixed upstream revision, not `main`.
+
+    Upstream publishes breaking revisions to `main` (a past one rewrote 16 of the 100 answer keys), which
+    silently changes scores for a config that is otherwise unchanged.
+    """
+    import importlib.util
+    import inspect
+
+    repo_root = Path(__file__).parents[2]
+    prepare_fpath = repo_root / "benchmarks/aalcr/prepare.py"
+    spec = importlib.util.spec_from_file_location("_aalcr_prepare", prepare_fpath)
+    aalcr_prepare = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(aalcr_prepare)
+
+    assert re.fullmatch(r"[0-9a-f]{40}", aalcr_prepare.HF_REVISION), "pin must be a full commit sha"
+    assert inspect.signature(aalcr_prepare.prepare).parameters["revision"].default == aalcr_prepare.HF_REVISION
+    assert "resolve/main/" not in prepare_fpath.read_text()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -39,13 +39,16 @@ def test_pinchbench_tavily_key_is_derived_from_environment() -> None:
 
 
 def test_aalcr_dataset_revision_is_pinned() -> None:
-    """AA-LCR must resolve a fixed upstream revision, not `main`.
+    """AA-LCR must resolve a fixed upstream revision, not `main`, and pick its judge protocol with it.
 
-    Upstream publishes breaking revisions to `main` (a past one rewrote 16 of the 100 answer keys), which
-    silently changes scores for a config that is otherwise unchanged.
+    Upstream publishes breaking revisions to `main` (v1.1 corrected 16 of the 100 answer keys) and
+    versions the judge protocol alongside them, so a floating revision silently changes scores and a
+    revision chosen independently of the protocol silently mis-grades.
     """
     import importlib.util
     import inspect
+
+    from resources_servers.aalcr.versions import DEFAULT_VERSION, VERSIONS
 
     repo_root = Path(__file__).parents[2]
     prepare_fpath = repo_root / "benchmarks/aalcr/prepare.py"
@@ -53,8 +56,15 @@ def test_aalcr_dataset_revision_is_pinned() -> None:
     aalcr_prepare = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(aalcr_prepare)
 
-    assert re.fullmatch(r"[0-9a-f]{40}", aalcr_prepare.HF_REVISION), "pin must be a full commit sha"
-    assert inspect.signature(aalcr_prepare.prepare).parameters["revision"].default == aalcr_prepare.HF_REVISION
+    assert DEFAULT_VERSION == "1.1"
+    assert VERSIONS[DEFAULT_VERSION].revision == "9a77ef56b717057ade24ceab4d273712a0b4f19e"  # pragma: allowlist secret
+    for version in VERSIONS.values():
+        assert re.fullmatch(r"[0-9a-f]{40}", version.revision), "each pin must be a full commit sha"
+
+    # The data and the protocol are chosen by one selector; `revision` is deliberately not a parameter.
+    signature = inspect.signature(aalcr_prepare.prepare)
+    assert signature.parameters["version"].default == DEFAULT_VERSION
+    assert "revision" not in signature.parameters
     assert "resolve/main/" not in prepare_fpath.read_text()
 
 


### PR DESCRIPTION
## What does this PR do?

`benchmarks/aalcr/prepare.py` resolved the upstream HuggingFace dataset at `main` — both the answer keys (`load_dataset(...)`, no `revision=`) and the source documents (`.../resolve/main/...zip`). Nothing in the repo, or in a run's recorded config, said which dataset version was actually scored. Upstream then published **v1.1**, which corrected **16 of the 100 answer keys**, so an unchanged config silently started producing different scores.

This PR pins the version and moves the benchmark to v1.1.

### Why the version is one selector, not two knobs

Upstream versions the answer keys and the scoring protocol *together*, so this selects them together. `resources_servers/aalcr/versions.py` maps a version to its dataset revision, judge system prompt, judge user prompt and verdict format. `prepare()` takes `version`; the resources server takes a matching `dataset_version`. A raw `revision` is deliberately *not* exposed.

That matters because the two halves are not independent. Several v1.1 keys now carry instructions addressed to the judge — question 26 offers two acceptable values, question 78 permits either alphabetical ordering, question 10 reads `8.57%, increase not decrease`. Nine more are notation rewrites (`0.16` to `16%`, `16400000` to `$16,400,000`) whose equivalence only the v1.1 system prompt declares. Grading v1.1 keys under the v1.0 protocol matches no published version and yields a plausible but meaningless number, which is worse than an obvious failure.

v1.0 remains selectable, so earlier results stay reproducible:

```bash
gym eval prepare --benchmark aalcr ++prepare_script_args.version=1.0
gym eval run --benchmark aalcr ... '++aalcr_benchmark_resources_server.resources_servers.aalcr.dataset_version=1.0'
```

A new upstream version now needs a deliberate addition to the table rather than a passed-through sha. That is the intent: a new revision may change the protocol too, so it should get a review.

### The judge port

v1.1 replaces the scoring protocol, so `resources_servers/aalcr/app.py` moves with the data:

1. **A system prompt is added.** v1.0 ran with none. v1.1 specifies four grading rules (numeric equivalence across notations and scales; honouring a format the question demands; list-ordering tolerance for titles and honorifics; requiring the candidate to commit to exactly one value). It rides on `instructions`, which already exists on `NeMoGymResponseCreateParamsNonStreaming`, so no schema change.
2. **The user prompt changes.** The final line becomes `Reply as JSON, with a verdict of CORRECT or INCORRECT.`, and the body gains `START/END QUESTION`, `END OFFICIAL ANSWER` and `BEGIN/END CANDIDATE ANSWER TO ASSESS` delimiters.
3. **The parser changes**, from exact-matching a bare `CORRECT`/`INCORRECT` to reading a JSON verdict, tolerating a code fence or surrounding prose. Upstream asks for "JSON, with a verdict of" without fixing a schema, so any JSON object carrying a `verdict` key is accepted.

(3) is why the prompt and the parser must ship together: a v1.1 prompt with a v1.0 parser scores every rollout zero. All three prompts are stored verbatim and are asserted byte-exact against the upstream dataset card at their respective revisions.

An unparseable reply stays a scored wrong answer flagged via `invalid_judge_response`, rather than an exception — `nemo_gym.judge` reserves exceptions for failed judge *calls*. That flag is also a free canary: it aggregates to `mean/invalid_judge_response`, which sits at 0.0 when prompt and parser agree and is driven toward 1.0 by any mismatch between them, so this class of failure is detectable from the metrics alone without extra instrumentation.

### Note on the upstream dataset card

The v1.1 card's "Version 1.0.0 scoring prompt" appendix describes v1.0 as having used the delimited blocks, and differing from v1.1 only in the final line. The v1.0 card as published documents a compact prompt with no blocks, and that compact form is what this server has always sent. The `1.0` entry keeps the compact form, so selecting v1.0 reproduces what v1.0 actually scored rather than the later description of it.

## Verification

Ran the real `prepare()` against the live hub at both versions and compared all 100 answer keys against both upstream CSVs:

```
pinned    == v1.1 for ALL 100 keys: True
v1.0 pin  == v1.0 for ALL 100 keys: True
pinned differs from v1.0 on exactly the 16 changed ids: True
```

The last line is the discriminating one: exactly `[10, 21, 25, 26, 28, 30, 40, 60, 67, 76, 78, 86, 87, 89, 90, 94]`, no more and no fewer.

| qid | v1.1 (new default) | v1.0 (`version=1.0`) |
|---|---|---|
| 10 | `8.57%, increase not decrease` | `0.0153` |
| 25 | `Yes` | `No` |
| 28 | `65.8%` | `0.658` |
| 40 | `June 2024` | `45444` |
| 86 | `0.16%` | `0.0016` |

Tests: 35 in `resources_servers/aalcr/tests/test_app.py` covering both protocols end to end (verdict parsing including malformed, non-JSON and truncated replies; a bare `CORRECT` under v1.1 flagged rather than silently scored; v1.0 selection restoring the whole v1.0 protocol), plus the pin guard in `tests/unit_tests/test_benchmarks.py`. Full `tests/unit_tests/` is green apart from two sandbox-provider tests that fail identically on this branch's parent.

**Not exercised against a live judge model.** The judge is covered by unit tests with mocked replies in the shapes a real judge produces; that a given judge actually emits `{"verdict": ...}` under this prompt has not been confirmed by running one.

## Downstream impact

**v1.0 and v1.1 scores are not comparable — upstream says so directly.** Any consumer must **re-run and re-baseline every AA-LCR result**; existing numbers cannot be compared against numbers produced after this lands, and the change should be recorded as a discontinuity rather than absorbed. Expect movement upward: five of the ten notation questions were being graded against a bare decimal while the model wrote a percentage.

Also worth noting for anyone relying on it: `benchmarks/aalcr/data/aalcr_benchmark_metrics.json` does **not** flag this change. `answer.unique_count` is 98 under both versions, so the aggregate-metrics conflict check passes unchanged — it counts values rather than comparing them, and cannot detect a rewritten key.

Not changed here: the judge model. v1.1 documents a different reference equality checker, and `judge_model_server` still names the v1.0 one in both `benchmarks/aalcr/config.yaml` and `resources_servers/aalcr/configs/aalcr.yaml`. That is a separate decision about which model to serve, left deliberately for its own review.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally.
- [x] Pre-commit checks pass locally.
- [x] All commits have DCO sign-off (`git commit -s`).
