### PR TITLE
feat(orchestration): composability in gym eval submit

### DIFF
--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -543,6 +543,27 @@ def _merge_config_paths(overrides: list[str]) -> list[str]:
     return ([f"+config_paths=[{','.join(paths)}]"] if paths else []) + rest
 
 
+# Root-level keys prefixed with `_` are scratch namespaces: not part of SubmitConfig's schema, only
+# present so other parts of the config can interpolate into them (e.g. `${_image_tags.vllm}`). They must
+# be fully defined in the config file itself — `+`/`++` overrides are rejected here so a typo'd scratch
+# field (e.g. `+_image_tags.vllmm=...`) fails loudly instead of silently creating an unused field that
+# nothing interpolates against. Overriding an *existing* scratch leaf with a bare `key=value` still works,
+# and Hydra itself already rejects bare overrides of nonexistent keys, so typos there are caught for free.
+def _reject_scratch_namespace_additions(overrides: list[str]) -> None:
+    for token in overrides:
+        prefix = "++" if token.startswith("++") else "+" if token.startswith("+") else ""
+        if not prefix:
+            continue
+        key = token[len(prefix) :].split("=", 1)[0]
+        root = key.split(".", 1)[0]
+        if root.startswith("_"):
+            raise ValueError(
+                f"Refusing override {token!r}: scratch namespace {root!r} must be fully defined in the "
+                "config file. Only pre-existing fields may be overridden — use a bare 'key=value' override "
+                "instead of '+'/'++' so a typo is rejected rather than silently adding an unused field."
+            )
+
+
 def _eval_submit(args: argparse.Namespace, overrides: list[str]) -> None:
     from pathlib import Path
 
@@ -553,15 +574,17 @@ def _eval_submit(args: argparse.Namespace, overrides: list[str]) -> None:
     from nemo_gym.orchestration.api import SubmitConfig
     from nemo_gym.orchestration.submit import submit
 
+    _reject_scratch_namespace_additions(overrides)
     config_path = Path(args.config).resolve()
     GlobalHydra.instance().clear()
     with initialize_config_dir(config_dir=str(config_path.parent), version_base=None):
         composed = compose(config_name=config_path.stem, overrides=overrides)
-    # Resolve interpolations (e.g. `${my_scratch.value}`) before dropping any root-level keys that live
-    # outside SubmitConfig's schema — they may exist purely to be interpolated into the fields below.
+    # Resolve interpolations (e.g. `${_scratch.value}`) before dropping scratch namespaces (root keys
+    # prefixed with `_`) — any other unrecognized root key is a real typo and must reach SubmitConfig's
+    # strict validation so it fails loudly instead of being silently dropped.
     resolved = OmegaConf.to_container(composed, resolve=True)
-    known_fields = resolved.keys() & SubmitConfig.model_fields.keys()
-    config = SubmitConfig.model_validate({key: resolved[key] for key in known_fields})
+    scratch_keys = {key for key in resolved if key.startswith("_")}
+    config = SubmitConfig.model_validate({key: value for key, value in resolved.items() if key not in scratch_keys})
     submit(config, dry_run=args.dry_run)
 
 

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -544,16 +544,24 @@ def _merge_config_paths(overrides: list[str]) -> list[str]:
 
 
 def _eval_submit(args: argparse.Namespace, overrides: list[str]) -> None:
+    from pathlib import Path
+
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
     from omegaconf import OmegaConf
 
     from nemo_gym.orchestration.api import SubmitConfig
     from nemo_gym.orchestration.submit import submit
 
-    merged = OmegaConf.merge(
-        OmegaConf.load(args.config),
-        OmegaConf.from_dotlist([t.lstrip("+") for t in overrides]) if overrides else OmegaConf.create(),
-    )
-    config = SubmitConfig.model_validate(OmegaConf.to_container(merged, resolve=True))
+    config_path = Path(args.config).resolve()
+    GlobalHydra.instance().clear()
+    with initialize_config_dir(config_dir=str(config_path.parent), version_base=None):
+        composed = compose(config_name=config_path.stem, overrides=overrides)
+    # Resolve interpolations (e.g. `${my_scratch.value}`) before dropping any root-level keys that live
+    # outside SubmitConfig's schema — they may exist purely to be interpolated into the fields below.
+    resolved = OmegaConf.to_container(composed, resolve=True)
+    known_fields = resolved.keys() & SubmitConfig.model_fields.keys()
+    config = SubmitConfig.model_validate({key: resolved[key] for key in known_fields})
     submit(config, dry_run=args.dry_run)
 
 

--- a/tests/unit_tests/test_cli_eval_submit.py
+++ b/tests/unit_tests/test_cli_eval_submit.py
@@ -17,6 +17,7 @@ import argparse
 import pytest
 import yaml
 from hydra.errors import ConfigCompositionException
+from pydantic import ValidationError
 from pytest import MonkeyPatch
 
 import nemo_gym.orchestration.submit as submit_module
@@ -102,43 +103,79 @@ class TestEvalSubmitFlatConfig:
 
 
 class TestEvalSubmitScratchNamespace:
-    """Root-level keys outside SubmitConfig's schema are allowed to exist purely for interpolation, but must
-    be resolved away before validation instead of tripping SubmitConfig's `extra="forbid"`."""
+    """Root-level keys prefixed with `_` are scratch namespaces: not part of SubmitConfig's schema, only
+    present so other fields can interpolate into them. They must be fully defined in the config file
+    itself (only pre-existing leaves may be overridden, and only with a bare `key=value`), and get
+    resolved-then-stripped before validation instead of tripping SubmitConfig's `extra="forbid"`."""
 
-    def test_extra_root_key_is_stripped_before_validation(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
-        captured = _capture_submit(monkeypatch)
+    def _write_config(self, tmp_path, **extra):
         config_path = tmp_path / "submit.yaml"
         config_path.write_text(
-            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB, **extra})
         )
+        return config_path
 
-        _eval_submit(_args(config_path), overrides=["+my_env_space.tag=nightly"])
+    def test_scratch_namespace_is_stripped_before_validation(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = self._write_config(tmp_path, _my_env_space={"tag": "default-tag"})
 
-        assert not hasattr(captured["config"], "my_env_space")
+        _eval_submit(_args(config_path), overrides=[])
 
-    def test_extra_root_key_is_resolved_before_being_stripped(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        assert not hasattr(captured["config"], "_my_env_space")
+
+    def test_scratch_namespace_is_resolved_before_being_stripped(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
         """A field can interpolate into the scratch namespace; the interpolated value must survive even
         though the scratch namespace itself gets dropped afterwards."""
         captured = _capture_submit(monkeypatch)
-        config_path = tmp_path / "submit.yaml"
-        config_path.write_text(
-            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        config_path = self._write_config(
+            tmp_path,
+            _my_env_space={"tag": "default-tag"},
+            driver={**DRIVER, "container": "gym:${_my_env_space.tag}"},
         )
 
-        _eval_submit(
-            _args(config_path),
-            overrides=["+my_env_space.tag=nightly", "driver.container=gym:${my_env_space.tag}"],
+        _eval_submit(_args(config_path), overrides=[])
+
+        assert captured["config"].driver.container == "gym:default-tag"
+        assert not hasattr(captured["config"], "_my_env_space")
+
+    def test_bare_override_of_existing_scratch_leaf(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = self._write_config(
+            tmp_path,
+            _my_env_space={"tag": "default-tag"},
+            driver={**DRIVER, "container": "gym:${_my_env_space.tag}"},
         )
+
+        _eval_submit(_args(config_path), overrides=["_my_env_space.tag=nightly"])
 
         assert captured["config"].driver.container == "gym:nightly"
-        assert not hasattr(captured["config"], "my_env_space")
 
-    def test_without_extra_root_key_still_validates(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+    def test_bare_override_of_typo_scratch_leaf_fails(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """Hydra itself rejects a bare override of a key that doesn't already exist, for free."""
+        config_path = self._write_config(tmp_path, _my_env_space={"tag": "default-tag"})
+
+        with pytest.raises(ConfigCompositionException):
+            _eval_submit(_args(config_path), overrides=["_my_env_space.tagg=nightly"])
+
+    def test_plus_override_into_scratch_namespace_is_rejected(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """`+`/`++` could silently create an unused, typo'd field in a scratch namespace; refuse it
+        outright instead of letting it through."""
+        config_path = self._write_config(tmp_path, _my_env_space={"tag": "default-tag"})
+
+        with pytest.raises(ValueError, match="scratch namespace"):
+            _eval_submit(_args(config_path), overrides=["+_my_env_space.tagg=nightly"])
+
+    def test_typo_in_top_level_key_is_rejected(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """A root key that isn't `_`-prefixed and isn't a SubmitConfig field is a real typo, not a scratch
+        namespace — it must still hit SubmitConfig's strict validation instead of being silently dropped."""
+        config_path = self._write_config(tmp_path, drivver=DRIVER)
+
+        with pytest.raises(ValidationError):
+            _eval_submit(_args(config_path), overrides=[])
+
+    def test_without_scratch_namespace_still_validates(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
         captured = _capture_submit(monkeypatch)
-        config_path = tmp_path / "submit.yaml"
-        config_path.write_text(
-            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
-        )
+        config_path = self._write_config(tmp_path)
 
         _eval_submit(_args(config_path), overrides=[])
 

--- a/tests/unit_tests/test_cli_eval_submit.py
+++ b/tests/unit_tests/test_cli_eval_submit.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+import pytest
+import yaml
+from hydra.errors import ConfigCompositionException
+from pytest import MonkeyPatch
+
+import nemo_gym.orchestration.submit as submit_module
+from nemo_gym.cli.main import _eval_submit
+
+
+COMPUTE = {"cluster": {"type": "slurm", "account": "my-account", "hostname": "foo"}}
+SERVICE = {"container": "gym:latest", "type": "vllm", "model": "org/model"}
+DRIVER = {"container": "gym:latest", "benchmarks": {"gsm8k": {}}}
+JOB = {"output_path": "/tmp/gym-jobs"}
+
+
+def _args(config_path, *, dry_run: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(config=str(config_path), dry_run=dry_run)
+
+
+def _capture_submit(monkeypatch: MonkeyPatch) -> dict:
+    captured: dict = {}
+
+    def fake_submit(config, *, dry_run: bool = False) -> None:
+        captured["config"] = config
+        captured["dry_run"] = dry_run
+
+    monkeypatch.setattr(submit_module, "submit", fake_submit)
+    return captured
+
+
+class TestEvalSubmitFlatConfig:
+    def test_flat_config_validates_and_submits(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path), overrides=[])
+
+        assert captured["config"].job.output_path == "/tmp/gym-jobs"
+        assert captured["dry_run"] is False
+
+    def test_dry_run_flag_is_forwarded(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path, dry_run=True), overrides=[])
+
+        assert captured["dry_run"] is True
+
+    def test_bare_override_replaces_existing_key(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path), overrides=["job.output_path=/tmp/other"])
+
+        assert captured["config"].job.output_path == "/tmp/other"
+
+    def test_plus_prefix_rejects_override_of_existing_key(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        with pytest.raises(ConfigCompositionException):
+            _eval_submit(_args(config_path), overrides=["+job.output_path=/tmp/other"])
+
+    def test_plus_prefix_adds_new_key(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path), overrides=["+driver.env.FOO=bar"])
+
+        assert captured["config"].driver.env == {"FOO": "bar"}
+
+
+class TestEvalSubmitScratchNamespace:
+    """Root-level keys outside SubmitConfig's schema are allowed to exist purely for interpolation, but must
+    be resolved away before validation instead of tripping SubmitConfig's `extra="forbid"`."""
+
+    def test_extra_root_key_is_stripped_before_validation(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path), overrides=["+my_env_space.tag=nightly"])
+
+        assert not hasattr(captured["config"], "my_env_space")
+
+    def test_extra_root_key_is_resolved_before_being_stripped(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """A field can interpolate into the scratch namespace; the interpolated value must survive even
+        though the scratch namespace itself gets dropped afterwards."""
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(
+            _args(config_path),
+            overrides=["+my_env_space.tag=nightly", "driver.container=gym:${my_env_space.tag}"],
+        )
+
+        assert captured["config"].driver.container == "gym:nightly"
+        assert not hasattr(captured["config"], "my_env_space")
+
+    def test_without_extra_root_key_still_validates(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path), overrides=[])
+
+        assert captured["config"].job.output_path == "/tmp/gym-jobs"
+
+
+class TestEvalSubmitConfigGroupComposition:
+    def test_defaults_list_pulls_in_config_group(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """A `defaults:` list should compose config-group files the same way real Hydra does."""
+        captured = _capture_submit(monkeypatch)
+
+        compute_dir = tmp_path / "compute"
+        compute_dir.mkdir()
+        (compute_dir / "slurm.yaml").write_text(yaml.dump(COMPUTE))
+
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "defaults": [{"compute": "slurm"}, "_self_"],
+                    "services": {"svc": SERVICE},
+                    "driver": DRIVER,
+                    "job": JOB,
+                }
+            )
+        )
+
+        _eval_submit(_args(config_path), overrides=[])
+
+        assert captured["config"].compute["cluster"].account == "my-account"
+        assert captured["config"].compute["cluster"].hostname == "foo"
+
+    def test_config_group_can_be_overridden_from_cli(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        captured = _capture_submit(monkeypatch)
+
+        compute_dir = tmp_path / "compute"
+        compute_dir.mkdir()
+        (compute_dir / "slurm.yaml").write_text(yaml.dump(COMPUTE))
+        other_compute = {"cluster": {"type": "slurm", "account": "other-account", "hostname": "bar"}}
+        (compute_dir / "other.yaml").write_text(yaml.dump(other_compute))
+
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "defaults": [{"compute": "slurm"}, "_self_"],
+                    "services": {"svc": SERVICE},
+                    "driver": DRIVER,
+                    "job": JOB,
+                }
+            )
+        )
+
+        _eval_submit(_args(config_path), overrides=["compute=other"])
+
+        assert captured["config"].compute["cluster"].account == "other-account"
+        assert captured["config"].compute["cluster"].hostname == "bar"
+
+    def test_repeated_calls_do_not_leak_global_hydra_state(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """GlobalHydra must be reset between calls or the second `initialize_config_dir` raises."""
+        captured = _capture_submit(monkeypatch)
+        config_path = tmp_path / "submit.yaml"
+        config_path.write_text(
+            yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
+        )
+
+        _eval_submit(_args(config_path), overrides=[])
+        _eval_submit(_args(config_path), overrides=[])
+
+        assert captured["config"].job.output_path == "/tmp/gym-jobs"


### PR DESCRIPTION
### What changed

`gym eval submit` previously loaded its `--config` YAML with a plain `OmegaConf.load()` + dotlist merge — no real Hydra composition, and overrides silently accepted `+key=value` for keys that already existed.

This MR rewires `_eval_submit` (`nemo_gym/cli/main.py`) to compose the config through real Hydra (`hydra.compose` + `initialize_config_dir`, pointed at the `--config` file's own directory), so:

- A `--config` file can now use a Hydra `defaults:` list to pull in config groups from subdirectories (e.g. `compute: slurm`, `services: vllm`) instead of being a single flat file.
- CLI overrides follow real Hydra semantics: bare `key=value` overrides an existing key, `+key=value` only adds a new key (errors if the key already exists), `++key=value` does either — replacing the old lenient dotlist behavior.
- Config groups themselves can be swapped from the CLI, e.g. `compute=slurm_large`.

### Root-level scratch namespace support

Since `SubmitConfig` is a strict pydantic model (`extra="forbid"`), any root-level key outside its schema would fail validation — but such a key can be useful purely as an interpolation source shared across independently-composed group files (e.g. pinning an image tag once, referenced by both `services/*.yaml` and `driver/*.yaml`). `_eval_submit` now resolves all interpolations first, then strips any root-level key that isn't one of `SubmitConfig`'s declared fields before validating, so scratch namespaces work without needing to satisfy the schema themselves.

### Tests

Added `tests/unit_tests/test_cli_eval_submit.py` (11 cases) covering:
- Flat-config backward compatibility
- Override semantics (bare / `+` / rejection of `+` on existing keys)
- Config-group composition and swapping
- Repeated in-process calls (`GlobalHydra` reset)
- Scratch-namespace resolve-then-strip behavior

### Docs / example

Added `examples/slurm_vllm_composed/`, a fully worked example mirroring `slurm_vllm_1IN.yaml` but split across Hydra config groups (`compute/`, `services/`, `driver/`, `job/`), including:
- A `compute/slurm_large.yaml` alternate profile
- A root-level `image_tags` scratch namespace consumed by both `services/vllm.yaml` and `driver/ifbench.yaml`, demonstrating shared version pinning across independently-composed files

### ⚠️ Behavior change for reviewers

Override syntax is now strict Hydra (`+` only for new keys) rather than the old lenient dotlist merge. Any existing scripts/docs relying on `+key=value` against pre-existing keys need updating to drop the `+`.