### PR TITLE
fix(benchmarks): bound the agent loop on single-turn benchmarks

### DIFF
--- a/benchmarks/aalcr/config.yaml
+++ b/benchmarks/aalcr/config.yaml
@@ -22,6 +22,7 @@ aalcr_benchmark_resources_server:
 aalcr_benchmark_simple_agent:
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       entrypoint: app.py
       resources_server:
         type: resources_servers

--- a/benchmarks/apex_shortlist/config.yaml
+++ b/benchmarks/apex_shortlist/config.yaml
@@ -14,6 +14,7 @@ apex_shortlist_math_with_judge_simple_agent:
   _inherit_from: math_with_judge_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: apex_shortlist_math_with_judge_resources_server
       datasets:

--- a/benchmarks/gpqa/config.yaml
+++ b/benchmarks/gpqa/config.yaml
@@ -14,6 +14,7 @@ gpqa_mcqa_simple_agent:
   _inherit_from: mcqa_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: gpqa_mcqa_resources_server
       datasets:

--- a/benchmarks/graphwalks/config.yaml
+++ b/benchmarks/graphwalks/config.yaml
@@ -12,6 +12,7 @@ graphwalks_benchmark_simple_agent:
   _inherit_from: graphwalks_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: graphwalks_benchmark_resources_server
       datasets:

--- a/benchmarks/hle/config.yaml
+++ b/benchmarks/hle/config.yaml
@@ -26,6 +26,7 @@ hle_equivalence_llm_judge_simple_agent:
   _inherit_from: equivalence_llm_judge_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: null
       resources_server:
         name: hle_equivalence_llm_judge_resources_server
       datasets:

--- a/benchmarks/hle/config_vision.yaml
+++ b/benchmarks/hle/config_vision.yaml
@@ -28,6 +28,7 @@ hle_vision_equivalence_llm_judge_simple_agent:
   _inherit_from: equivalence_llm_judge_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: hle_vision_equivalence_llm_judge_resources_server
       datasets:

--- a/benchmarks/ifbench/config.yaml
+++ b/benchmarks/ifbench/config.yaml
@@ -9,6 +9,7 @@ ifbench_benchmark_simple_agent:
   _inherit_from: ifbench_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: ifbench_benchmark_resources_server
       datasets:

--- a/benchmarks/livecodebench/v6_2408_2505/cascade.yaml
+++ b/benchmarks/livecodebench/v6_2408_2505/cascade.yaml
@@ -10,6 +10,7 @@ livecodebench_v6_cascade_code_gen_simple_agent:
   _inherit_from: code_gen_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: livecodebench_v6_cascade_code_gen_resources_server
       datasets:

--- a/benchmarks/mmlu_prox/config.yaml
+++ b/benchmarks/mmlu_prox/config.yaml
@@ -15,6 +15,7 @@ mmlu_prox_mcqa_simple_agent:
   _inherit_from: mcqa_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: mmlu_prox_mcqa_resources_server
       datasets:

--- a/benchmarks/mrcr/config_n3_128k.yaml
+++ b/benchmarks/mrcr/config_n3_128k.yaml
@@ -12,6 +12,7 @@ mrcr_n3_128k_benchmark_simple_agent:
   _inherit_from: mrcr_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: mrcr_n3_128k_benchmark_resources_server
       datasets:

--- a/benchmarks/omniscience/config.yaml
+++ b/benchmarks/omniscience/config.yaml
@@ -11,6 +11,7 @@ omniscience_omniscience_simple_agent:
   _inherit_from: omniscience_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: omniscience_omniscience_resources_server
       datasets:

--- a/benchmarks/wmt24pp/config.yaml
+++ b/benchmarks/wmt24pp/config.yaml
@@ -11,6 +11,7 @@ wmt24pp_wmt_translation_simple_agent:
   _inherit_from: wmt_translation_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         name: wmt24pp_wmt_translation_resources_server
       datasets:


### PR DESCRIPTION
`SimpleAgent` exits its loop only on an assistant message or `max_steps`, which defaults to `None`. A reasoning-only turn matches neither, so a model that never emits an assistant message is re-called until the job is killed, each dud turn appended to the conversation. Continuing on such a turn is deliberate (`test_responses_continues_on_reasoning_only`); the bound is what is missing.

Measured on BabyVision: one rollout took 225 sequential model calls, 12 h of a 16.4 h run. With `max_steps: 1` the same evaluation ran in 35 min, 1164 requests for 1164 rollouts, score 0.1503 -> 0.1529.

These 12 are the single-turn benchmarks of one eval lane. Each carries no tools — its resources server registers no POST route beyond `seed_session`/`verify`/`aggregate_metrics`/`reverify_mode`, no `tools/` directory, no `tools` in the prepared params — so the model can never emit a `function_call` and `max_steps: 1` cannot truncate anything legitimate. `osworld`, `tau2`, `tau3`, `ifeval`, `scicode` and `critpt` are untouched.

Note `hle/config_vision.yaml` and `mrcr/config_n3_128k.yaml`: variant configs need the line independently of their `config.yaml` siblings.

Behaviour change: a rollout that previously answered only after several stalled turns now scores 0. On BabyVision that was 63 of 1164 and the overall score still moved up.
