### PR TITLE
feat(terminus-2): honour Terminal-Bench per-task agent timeouts

### DIFF
--- a/benchmarks/terminal_bench_2_1/prepare.py
+++ b/benchmarks/terminal_bench_2_1/prepare.py
@@ -41,6 +41,9 @@ def prepare() -> Path:
             "task_name": task_toml["task"]["name"],
             "docker_image": task_toml["environment"]["docker_image"],
             "task_folder": str(task_dir.relative_to(BENCHMARK_DIR.parent.parent)),
+            # Terminal-Bench declares a per-task agent budget. Carry it through so the
+            # agent can honour it instead of applying one flat wall to every task.
+            "agent_timeout_sec": (task_toml.get("agent") or {}).get("timeout_sec"),
         }
 
         f_out.write(json.dumps(sample) + "\n")

--- a/responses_api_agents/terminus_2_sandboxed_agent/app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/app.py
@@ -67,7 +67,10 @@ class Terminus2AgentConfig(BaseResponsesAPIAgentConfig):
 
     sandbox_provider: str
     sandbox_config: dict[str, Any] = Field(default_factory=dict)
+    # Fallback agent wall clock, used when the dataset row carries no per-task budget.
     sandbox_timeout: float
+    # Upper bound applied to the per-task budget, mirroring Harbor's agent.max_timeout_sec.
+    max_agent_timeout: Optional[float] = None
     remote_tmux_binary_path: Optional[str]
 
 
@@ -326,13 +329,22 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         sandbox = await AsyncSandbox.connect({"sandbox_id": sandbox_id}, provider=provider)
         return sandbox
 
+    def _resolve_agent_timeout(self, task_timeout: float | None) -> float:
+        """Per-task budget when the dataset supplies one, else the flat fallback, then capped."""
+        timeout = self.config.sandbox_timeout if task_timeout is None else float(task_timeout)
+        if self.config.max_agent_timeout is not None:
+            timeout = min(timeout, self.config.max_agent_timeout)
+        return timeout
+
     async def _execute(
         self,
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming,
         sandbox: AsyncSandbox,
+        task_timeout: float | None = None,
     ) -> Tuple[NeMoGymResponse, Dict[str, Any]]:
         start_time = perf_counter()
+        agent_timeout = self._resolve_agent_timeout(task_timeout)
         instruction = _instruction(body.input)
 
         model_base_url = (
@@ -383,7 +395,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             await agent.setup(environment)
 
             try:
-                async with asyncio.timeout(self.config.sandbox_timeout):
+                async with asyncio.timeout(agent_timeout):
                     await agent.run(instruction, environment, context)
                 terminus2_completed = True
                 error = None
@@ -430,6 +442,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             "command_exec_time_pct": 100 * total_command_exec_time / total_time,
             "model_call_time_pct": 100 * total_model_call_time / total_time,
             "terminus2_time_taken": total_time,
+            "agent_timeout": agent_timeout,
             "model_calls_gt_10min": llm._model_calls_gt_10min,
             "num_proactive_compactions": agent._num_proactive_compactions,
             "num_compactions": llm._num_compactions,
@@ -462,7 +475,12 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         session_key = request.session[SESSION_ID_KEY]
         self._session_sandboxes[session_key] = sandbox
 
-        response, metrics = await self._execute(request, body.responses_create_params, sandbox)
+        response, metrics = await self._execute(
+            request,
+            body.responses_create_params,
+            sandbox,
+            task_timeout=getattr(body, "agent_timeout_sec", None),
+        )
 
         verification = await self.server_client.post(
             server_name=self.config.resources_server.name,

--- a/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
+++ b/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
@@ -23,7 +23,8 @@ terminus_2_sandboxed_agent:
       llm_request_timeout: 600  # 10 mins, Litellm default
 
       sandbox_provider: sandbox
-      sandbox_timeout: 10800  # 3 hrs
+      sandbox_timeout: 10800  # 3 hrs; only used when the dataset row has no agent_timeout_sec
+      max_agent_timeout: null  # cap on the per-task budget; null means uncapped
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -163,6 +163,54 @@ async def test_nemo_gym_llm_records_every_responses_request_and_output():
     ]
 
 
+def _agent_config(**overrides):
+    defaults = dict(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="app.py",
+        name="terminus_2_1_agent",
+        resources_server=ResourcesServerRef(type="resources_servers", name="swebench_resources_server"),
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        max_turns=100,
+        enable_summarize=True,
+        proactive_summarization_threshold=8000,
+        tmux_pane_width=160,
+        tmux_pane_height=40,
+        dump_trajectory=False,
+        debug=False,
+        model_context_limit=32_000,
+        model_output_limit=4_000,
+        llm_request_timeout=60,
+        sandbox_provider="opensandbox",
+        sandbox_timeout=10800,
+        remote_tmux_binary_path=None,
+    )
+    return Terminus2AgentConfig(**(defaults | overrides))
+
+
+@pytest.mark.parametrize(
+    "task_timeout, max_agent_timeout, expected",
+    [
+        # No per-task budget in the dataset row: fall back to the flat wall.
+        (None, None, 10800),
+        # Per-task budget wins over the flat wall, in both directions.
+        (900, None, 900),
+        (12000, None, 12000),
+        # The cap only binds when the per-task budget exceeds it.
+        (12000, 7200, 7200),
+        (900, 7200, 900),
+        # The cap also bounds the fallback.
+        (None, 7200, 7200),
+    ],
+)
+def test_resolve_agent_timeout(task_timeout, max_agent_timeout, expected):
+    server = Terminus2Agent(
+        config=_agent_config(max_agent_timeout=max_agent_timeout),
+        server_client=MagicMock(spec=ServerClient),
+    )
+    assert server._resolve_agent_timeout(task_timeout) == expected
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("dump_trajectory", [False, True])
 @pytest.mark.parametrize("debug", [False, True])
@@ -267,6 +315,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         "command_exec_time_pct": 40.0,
         "model_call_time_pct": 60.0,
         "terminus2_time_taken": 10.0,
+        "agent_timeout": 10.0,
         "model_calls_gt_10min": 0,
         "num_proactive_compactions": 0,
         "num_compactions": 2,


### PR DESCRIPTION
## Problem

Terminal-Bench declares an agent time budget per task, in each task's `task.toml`:

```toml
[agent]
timeout_sec = 900.0
```

The sandboxed Terminus-2 agent never reads it. `prepare.py` takes only `task.name`,
`environment.docker_image` and the task folder, and `app.py` wraps the agent loop in a single
flat `sandbox_timeout` (10800 s by default) that applies to every task equally.

Across the 89 tasks in Terminal-Bench 2.1 the declared budgets range from 600 s to 12000 s, with
a median of 900 s — 48 of the 89 tasks budget exactly 900 s. A flat three-hour wall is therefore
12x the declared budget for the majority of the suite.

On a recent 712-rollout run (89 tasks x 8 repeats) this had a measurable effect on the reported
score, not just on cost:

- **338 of 712 rollouts (47.5%) ran past their own task's budget**, the worst by **14.4x**.
- **24 of the 134 solved rollouts were solved out of spec** — they were still running long after
  the task's declared budget had expired. Of those 24, **19 first reported task completion only
  after the budget had already passed**, so they are not solves under the benchmark's own rules.
- Mean trial duration was 3432 s. For comparison, every accepted Terminus-2 submission on the
  public Terminal-Bench 2.1 leaderboard reports a mean trial duration between 548 s and 1043 s.

The reference implementation does honour the per-task value. Harbor's own trial layer resolves
`config.agent.override_timeout_sec or self._task.config.agent.timeout_sec`, caps it with
`config.agent.max_timeout_sec`, and applies the result as the deadline for `agent.run(...)`.
Because this agent calls `agent.run(...)` directly rather than going through `Trial`, that logic
is bypassed.

## Change

- `benchmarks/terminal_bench_2_1/prepare.py` emits `agent_timeout_sec` on every row, read from
  `task.toml`.
- `terminus_2_sandboxed_agent` uses that value as the agent-loop deadline when the dataset row
  provides one, and falls back to `sandbox_timeout` when it does not.
- New `max_agent_timeout` config key caps the resolved budget. This mirrors Harbor's
  `agent.max_timeout_sec` and exists so a long-tail task cannot stretch a whole job's wall clock.
  It defaults to `null` (uncapped), so it is opt-in.
- The resolved deadline is recorded as an `agent_timeout` metric, so a completed run can be
  audited against the budget it actually ran under.

I followed Harbor's semantics (per-task value, capped) rather than `anyterminal_agent`'s
(per-task value with a `global_agent_timeout` that *replaces* it), because a cap is what keeps a
job's wall clock bounded without discarding the per-task budgets. The dataset field is named
`agent_timeout_sec` to match the name `anyterminal_agent` already uses for the same `task.toml`
field.

## Compatibility

Behaviour is unchanged for any dataset that does not emit `agent_timeout_sec` — that path still
resolves to `sandbox_timeout`. Terminal-Bench 2.1 runs will change, which is the intent.

Anyone comparing to earlier Terminal-Bench 2.1 numbers should treat this as a new baseline rather
than a regression: the previous numbers measure reward under a flat wall, and these measure reward
under the benchmark's declared budgets. On the run described above the change is worth roughly
-0.034 absolute (0.188 to 0.155), because it withdraws the 24 out-of-spec solves.

## Testing

- `uv run python -m pytest responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py` — 15 passed.
- New parametrised test covers fallback, per-task override in both directions, and the cap
  binding and not binding.
- Ran the new `prepare.py` extraction expression against all 89 real `task.toml` files: 89/89
  yield a non-null budget, distribution `{600: 1, 750: 1, 900: 48, 1200: 5, 1800: 17, 2400: 2, 3600: 13, 7200: 1, 12000: 1}`.
- Confirmed the extra dataset field survives onto `Terminus2AgentRunRequest` (`extra="allow"`) and
  that its absence resolves to `None`.
- `ruff check` and `ruff format --check` clean on the touched trees.
