### PR TITLE
Fix agent override behavior for agents that were not overrides

### DIFF
--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -980,6 +980,8 @@ the check."""
         if held_agent_overrides is None:
             return
         override = OmegaConf.select(held_agent_overrides, f"{name}.{AGENT_SERVER_TYPE_KEY_NAME}.{agent_type}")
+        with open_dict(held_agent_overrides):
+            held_agent_overrides.pop(name, None)
         if not isinstance(override, DictConfig):
             return
         # Struct mode is what makes a field the agent does not declare an error rather than a silent add.
@@ -1210,6 +1212,7 @@ Pass each config with --config (it builds the list for you), e.g.:
         # Must run after the swap above (inherited bindings must exist to carry over) and before the
         # missing-value check below (it removes the unbound agent instance that still carries '???').
         self.compose_unbound_agent(global_config_dict, held_agent_overrides)
+        global_config_dict = OmegaConf.merge(global_config_dict, held_agent_overrides)
         self.apply_legacy_agent_aliases(global_config_dict)
 
         # Fail fast with one actionable error if any required value is still '???'. Runs *after*

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -2695,6 +2695,36 @@ class TestComposeUnboundAgent:
 
         assert resolved[renamed]["responses_api_agents"]["hermes_agent"]["max_turns"] == 99
 
+    def test_config_resolution_restores_held_agent_override_after_inheritance(self, monkeypatch: MonkeyPatch) -> None:
+        instance = "terminal_bench_2_1_terminus_2_sandboxed_agent"
+        agent_type = "terminus_2_sandboxed_agent"
+        config = DictConfig(
+            {
+                agent_type: {
+                    "responses_api_agents": {
+                        agent_type: {
+                            "entrypoint": "app.py",
+                            "sandbox_timeout": 10800,
+                        }
+                    }
+                },
+                instance: {
+                    "_inherit_from": agent_type,
+                    "responses_api_agents": {agent_type: {}},
+                },
+            }
+        )
+        cli = self._cli_dict(
+            {
+                instance: {"responses_api_agents": {agent_type: {"sandbox_timeout": 21600}}},
+            }
+        )
+
+        resolved = self._parse_with_cli(config, cli, monkeypatch)
+
+        assert agent_type not in resolved
+        assert resolved[instance]["responses_api_agents"][agent_type]["sandbox_timeout"] == 21600
+
     def test_command_line_override_outranks_the_carried_over_bindings(self, monkeypatch: MonkeyPatch) -> None:
         # The override must carry only the fields the user set, leaving the environment's bindings intact.
         config = self._config(


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
