### PR TITLE
feat(aalcr): add versioned v1.1 protocol

### DIFF
--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -21,20 +21,17 @@ The v1.1 config always sends its grading requests to
 `openai/openai/gpt-5.6-luna` on NVIDIA's inference gateway
 (`https://inference-api.nvidia.com/v1`) with medium reasoning effort.
 
-For a direct Gym run, `JUDGE_API_KEY` must contain a bearer token accepted by
-that gateway:
+Before running the evaluation, set `JUDGE_API_KEY` to an NVIDIA inference
+gateway API key that has access to GPT-5.6 Luna:
 
 ```bash
-: "${JUDGE_API_KEY:?Set JUDGE_API_KEY to your NVIDIA inference gateway API key}"
+export JUDGE_API_KEY='<your NVIDIA inference gateway API key>'
 ```
 
-This is not an AA-LCR-specific credential. EFB stores the same gateway
-credential as `INFERENCE_API_KEY` and passes it directly to the Gym judge
-configuration, so an EFB run does not require an additional environment
-variable. In Gym's recipe environment, `NVIDIA_API_KEY` remains the policy
-model credential and is not reused for this judge. Data preparation does not
-require the judge credential. Evaluation fails during judge startup when it is
-absent; it never falls back to another judge.
+`JUDGE_API_KEY` authenticates requests to the Luna judge; it is not an
+AA-LCR-specific credential. Data preparation does not require it. Evaluation
+fails during judge startup when it is absent and never falls back to another
+judge.
 
 ### Run
 ```bash

--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -1,14 +1,51 @@
-# Prepare data
+# AA-LCR
+
+AA-LCR provides two versioned configs in one benchmark:
+
+- `aalcr/config_v1_1`: the recommended AA-LCR v1.1 grading update introduced with the
+  [Artificial Analysis Intelligence Index v4.2](https://artificialanalysis.ai/articles/artificial-analysis-intelligence-index-v4-2).
+  It pins [dataset commit `9a77ef5`](https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR/commit/9a77ef56b717057ade24ceab4d273712a0b4f19e),
+  which corrects 16 answer keys, adds the published judge system prompt, uses
+  JSON verdicts, and specifies GPT-5.6 Luna (medium) as the equality checker.
+- `aalcr`: the original v1.0 dataset and Gym's historical plain-text judge
+  protocol, retained at the existing selector for backward compatibility.
+
+## v1.1
+
+### Prepare data
+```bash
+gym eval prepare --benchmark aalcr/config_v1_1
+```
+
+### Run
+```bash
+gym eval run \
+    --model-type vllm_model \
+    --benchmark aalcr/config_v1_1 \
+    ++output_jsonl_fpath=results/benchmarks/aalcr_v1_1.jsonl \
+    ++overwrite_metrics_conflicts=true \
+    ++split=benchmark \
+    ++resume_from_cache=true \
+    ++ray_head_node_address=auto \
+    ++reuse_existing_data_preparation=true \
+    ++policy_base_url=<> \
+    ++policy_api_key=<> \
+    ++policy_model_name=<>
+```
+
+## v1.0 compatibility
+
+### Prepare data
 ```bash
 gym eval prepare --benchmark aalcr
 ```
 
-# Run
+### Run
 ```bash
 gym eval run \
     --model-type vllm_model \
     --benchmark aalcr \
-    ++output_jsonl_fpath=results/benchmarks/aalcr.jsonl \
+    ++output_jsonl_fpath=results/benchmarks/aalcr_v1_0.jsonl \
     ++overwrite_metrics_conflicts=true \
     ++split=benchmark \
     ++resume_from_cache=true \

--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -21,7 +21,7 @@ The v1.1 config always grades with GPT-5.6 Luna at medium reasoning effort.
 Provide its credential before running:
 
 ```bash
-export AA_LCR_JUDGE_API_KEY='...'
+export NVIDIA_API_KEY='...'
 ```
 
 `AA_LCR_JUDGE_BASE_URL` optionally overrides the default NVIDIA inference API

--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -17,6 +17,17 @@ AA-LCR provides two versioned configs in one benchmark:
 gym eval prepare --benchmark aalcr/config_v1_1
 ```
 
+The v1.1 config always grades with GPT-5.6 Luna at medium reasoning effort.
+Provide its credential before running:
+
+```bash
+export AA_LCR_JUDGE_API_KEY='...'
+```
+
+`AA_LCR_JUDGE_BASE_URL` optionally overrides the default NVIDIA inference API
+URL. Data preparation does not require the credential. Evaluation fails during
+judge startup when it is absent; it never falls back to another judge.
+
 ### Run
 ```bash
 gym eval run \

--- a/benchmarks/aalcr/README.md
+++ b/benchmarks/aalcr/README.md
@@ -17,16 +17,24 @@ AA-LCR provides two versioned configs in one benchmark:
 gym eval prepare --benchmark aalcr/config_v1_1
 ```
 
-The v1.1 config always grades with GPT-5.6 Luna at medium reasoning effort.
-Provide its credential before running:
+The v1.1 config always sends its grading requests to
+`openai/openai/gpt-5.6-luna` on NVIDIA's inference gateway
+(`https://inference-api.nvidia.com/v1`) with medium reasoning effort.
+
+For a direct Gym run, `JUDGE_API_KEY` must contain a bearer token accepted by
+that gateway:
 
 ```bash
-export NVIDIA_API_KEY='...'
+: "${JUDGE_API_KEY:?Set JUDGE_API_KEY to your NVIDIA inference gateway API key}"
 ```
 
-`AA_LCR_JUDGE_BASE_URL` optionally overrides the default NVIDIA inference API
-URL. Data preparation does not require the credential. Evaluation fails during
-judge startup when it is absent; it never falls back to another judge.
+This is not an AA-LCR-specific credential. EFB stores the same gateway
+credential as `INFERENCE_API_KEY` and passes it directly to the Gym judge
+configuration, so an EFB run does not require an additional environment
+variable. In Gym's recipe environment, `NVIDIA_API_KEY` remains the policy
+model credential and is not reused for this judge. Data preparation does not
+require the judge credential. Evaluation fails during judge startup when it is
+absent; it never falls back to another judge.
 
 ### Run
 ```bash

--- a/benchmarks/aalcr/config_v1_1.yaml
+++ b/benchmarks/aalcr/config_v1_1.yaml
@@ -5,7 +5,7 @@ aalcr_v1_1_judge_model:
     openai_model:
       entrypoint: app.py
       openai_base_url: ${oc.env:AA_LCR_JUDGE_BASE_URL,https://inference-api.nvidia.com/v1}
-      openai_api_key: ${oc.env:AA_LCR_JUDGE_API_KEY,null}
+      openai_api_key: ${oc.env:NVIDIA_API_KEY,null}
       openai_model: openai/openai/gpt-5.6-luna
       extra_body:
         reasoning_effort: medium

--- a/benchmarks/aalcr/config_v1_1.yaml
+++ b/benchmarks/aalcr/config_v1_1.yaml
@@ -4,8 +4,8 @@ aalcr_v1_1_judge_model:
   responses_api_models:
     openai_model:
       entrypoint: app.py
-      openai_base_url: ${oc.env:AA_LCR_JUDGE_BASE_URL,https://inference-api.nvidia.com/v1}
-      openai_api_key: ${oc.env:NVIDIA_API_KEY,null}
+      openai_base_url: https://inference-api.nvidia.com/v1
+      openai_api_key: ${oc.env:JUDGE_API_KEY,null}
       openai_model: openai/openai/gpt-5.6-luna
       extra_body:
         reasoning_effort: medium

--- a/benchmarks/aalcr/config_v1_1.yaml
+++ b/benchmarks/aalcr/config_v1_1.yaml
@@ -1,12 +1,14 @@
-# Refer to the params in responses_api_models/local_vllm_model/configs/Qwen/Qwen3-235B-A22B-Instruct-2507-FP8.yaml
-Qwen3-235B-A22B-Instruct-2507-FP8:
+# Official AA-LCR v1.1 equality checker. Data preparation does not require the
+# key, but the judge model fails validation at server startup if it is absent.
+aalcr_v1_1_judge_model:
   responses_api_models:
-    vllm_model:
+    openai_model:
       entrypoint: app.py
-      model: Qwen3-235B-A22B-Instruct-2507-FP8
-      replace_developer_role_with_system: true
-      return_token_id_information: false
-      uses_reasoning_parser: true
+      openai_base_url: ${oc.env:AA_LCR_JUDGE_BASE_URL,https://inference-api.nvidia.com/v1}
+      openai_api_key: ${oc.env:AA_LCR_JUDGE_API_KEY,null}
+      openai_model: openai/openai/gpt-5.6-luna
+      extra_body:
+        reasoning_effort: medium
 
 aalcr_benchmark_resources_server:
   resources_servers:
@@ -16,13 +18,14 @@ aalcr_benchmark_resources_server:
       verified: false
       judge_model_server:
         type: responses_api_models
-        name: Qwen3-235B-A22B-Instruct-2507-FP8
+        name: aalcr_v1_1_judge_model
       judge_protocol: official_v1_1
       judge_responses_create_params_overrides: {}
 
 aalcr_benchmark_simple_agent:
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       entrypoint: app.py
       resources_server:
         type: resources_servers

--- a/benchmarks/aalcr/config_v1_1.yaml
+++ b/benchmarks/aalcr/config_v1_1.yaml
@@ -17,7 +17,7 @@ aalcr_benchmark_resources_server:
       judge_model_server:
         type: responses_api_models
         name: Qwen3-235B-A22B-Instruct-2507-FP8
-      judge_protocol: legacy_v1_0
+      judge_protocol: official_v1_1
       judge_responses_create_params_overrides: {}
 
 aalcr_benchmark_simple_agent:
@@ -31,9 +31,9 @@ aalcr_benchmark_simple_agent:
         type: responses_api_models
         name: policy_model
       datasets:
-      - name: aalcr
+      - name: aalcr_v1_1
         type: benchmark
-        jsonl_fpath: benchmarks/aalcr/data/aalcr_v1_0_benchmark.jsonl
+        jsonl_fpath: benchmarks/aalcr/data/aalcr_v1_1_benchmark.jsonl
         prompt_config: null
-        prepare_script: benchmarks/aalcr/prepare.py
+        prepare_script: benchmarks/aalcr/prepare_v1_1.py
         num_repeats: 16

--- a/benchmarks/aalcr/data/aalcr_benchmark_metrics.json
+++ b/benchmarks/aalcr/data/aalcr_benchmark_metrics.json
@@ -1,7 +1,7 @@
 {
     "name": "aalcr",
     "type": "benchmark",
-    "jsonl_fpath": "benchmarks/aalcr/data/aalcr_benchmark.jsonl",
+    "jsonl_fpath": "benchmarks/aalcr/data/aalcr_v1_0_benchmark.jsonl",
     "prepare_script": "benchmarks/aalcr/prepare.py",
     "prompt_config": null,
     "num_repeats": 16,

--- a/benchmarks/aalcr/prepare.py
+++ b/benchmarks/aalcr/prepare.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Prepare AA-LCR benchmark data.
+"""Prepare legacy-compatible AA-LCR v1.0 benchmark data.
 
 From the instructions at https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR"""
 
@@ -30,7 +30,10 @@ from nemo_gym.global_config import get_hf_token
 
 BENCHMARK_DIR = Path(__file__).parent
 DATA_DIR = BENCHMARK_DIR / "data"
-OUTPUT_FPATH = DATA_DIR / "aalcr_benchmark.jsonl"
+OUTPUT_FPATH = DATA_DIR / "aalcr_v1_0_benchmark.jsonl"
+DATASET_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"
+BENCHMARK_VERSION = "1.0.0"
+JUDGE_PROTOCOL = "legacy_v1_0"
 
 
 # From https://github.com/NVIDIA-NeMo/Skills/blob/54d2e113c2f64bf74bda72e15f23f01b524850da/nemo_skills/dataset/aalcr/prepare.py#L94-L105
@@ -51,12 +54,26 @@ def _dirty_filename(fname: str) -> str:
     return filename_with_artifacts
 
 
-def prepare() -> Path:
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
+def prepare_version(
+    *,
+    dataset_revision: str,
+    benchmark_version: str,
+    judge_protocol: str,
+    output_fpath: Path,
+) -> Path:
+    output_fpath.parent.mkdir(parents=True, exist_ok=True)
 
-    data = load_dataset("ArtificialAnalysis/AA-LCR", split="test", token=get_hf_token())
+    data = load_dataset(
+        "ArtificialAnalysis/AA-LCR",
+        revision=dataset_revision,
+        split="test",
+        token=get_hf_token(),
+    )
 
-    documents_url = "https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR/resolve/main/extracted_text/AA-LCR_extracted-text.zip"
+    documents_url = (
+        "https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR/"
+        f"resolve/{dataset_revision}/extracted_text/AA-LCR_extracted-text.zip"
+    )
     response = requests.get(documents_url)
     response.raise_for_status()
     zip_file = ZipFile(BytesIO(response.content))
@@ -126,16 +143,30 @@ END QUESTION
             "data_source_urls": row["data_source_urls"],
             "input_tokens": row["input_tokens"],
             "input_tokens_band": input_tokens_band,
+            "aa_lcr_version": benchmark_version,
+            "aa_lcr_dataset_revision": dataset_revision,
+            "aa_lcr_judge_protocol": judge_protocol,
         }
         samples.append(sample)
 
-    with OUTPUT_FPATH.open("w") as f:
+    with output_fpath.open("w") as f:
         for sample in samples:
             f.write(json.dumps(sample) + "\n")
 
-    print(f"Wrote {len(samples)} samples to {OUTPUT_FPATH}")
+    print(f"Wrote {len(samples)} samples to {output_fpath}")
 
-    return OUTPUT_FPATH
+    return output_fpath
+
+
+def prepare(*, dataset_revision: str = DATASET_REVISION) -> Path:
+    if dataset_revision != DATASET_REVISION:
+        raise ValueError(f"AA-LCR v1.0 requires dataset revision {DATASET_REVISION}, got {dataset_revision}")
+    return prepare_version(
+        dataset_revision=dataset_revision,
+        benchmark_version=BENCHMARK_VERSION,
+        judge_protocol=JUDGE_PROTOCOL,
+        output_fpath=OUTPUT_FPATH,
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/aalcr/prepare.py
+++ b/benchmarks/aalcr/prepare.py
@@ -31,7 +31,7 @@ from nemo_gym.global_config import get_hf_token
 BENCHMARK_DIR = Path(__file__).parent
 DATA_DIR = BENCHMARK_DIR / "data"
 OUTPUT_FPATH = DATA_DIR / "aalcr_v1_0_benchmark.jsonl"
-DATASET_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"
+DATASET_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"  # pragma: allowlist secret
 BENCHMARK_VERSION = "1.0.0"
 JUDGE_PROTOCOL = "legacy_v1_0"
 

--- a/benchmarks/aalcr/prepare_v1_1.py
+++ b/benchmarks/aalcr/prepare_v1_1.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Prepare AA-LCR v1.1 benchmark data."""
+
+from pathlib import Path
+
+from benchmarks.aalcr.prepare import prepare_version
+
+
+BENCHMARK_DIR = Path(__file__).parent
+OUTPUT_FPATH = BENCHMARK_DIR / "data" / "aalcr_v1_1_benchmark.jsonl"
+DATASET_REVISION = "9a77ef56b717057ade24ceab4d273712a0b4f19e"
+BENCHMARK_VERSION = "1.1"
+JUDGE_PROTOCOL = "official_v1_1"
+
+
+def prepare(*, dataset_revision: str = DATASET_REVISION) -> Path:
+    if dataset_revision != DATASET_REVISION:
+        raise ValueError(f"AA-LCR v1.1 requires dataset revision {DATASET_REVISION}, got {dataset_revision}")
+    return prepare_version(
+        dataset_revision=dataset_revision,
+        benchmark_version=BENCHMARK_VERSION,
+        judge_protocol=JUDGE_PROTOCOL,
+        output_fpath=OUTPUT_FPATH,
+    )
+
+
+if __name__ == "__main__":
+    prepare()

--- a/benchmarks/aalcr/prepare_v1_1.py
+++ b/benchmarks/aalcr/prepare_v1_1.py
@@ -9,7 +9,7 @@ from benchmarks.aalcr.prepare import prepare_version
 
 BENCHMARK_DIR = Path(__file__).parent
 OUTPUT_FPATH = BENCHMARK_DIR / "data" / "aalcr_v1_1_benchmark.jsonl"
-DATASET_REVISION = "9a77ef56b717057ade24ceab4d273712a0b4f19e"
+DATASET_REVISION = "9a77ef56b717057ade24ceab4d273712a0b4f19e"  # pragma: allowlist secret
 BENCHMARK_VERSION = "1.1"
 JUDGE_PROTOCOL = "official_v1_1"
 

--- a/benchmarks/aalcr/tests/test_config.py
+++ b/benchmarks/aalcr/tests/test_config.py
@@ -61,7 +61,7 @@ def _judge_response() -> NeMoGymResponse:
 
 
 def test_v1_1_uses_official_luna_medium_judge(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("AA_LCR_JUDGE_API_KEY", "not-a-secret")
+    monkeypatch.setenv("NVIDIA_API_KEY", "not-a-secret")
 
     config = _resolved_v1_1_config()
     judge_model = SimpleModelServerConfig.model_validate(_runtime_judge_model_config(config))
@@ -74,7 +74,7 @@ def test_v1_1_uses_official_luna_medium_judge(monkeypatch: pytest.MonkeyPatch) -
 
 
 async def test_v1_1_forwards_luna_model_and_medium_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("AA_LCR_JUDGE_API_KEY", "not-a-secret")
+    monkeypatch.setenv("NVIDIA_API_KEY", "not-a-secret")
     judge_model = SimpleModelServerConfig.model_validate(_runtime_judge_model_config(_resolved_v1_1_config()))
     server = SimpleModelServer(
         config=judge_model,
@@ -95,7 +95,7 @@ async def test_v1_1_forwards_luna_model_and_medium_reasoning(monkeypatch: pytest
 def test_v1_1_allows_preparation_but_rejects_judge_startup_without_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("AA_LCR_JUDGE_API_KEY", raising=False)
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
 
     config = _resolved_v1_1_config()
     judge_model = _judge_model_config(config)
@@ -108,7 +108,7 @@ def test_v1_1_allows_preparation_but_rejects_judge_startup_without_key(
 
 
 def test_v1_1_honors_explicit_judge_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("AA_LCR_JUDGE_API_KEY", "not-a-secret")
+    monkeypatch.setenv("NVIDIA_API_KEY", "not-a-secret")
     monkeypatch.setenv("AA_LCR_JUDGE_BASE_URL", "https://judge.example/v1")
 
     judge_model = _judge_model_config(_resolved_v1_1_config())

--- a/benchmarks/aalcr/tests/test_config.py
+++ b/benchmarks/aalcr/tests/test_config.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
+from nemo_gym.server_utils import ServerClient
+from responses_api_models.openai_model.app import NeMoGymAsyncOpenAI, SimpleModelServer, SimpleModelServerConfig
+
+
+BENCHMARK_DIR = Path(__file__).parents[1]
+V1_1_CONFIG = BENCHMARK_DIR / "config_v1_1.yaml"
+
+
+def _resolved_v1_1_config() -> dict:
+    return OmegaConf.to_container(OmegaConf.load(V1_1_CONFIG), resolve=True)
+
+
+def _judge_model_config(config: dict) -> dict:
+    return config["aalcr_v1_1_judge_model"]["responses_api_models"]["openai_model"]
+
+
+def _runtime_judge_model_config(config: dict) -> dict:
+    return {
+        "name": "aalcr_v1_1_judge_model",
+        "host": "127.0.0.1",
+        "port": 8081,
+        **_judge_model_config(config),
+    }
+
+
+def _judge_response() -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="response",
+        created_at=0.0,
+        model="openai/openai/gpt-5.6-luna",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="message",
+                content=[NeMoGymResponseOutputText(annotations=[], text='{"verdict":"CORRECT"}', type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
+
+
+def test_v1_1_uses_official_luna_medium_judge(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AA_LCR_JUDGE_API_KEY", "not-a-secret")
+
+    config = _resolved_v1_1_config()
+    judge_model = SimpleModelServerConfig.model_validate(_runtime_judge_model_config(config))
+    judge_ref = config["aalcr_benchmark_resources_server"]["resources_servers"]["aalcr"]["judge_model_server"]
+
+    assert judge_ref == {"type": "responses_api_models", "name": "aalcr_v1_1_judge_model"}
+    assert judge_model.openai_base_url == "https://inference-api.nvidia.com/v1"
+    assert judge_model.openai_model == "openai/openai/gpt-5.6-luna"
+    assert judge_model.extra_body == {"reasoning_effort": "medium"}
+
+
+async def test_v1_1_forwards_luna_model_and_medium_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AA_LCR_JUDGE_API_KEY", "not-a-secret")
+    judge_model = SimpleModelServerConfig.model_validate(_runtime_judge_model_config(_resolved_v1_1_config()))
+    server = SimpleModelServer(
+        config=judge_model,
+        server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+    )
+    server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+    server._client.create_response = AsyncMock(return_value=_judge_response().model_dump(mode="json"))
+
+    await server.responses(NeMoGymResponseCreateParamsNonStreaming(input="judge input"))
+
+    server._client.create_response.assert_awaited_once_with(
+        reasoning_effort="medium",
+        input="judge input",
+        model="openai/openai/gpt-5.6-luna",
+    )
+
+
+def test_v1_1_allows_preparation_but_rejects_judge_startup_without_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AA_LCR_JUDGE_API_KEY", raising=False)
+
+    config = _resolved_v1_1_config()
+    judge_model = _judge_model_config(config)
+    dataset = config["aalcr_benchmark_simple_agent"]["responses_api_agents"]["simple_agent"]["datasets"][0]
+
+    assert judge_model["openai_api_key"] is None
+    assert dataset["prepare_script"] == "benchmarks/aalcr/prepare_v1_1.py"
+    with pytest.raises(ValidationError, match="openai_api_key"):
+        SimpleModelServerConfig.model_validate(_runtime_judge_model_config(config))
+
+
+def test_v1_1_honors_explicit_judge_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AA_LCR_JUDGE_API_KEY", "not-a-secret")
+    monkeypatch.setenv("AA_LCR_JUDGE_BASE_URL", "https://judge.example/v1")
+
+    judge_model = _judge_model_config(_resolved_v1_1_config())
+
+    assert judge_model["openai_base_url"] == "https://judge.example/v1"

--- a/benchmarks/aalcr/tests/test_config.py
+++ b/benchmarks/aalcr/tests/test_config.py
@@ -61,7 +61,7 @@ def _judge_response() -> NeMoGymResponse:
 
 
 def test_v1_1_uses_official_luna_medium_judge(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NVIDIA_API_KEY", "not-a-secret")
+    monkeypatch.setenv("JUDGE_API_KEY", "not-a-secret")
 
     config = _resolved_v1_1_config()
     judge_model = SimpleModelServerConfig.model_validate(_runtime_judge_model_config(config))
@@ -74,7 +74,7 @@ def test_v1_1_uses_official_luna_medium_judge(monkeypatch: pytest.MonkeyPatch) -
 
 
 async def test_v1_1_forwards_luna_model_and_medium_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NVIDIA_API_KEY", "not-a-secret")
+    monkeypatch.setenv("JUDGE_API_KEY", "not-a-secret")
     judge_model = SimpleModelServerConfig.model_validate(_runtime_judge_model_config(_resolved_v1_1_config()))
     server = SimpleModelServer(
         config=judge_model,
@@ -95,7 +95,7 @@ async def test_v1_1_forwards_luna_model_and_medium_reasoning(monkeypatch: pytest
 def test_v1_1_allows_preparation_but_rejects_judge_startup_without_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    monkeypatch.delenv("JUDGE_API_KEY", raising=False)
 
     config = _resolved_v1_1_config()
     judge_model = _judge_model_config(config)
@@ -107,10 +107,11 @@ def test_v1_1_allows_preparation_but_rejects_judge_startup_without_key(
         SimpleModelServerConfig.model_validate(_runtime_judge_model_config(config))
 
 
-def test_v1_1_honors_explicit_judge_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NVIDIA_API_KEY", "not-a-secret")
-    monkeypatch.setenv("AA_LCR_JUDGE_BASE_URL", "https://judge.example/v1")
+def test_v1_1_does_not_reuse_policy_model_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+    monkeypatch.setenv("NVIDIA_API_KEY", "policy-model-key")
 
     judge_model = _judge_model_config(_resolved_v1_1_config())
 
-    assert judge_model["openai_base_url"] == "https://judge.example/v1"
+    assert judge_model["openai_base_url"] == "https://inference-api.nvidia.com/v1"
+    assert judge_model["openai_api_key"] is None

--- a/benchmarks/aalcr/tests/test_prepare.py
+++ b/benchmarks/aalcr/tests/test_prepare.py
@@ -55,12 +55,30 @@ def test_prepare_pins_dataset_and_records_provenance(module, tmp_path) -> None:
     assert f"/resolve/{module.DATASET_REVISION}/" in requested_url
     response.raise_for_status.assert_called_once_with()
 
-    row = json.loads(output_fpath.read_text())
-    assert row["answer"] == "65.8%"
-    assert row["input_tokens_band"] == "80k-100k"
-    assert row["aa_lcr_version"] == module.BENCHMARK_VERSION
-    assert row["aa_lcr_dataset_revision"] == module.DATASET_REVISION
-    assert row["aa_lcr_judge_protocol"] == module.JUDGE_PROTOCOL
+    prompt = """BEGIN INPUT DOCUMENTS
+
+BEGIN DOCUMENT 1:
+document contents
+END DOCUMENT 1
+
+END INPUT DOCUMENTS
+
+Answer the following question using the input documents provided above.
+
+START QUESTION
+
+What percentage?
+
+END QUESTION
+"""
+    assert json.loads(output_fpath.read_text()) == {
+        "responses_create_params": {"input": [{"role": "user", "content": prompt}]},
+        **ROW,
+        "input_tokens_band": "80k-100k",
+        "aa_lcr_version": module.BENCHMARK_VERSION,
+        "aa_lcr_dataset_revision": module.DATASET_REVISION,
+        "aa_lcr_judge_protocol": module.JUDGE_PROTOCOL,
+    }
 
 
 @pytest.mark.parametrize("module", [v1_0, v1_1], ids=["v1.0", "v1.1"])

--- a/benchmarks/aalcr/tests/test_prepare.py
+++ b/benchmarks/aalcr/tests/test_prepare.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+from zipfile import ZipFile
+
+import pytest
+
+from benchmarks.aalcr import prepare as v1_0
+from benchmarks.aalcr import prepare_v1_1 as v1_1
+
+
+ROW = {
+    "document_category": "category",
+    "document_set_id": "set",
+    "question_id": 28,
+    "question": "What percentage?",
+    "answer": "65.8%",
+    "data_source_filenames": "document.txt",
+    "data_source_urls": "https://example.com/document",
+    "input_tokens": 90000,
+}
+
+
+def _documents_zip() -> bytes:
+    payload = BytesIO()
+    with ZipFile(payload, "w") as archive:
+        archive.writestr("lcr/category/set/document.txt", "document contents")
+    return payload.getvalue()
+
+
+@pytest.mark.parametrize("module", [v1_0, v1_1], ids=["v1.0", "v1.1"])
+def test_prepare_pins_dataset_and_records_provenance(module, tmp_path) -> None:
+    output_fpath = tmp_path / module.OUTPUT_FPATH.name
+    response = MagicMock(content=_documents_zip())
+
+    with (
+        patch.object(v1_0, "load_dataset", return_value=[ROW]) as load_dataset,
+        patch.object(v1_0, "get_hf_token", return_value="token"),
+        patch.object(v1_0.requests, "get", return_value=response) as get,
+        patch.object(module, "OUTPUT_FPATH", output_fpath),
+    ):
+        result = module.prepare(dataset_revision=module.DATASET_REVISION)
+
+    assert result == output_fpath
+    load_dataset.assert_called_once_with(
+        "ArtificialAnalysis/AA-LCR",
+        revision=module.DATASET_REVISION,
+        split="test",
+        token="token",
+    )
+    requested_url = get.call_args.args[0]
+    assert f"/resolve/{module.DATASET_REVISION}/" in requested_url
+    response.raise_for_status.assert_called_once_with()
+
+    row = json.loads(output_fpath.read_text())
+    assert row["answer"] == "65.8%"
+    assert row["input_tokens_band"] == "80k-100k"
+    assert row["aa_lcr_version"] == module.BENCHMARK_VERSION
+    assert row["aa_lcr_dataset_revision"] == module.DATASET_REVISION
+    assert row["aa_lcr_judge_protocol"] == module.JUDGE_PROTOCOL
+
+
+@pytest.mark.parametrize("module", [v1_0, v1_1], ids=["v1.0", "v1.1"])
+def test_prepare_rejects_a_different_dataset_revision(module) -> None:
+    with pytest.raises(ValueError, match="requires dataset revision"):
+        module.prepare(dataset_revision="0" * 40)

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+import json
+from typing import Any, Dict, Literal, Optional
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -26,8 +27,36 @@ from nemo_gym.judge import JudgeError, call_judge
 from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
 
 
+LEGACY_JUDGE_PROTOCOL = "legacy_v1_0"
+V1_1_JUDGE_PROTOCOL = "official_v1_1"
+JudgeProtocol = Literal["legacy_v1_0", "official_v1_1"]
+
+V1_0_DATASET_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"
+V1_1_DATASET_REVISION = "9a77ef56b717057ade24ceab4d273712a0b4f19e"
+
+V1_1_SYSTEM_PROMPT = """Decide whether the CANDIDATE ANSWER is correct or incorrect against the OFFICIAL ANSWER.
+Note the following points when assessing correctness:
+
+- Numbers should still match when they are the same value written differently, e.g., a
+  percentage, a count of percentage points, and the equivalent decimal fraction are the same
+  value: 0.675, "67.5%" and "67.5 percentage points" all match. So do different scales
+  (thousand, million, bn) and different notations (thousands separators, currency symbols,
+  LaTeX markup, and numbers written as words).
+- Where the question asks for a particular format (e.g., a percentage, a number of decimal
+  places, a unit, a rounding, or an ordering) the CANDIDATE ANSWER must meet it. If the
+  question asks for no particular format, accept any equivalent form.
+- In cases where the question asks for an ordered list, a title, honorific or article added
+  to an entry in the CANDIDATE ANSWER can change where that entry sorts. Accept the ordering
+  if it is correct either with those additions or without them.
+- Grade the value the CANDIDATE ANSWER finally commits to, and it must commit to one. Values
+  reached while working, and alternatives it considers and sets aside, do not count. If it
+  offers several values without selecting one, it is incorrect even if one of them is right.
+  Hedging is fine as long as one clearly definitive answer is given."""
+
+
 class AalcrResourcesServerConfig(BaseResourcesServerConfig):
     judge_model_server: ModelServerRef
+    judge_protocol: JudgeProtocol = LEGACY_JUDGE_PROTOCOL
     judge_responses_create_params_overrides: Dict[str, Any]
 
 
@@ -41,6 +70,9 @@ class AALCRVerifyRequest(BaseVerifyRequest):
     data_source_urls: str
     input_tokens: int
     input_tokens_band: str
+    aa_lcr_version: str = "1.0.0"
+    aa_lcr_dataset_revision: str = V1_0_DATASET_REVISION
+    aa_lcr_judge_protocol: JudgeProtocol = LEGACY_JUDGE_PROTOCOL
 
 
 class AALCRVerifyResponse(AALCRVerifyRequest, BaseVerifyResponse):
@@ -59,6 +91,8 @@ class AalcrResourcesServer(SimpleResourcesServer):
     config: AalcrResourcesServerConfig
 
     async def verify(self, body: AALCRVerifyRequest) -> AALCRVerifyResponse:
+        _validate_protocol_metadata(body, self.config.judge_protocol)
+
         match body.input_tokens_band:
             case "<80k":
                 input_tokens_band_key = "reward_lt_80k"
@@ -81,16 +115,14 @@ class AalcrResourcesServer(SimpleResourcesServer):
                 **{input_tokens_band_key: reward},
             )
 
-        judge_prompt = f"""Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
-For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
-
-The question, for reference only: {body.question}
-The OFFICIAL ANSWER: {body.answer}
-CANDIDATE ANSWER TO ASSESS: {candidate_answer}
-
-Reply only with CORRECT or INCORRECT."""
-
-        judge_responses_create_params = dict(input=[{"role": "user", "content": judge_prompt}])
+        judge_responses_create_params = dict(
+            input=_build_judge_input(
+                self.config.judge_protocol,
+                question=body.question,
+                official_answer=body.answer,
+                candidate_answer=candidate_answer,
+            )
+        )
         judge_responses_create_params |= self.config.judge_responses_create_params_overrides
 
         judge_response = await call_judge(
@@ -100,14 +132,11 @@ Reply only with CORRECT or INCORRECT."""
             json=judge_responses_create_params,
             response_model=NeMoGymResponse,
         )
-        judge_response_text = judge_response.output_text.strip()
-        if not judge_response_text:
-            raise JudgeError("empty judge response")
-
-        if judge_response_text == "CORRECT":
+        verdict = _parse_judge_verdict(judge_response.output_text, self.config.judge_protocol)
+        if verdict == "CORRECT":
             invalid_judge_response = False
             reward = 1.0
-        elif judge_response_text == "INCORRECT":
+        elif verdict == "INCORRECT":
             invalid_judge_response = False
             reward = 0.0
         else:
@@ -122,6 +151,81 @@ Reply only with CORRECT or INCORRECT."""
             judge_responses_create_params=judge_responses_create_params,
             judge_response=judge_response,
             **{input_tokens_band_key: reward},
+        )
+
+
+def _build_judge_input(
+    judge_protocol: JudgeProtocol,
+    *,
+    question: str,
+    official_answer: str,
+    candidate_answer: str,
+) -> list[dict[str, str]]:
+    if judge_protocol == LEGACY_JUDGE_PROTOCOL:
+        user_prompt = f"""Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
+For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+
+The question, for reference only: {question}
+The OFFICIAL ANSWER: {official_answer}
+CANDIDATE ANSWER TO ASSESS: {candidate_answer}
+
+Reply only with CORRECT or INCORRECT."""
+        return [{"role": "user", "content": user_prompt}]
+
+    user_prompt = f"""Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
+For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+
+The question, for reference only: START QUESTION {question}
+
+END QUESTION
+
+The OFFICIAL ANSWER: {official_answer}
+
+END OFFICIAL ANSWER
+
+BEGIN CANDIDATE ANSWER TO ASSESS
+
+{candidate_answer}
+
+END CANDIDATE ANSWER TO ASSESS
+
+Reply as JSON, with a verdict of CORRECT or INCORRECT."""
+    return [
+        {"role": "system", "content": V1_1_SYSTEM_PROMPT},
+        {"role": "user", "content": user_prompt},
+    ]
+
+
+def _parse_judge_verdict(judge_response_text: str, judge_protocol: JudgeProtocol) -> Optional[str]:
+    text = judge_response_text.strip()
+    if not text:
+        raise JudgeError("empty judge response")
+
+    if judge_protocol == LEGACY_JUDGE_PROTOCOL:
+        return text if text in {"CORRECT", "INCORRECT"} else None
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise JudgeError("AA-LCR v1.1 judge response is not valid JSON") from error
+    if not isinstance(payload, dict) or set(payload) != {"verdict"}:
+        raise JudgeError("AA-LCR v1.1 judge response must contain only a verdict field")
+    verdict = payload["verdict"]
+    if verdict not in {"CORRECT", "INCORRECT"}:
+        raise JudgeError("AA-LCR v1.1 judge verdict must be CORRECT or INCORRECT")
+    return verdict
+
+
+def _validate_protocol_metadata(body: AALCRVerifyRequest, judge_protocol: JudgeProtocol) -> None:
+    expected = {
+        LEGACY_JUDGE_PROTOCOL: ("1.0.0", V1_0_DATASET_REVISION),
+        V1_1_JUDGE_PROTOCOL: ("1.1", V1_1_DATASET_REVISION),
+    }[judge_protocol]
+    actual = (body.aa_lcr_version, body.aa_lcr_dataset_revision)
+    if body.aa_lcr_judge_protocol != judge_protocol or actual != expected:
+        raise ValueError(
+            "AA-LCR dataset and judge protocol mismatch: "
+            f"server={judge_protocol}/{expected}, row={body.aa_lcr_judge_protocol}/{actual}"
         )
 
 

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -198,11 +198,11 @@ Reply as JSON, with a verdict of CORRECT or INCORRECT."""
 
 def _parse_judge_verdict(judge_response_text: str, judge_protocol: JudgeProtocol) -> Optional[str]:
     text = judge_response_text.strip()
-    if not text:
-        raise JudgeError("empty judge response")
-
     if judge_protocol == LEGACY_JUDGE_PROTOCOL:
         return text if text in {"CORRECT", "INCORRECT"} else None
+
+    if not text:
+        raise JudgeError("empty judge response")
 
     try:
         payload = json.loads(text)

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -31,8 +31,8 @@ LEGACY_JUDGE_PROTOCOL = "legacy_v1_0"
 V1_1_JUDGE_PROTOCOL = "official_v1_1"
 JudgeProtocol = Literal["legacy_v1_0", "official_v1_1"]
 
-V1_0_DATASET_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"
-V1_1_DATASET_REVISION = "9a77ef56b717057ade24ceab4d273712a0b4f19e"
+V1_0_DATASET_REVISION = "bdae010bbce259820c0e34c1d7cce210d966fb75"  # pragma: allowlist secret
+V1_1_DATASET_REVISION = "9a77ef56b717057ade24ceab4d273712a0b4f19e"  # pragma: allowlist secret
 
 V1_1_SYSTEM_PROMPT = """Decide whether the CANDIDATE ANSWER is correct or incorrect against the OFFICIAL ANSWER.
 Note the following points when assessing correctness:

--- a/resources_servers/aalcr/configs/aalcr.yaml
+++ b/resources_servers/aalcr/configs/aalcr.yaml
@@ -7,6 +7,7 @@ aalcr_resources_server:
       judge_model_server:
         type: responses_api_models
         name: Qwen3-235B-A22B-Instruct-2507-FP8
+      judge_protocol: legacy_v1_0
       judge_responses_create_params_overrides: {}
 aalcr_simple_agent:
   responses_api_agents:

--- a/resources_servers/aalcr/task_data.py
+++ b/resources_servers/aalcr/task_data.py
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the aalcr server.
 
-There is no verifier_metadata: all nine task fields ride as REQUIRED top-level row fields on
-``AALCRVerifyRequest`` (app.py), so all nine stay required here even though verify() only reads
-``question``, ``answer``, and ``input_tokens_band`` — the other six exist to be echoed into
-``AALCRVerifyResponse``. ``input_tokens_band`` is narrowed to the five-band Literal: verify()'s
-``match`` statement has no default case, so any other value crashes with an UnboundLocalError,
-making the enum the server's real contract even though the wire types it as a bare ``str``.
+There is no verifier_metadata: task fields ride as top-level row fields on ``AALCRVerifyRequest``
+(app.py). Version metadata defaults to the legacy protocol so committed examples and historical
+rows remain valid, while prepared benchmark rows always record it explicitly.
 """
 
 from typing import Literal
@@ -57,4 +54,20 @@ class TaskData(BaseModel):
             "so these five values are the de-facto enum."
         ),
         json_schema_extra={"consumed_by": ["verify", "metrics"]},
+    )
+    aa_lcr_version: Literal["1.0.0", "1.1"] = Field(
+        default="1.0.0",
+        description="AA-LCR benchmark version used to prepare this row.",
+        json_schema_extra={"consumed_by": ["verify", "provenance"]},
+    )
+    aa_lcr_dataset_revision: str = Field(
+        default="bdae010bbce259820c0e34c1d7cce210d966fb75",
+        pattern=r"^[0-9a-f]{40}$",
+        description="Immutable Hugging Face dataset commit used to prepare this row.",
+        json_schema_extra={"consumed_by": ["verify", "provenance"]},
+    )
+    aa_lcr_judge_protocol: Literal["legacy_v1_0", "official_v1_1"] = Field(
+        default="legacy_v1_0",
+        description="Judge prompt and verdict protocol required for this row.",
+        json_schema_extra={"consumed_by": ["verify", "provenance"]},
     )

--- a/resources_servers/aalcr/task_data.py
+++ b/resources_servers/aalcr/task_data.py
@@ -61,7 +61,7 @@ class TaskData(BaseModel):
         json_schema_extra={"consumed_by": ["verify", "provenance"]},
     )
     aa_lcr_dataset_revision: str = Field(
-        default="bdae010bbce259820c0e34c1d7cce210d966fb75",
+        default="bdae010bbce259820c0e34c1d7cce210d966fb75",  # pragma: allowlist secret
         pattern=r"^[0-9a-f]{40}$",
         description="Immutable Hugging Face dataset commit used to prepare this row.",
         json_schema_extra={"consumed_by": ["verify", "provenance"]},

--- a/resources_servers/aalcr/tests/test_app.py
+++ b/resources_servers/aalcr/tests/test_app.py
@@ -109,11 +109,15 @@ class TestApp:
             candidate_answer="candidate",
         )
 
-        assert len(messages) == 1
-        assert messages[0]["role"] == "user"
-        assert "The question, for reference only: question" in messages[0]["content"]
-        assert "START QUESTION" not in messages[0]["content"]
-        assert messages[0]["content"].endswith("Reply only with CORRECT or INCORRECT.")
+        expected_prompt = """Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
+For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+
+The question, for reference only: question
+The OFFICIAL ANSWER: answer
+CANDIDATE ANSWER TO ASSESS: candidate
+
+Reply only with CORRECT or INCORRECT."""
+        assert messages == [{"role": "user", "content": expected_prompt}]
 
     def test_v1_1_prompt_uses_official_system_and_user_messages(self) -> None:
         messages = _build_judge_input(
@@ -123,11 +127,60 @@ class TestApp:
             candidate_answer="candidate",
         )
 
-        assert messages[0] == {"role": "system", "content": V1_1_SYSTEM_PROMPT}
-        assert messages[1]["role"] == "user"
-        assert "START QUESTION question\n\nEND QUESTION" in messages[1]["content"]
-        assert "BEGIN CANDIDATE ANSWER TO ASSESS\n\ncandidate" in messages[1]["content"]
-        assert messages[1]["content"].endswith("Reply as JSON, with a verdict of CORRECT or INCORRECT.")
+        expected_system_prompt = """Decide whether the CANDIDATE ANSWER is correct or incorrect against the OFFICIAL ANSWER.
+Note the following points when assessing correctness:
+
+- Numbers should still match when they are the same value written differently, e.g., a
+  percentage, a count of percentage points, and the equivalent decimal fraction are the same
+  value: 0.675, "67.5%" and "67.5 percentage points" all match. So do different scales
+  (thousand, million, bn) and different notations (thousands separators, currency symbols,
+  LaTeX markup, and numbers written as words).
+- Where the question asks for a particular format (e.g., a percentage, a number of decimal
+  places, a unit, a rounding, or an ordering) the CANDIDATE ANSWER must meet it. If the
+  question asks for no particular format, accept any equivalent form.
+- In cases where the question asks for an ordered list, a title, honorific or article added
+  to an entry in the CANDIDATE ANSWER can change where that entry sorts. Accept the ordering
+  if it is correct either with those additions or without them.
+- Grade the value the CANDIDATE ANSWER finally commits to, and it must commit to one. Values
+  reached while working, and alternatives it considers and sets aside, do not count. If it
+  offers several values without selecting one, it is incorrect even if one of them is right.
+  Hedging is fine as long as one clearly definitive answer is given."""
+        expected_user_prompt = """Assess whether the following CANDIDATE ANSWER is CORRECT or INCORRECT.
+For the CANDIDATE ANSWER to be correct, it must be consistent with the OFFICIAL ANSWER.
+
+The question, for reference only: START QUESTION question
+
+END QUESTION
+
+The OFFICIAL ANSWER: answer
+
+END OFFICIAL ANSWER
+
+BEGIN CANDIDATE ANSWER TO ASSESS
+
+candidate
+
+END CANDIDATE ANSWER TO ASSESS
+
+Reply as JSON, with a verdict of CORRECT or INCORRECT."""
+        assert V1_1_SYSTEM_PROMPT == expected_system_prompt
+        assert messages == [
+            {"role": "system", "content": expected_system_prompt},
+            {"role": "user", "content": expected_user_prompt},
+        ]
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("CORRECT", "CORRECT"),
+            (" INCORRECT\n", "INCORRECT"),
+            ("NOT A VERDICT", None),
+            ("", None),
+            (" \n", None),
+        ],
+    )
+    def test_legacy_parser_preserves_previous_verdict_behavior(self, text: str, expected: str | None) -> None:
+        assert _parse_judge_verdict(text, LEGACY_JUDGE_PROTOCOL) == expected
 
     @pytest.mark.parametrize(
         ("text", "expected"),
@@ -145,23 +198,37 @@ class TestApp:
             "CORRECT",
             '{"verdict": "MAYBE"}',
             '{"verdict": "CORRECT", "reason": "extra"}',
+            "",
+            " \n",
         ],
     )
     def test_v1_1_parser_rejects_non_protocol_responses(self, text: str) -> None:
-        with pytest.raises(JudgeError, match="AA-LCR v1.1 judge"):
+        with pytest.raises(JudgeError, match="empty judge response|AA-LCR v1.1 judge"):
             _parse_judge_verdict(text, V1_1_JUDGE_PROTOCOL)
 
-    async def test_v1_1_verify_sends_system_prompt_and_parses_json(self) -> None:
+    def test_legacy_rows_without_provenance_use_legacy_defaults(self) -> None:
+        legacy_row = _request(LEGACY_JUDGE_PROTOCOL).model_dump(
+            exclude={"aa_lcr_version", "aa_lcr_dataset_revision", "aa_lcr_judge_protocol"}
+        )
+
+        request = AALCRVerifyRequest.model_validate(legacy_row)
+
+        assert request.aa_lcr_version == "1.0.0"
+        assert request.aa_lcr_dataset_revision == V1_0_DATASET_REVISION
+        assert request.aa_lcr_judge_protocol == LEGACY_JUDGE_PROTOCOL
+
+    @pytest.mark.parametrize(("verdict", "expected_reward"), [("CORRECT", 1.0), ("INCORRECT", 0.0)])
+    async def test_v1_1_verify_sends_system_prompt_and_parses_json(self, verdict: str, expected_reward: float) -> None:
         server = AalcrResourcesServer(
             config=_config(V1_1_JUDGE_PROTOCOL),
             server_client=MagicMock(spec=ServerClient),
         )
-        judge = AsyncMock(return_value=_response('{"verdict": "CORRECT"}'))
+        judge = AsyncMock(return_value=_response(f'{{"verdict": "{verdict}"}}'))
 
         with patch("resources_servers.aalcr.app.call_judge", judge):
             result = await server.verify(_request(V1_1_JUDGE_PROTOCOL))
 
-        assert result.reward == 1.0
+        assert result.reward == expected_reward
         assert result.invalid_judge_response is False
         judge_input = judge.await_args.kwargs["json"]["input"]
         assert [message["role"] for message in judge_input] == ["system", "user"]
@@ -175,15 +242,27 @@ class TestApp:
         with pytest.raises(ValueError, match="dataset and judge protocol mismatch"):
             await server.verify(_request(LEGACY_JUDGE_PROTOCOL))
 
-    async def test_legacy_invalid_verdict_remains_a_zero_reward(self) -> None:
+    @pytest.mark.parametrize(
+        ("judge_text", "expected_reward", "expected_invalid"),
+        [
+            ("CORRECT", 1.0, False),
+            ("INCORRECT", 0.0, False),
+            ("NOT A VERDICT", 0.0, True),
+            ("", 0.0, True),
+            (" \n", 0.0, True),
+        ],
+    )
+    async def test_legacy_verdict_preserves_previous_reward(
+        self, judge_text: str, expected_reward: float, expected_invalid: bool
+    ) -> None:
         server = AalcrResourcesServer(
             config=_config(LEGACY_JUDGE_PROTOCOL),
             server_client=MagicMock(spec=ServerClient),
         )
-        judge = AsyncMock(return_value=_response("NOT A VERDICT"))
+        judge = AsyncMock(return_value=_response(judge_text))
 
         with patch("resources_servers.aalcr.app.call_judge", judge):
             result = await server.verify(_request(LEGACY_JUDGE_PROTOCOL))
 
-        assert result.reward == 0.0
-        assert result.invalid_judge_response is True
+        assert result.reward == expected_reward
+        assert result.invalid_judge_response is expected_invalid

--- a/resources_servers/aalcr/tests/test_app.py
+++ b/resources_servers/aalcr/tests/test_app.py
@@ -12,13 +12,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from nemo_gym.judge import JudgeError
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
 from nemo_gym.server_utils import ServerClient
-from resources_servers.aalcr.app import AalcrResourcesServer, AalcrResourcesServerConfig
+from resources_servers.aalcr.app import (
+    LEGACY_JUDGE_PROTOCOL,
+    V1_0_DATASET_REVISION,
+    V1_1_DATASET_REVISION,
+    V1_1_JUDGE_PROTOCOL,
+    V1_1_SYSTEM_PROMPT,
+    AalcrResourcesServer,
+    AalcrResourcesServerConfig,
+    AALCRVerifyRequest,
+    _build_judge_input,
+    _parse_judge_verdict,
+)
 
 
-def _config() -> AalcrResourcesServerConfig:
+def _config(judge_protocol: str = LEGACY_JUDGE_PROTOCOL) -> AalcrResourcesServerConfig:
     return AalcrResourcesServerConfig(
         host="0.0.0.0",
         port=8080,
@@ -28,10 +48,142 @@ def _config() -> AalcrResourcesServerConfig:
             "type": "responses_api_models",
             "name": "abcd",
         },
+        judge_protocol=judge_protocol,
         judge_responses_create_params_overrides=dict(),
+    )
+
+
+def _response(text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="response",
+        created_at=0.0,
+        model="model",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="message",
+                content=[NeMoGymResponseOutputText(annotations=[], text=text, type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
+
+
+def _request(judge_protocol: str) -> AALCRVerifyRequest:
+    version, revision = {
+        LEGACY_JUDGE_PROTOCOL: ("1.0.0", V1_0_DATASET_REVISION),
+        V1_1_JUDGE_PROTOCOL: ("1.1", V1_1_DATASET_REVISION),
+    }[judge_protocol]
+    return AALCRVerifyRequest(
+        responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+        response=_response("candidate"),
+        document_category="Company Documents",
+        document_set_id="set",
+        question_id=28,
+        question="What percentage?",
+        answer="65.8%",
+        data_source_filenames="document.txt",
+        data_source_urls="https://example.com/document",
+        input_tokens=100,
+        input_tokens_band="<80k",
+        aa_lcr_version=version,
+        aa_lcr_dataset_revision=revision,
+        aa_lcr_judge_protocol=judge_protocol,
     )
 
 
 class TestApp:
     def test_sanity(self) -> None:
         AalcrResourcesServer(config=_config(), server_client=MagicMock(spec=ServerClient))
+
+    def test_legacy_prompt_is_preserved(self) -> None:
+        messages = _build_judge_input(
+            LEGACY_JUDGE_PROTOCOL,
+            question="question",
+            official_answer="answer",
+            candidate_answer="candidate",
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert "The question, for reference only: question" in messages[0]["content"]
+        assert "START QUESTION" not in messages[0]["content"]
+        assert messages[0]["content"].endswith("Reply only with CORRECT or INCORRECT.")
+
+    def test_v1_1_prompt_uses_official_system_and_user_messages(self) -> None:
+        messages = _build_judge_input(
+            V1_1_JUDGE_PROTOCOL,
+            question="question",
+            official_answer="answer",
+            candidate_answer="candidate",
+        )
+
+        assert messages[0] == {"role": "system", "content": V1_1_SYSTEM_PROMPT}
+        assert messages[1]["role"] == "user"
+        assert "START QUESTION question\n\nEND QUESTION" in messages[1]["content"]
+        assert "BEGIN CANDIDATE ANSWER TO ASSESS\n\ncandidate" in messages[1]["content"]
+        assert messages[1]["content"].endswith("Reply as JSON, with a verdict of CORRECT or INCORRECT.")
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ('{"verdict": "CORRECT"}', "CORRECT"),
+            ('{"verdict": "INCORRECT"}', "INCORRECT"),
+        ],
+    )
+    def test_v1_1_parser_accepts_official_json_verdict(self, text: str, expected: str) -> None:
+        assert _parse_judge_verdict(text, V1_1_JUDGE_PROTOCOL) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "CORRECT",
+            '{"verdict": "MAYBE"}',
+            '{"verdict": "CORRECT", "reason": "extra"}',
+        ],
+    )
+    def test_v1_1_parser_rejects_non_protocol_responses(self, text: str) -> None:
+        with pytest.raises(JudgeError, match="AA-LCR v1.1 judge"):
+            _parse_judge_verdict(text, V1_1_JUDGE_PROTOCOL)
+
+    async def test_v1_1_verify_sends_system_prompt_and_parses_json(self) -> None:
+        server = AalcrResourcesServer(
+            config=_config(V1_1_JUDGE_PROTOCOL),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        judge = AsyncMock(return_value=_response('{"verdict": "CORRECT"}'))
+
+        with patch("resources_servers.aalcr.app.call_judge", judge):
+            result = await server.verify(_request(V1_1_JUDGE_PROTOCOL))
+
+        assert result.reward == 1.0
+        assert result.invalid_judge_response is False
+        judge_input = judge.await_args.kwargs["json"]["input"]
+        assert [message["role"] for message in judge_input] == ["system", "user"]
+
+    async def test_verify_rejects_dataset_and_judge_protocol_mismatch(self) -> None:
+        server = AalcrResourcesServer(
+            config=_config(V1_1_JUDGE_PROTOCOL),
+            server_client=MagicMock(spec=ServerClient),
+        )
+
+        with pytest.raises(ValueError, match="dataset and judge protocol mismatch"):
+            await server.verify(_request(LEGACY_JUDGE_PROTOCOL))
+
+    async def test_legacy_invalid_verdict_remains_a_zero_reward(self) -> None:
+        server = AalcrResourcesServer(
+            config=_config(LEGACY_JUDGE_PROTOCOL),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        judge = AsyncMock(return_value=_response("NOT A VERDICT"))
+
+        with patch("resources_servers.aalcr.app.call_judge", judge):
+            result = await server.verify(_request(LEGACY_JUDGE_PROTOCOL))
+
+        assert result.reward == 0.0
+        assert result.invalid_judge_response is True


### PR DESCRIPTION
## Summary

- preserve the existing `aalcr` selector as the pinned v1.0 dataset and legacy judge protocol
- add `aalcr/config_v1_1` for dataset revision `9a77ef56b717057ade24ceab4d273712a0b4f19e`, including its 16 corrected answers
- configure the official GPT-5.6 Luna judge with medium reasoning for v1.1; read its credential from `JUDGE_API_KEY` with no fallback to another judge
- implement the published v1.1 system prompt and strict JSON verdict protocol
- attach dataset/protocol provenance to prepared rows and reject mismatched grading configurations
- preserve the historical v1.0 behavior for valid, malformed, and empty judge responses

## Compatibility evidence

- all 100 pinned v1.0 prepared rows match Gym `e446e4f` exactly after excluding the three additive provenance fields
- v1.0 sends the exact historical user-only judge prompt and produces identical rewards for `CORRECT`, `INCORRECT`, malformed, and empty verdicts
- legacy prepared rows without provenance fields load with v1.0 defaults
- v1.1 changes exactly the 16 published answer keys; questions, documents, policy prompts, and other task inputs are unchanged
- v1.1 sends the published system/user prompts, uses Luna-medium, accepts strict JSON `CORRECT`/`INCORRECT`, and rejects malformed or cross-version inputs

## Testing

- `uv run pytest -q benchmarks/aalcr/tests resources_servers/aalcr/tests/test_app.py` (32 passed)
- `uv run pytest -q tests/unit_tests/test_benchmarks.py` (49 passed)
- pre-commit and secret-detector checks
- `gym eval prepare --benchmark aalcr` (100 rows)
- keyless `gym eval prepare --benchmark aalcr/config_v1_1` (100 rows)
- config tests verify missing-key startup validation and forwarding `reasoning_effort=medium` with model `openai/openai/gpt-5.6-luna`
- direct data and verifier A/B against Gym `e446e4f415b9cde0e95bb813c85e9e3e23f5d893`