### PR TITLE
Fix lc_niah timeout

### DIFF
--- a/resources_servers/lc_niah/README.md
+++ b/resources_servers/lc_niah/README.md
@@ -21,7 +21,7 @@ response on two signals at once:
 Two config knobs decide the reward:
 
 - **`overlap_metric_rule`** — which overlap signal is computed and becomes the single
-  `reasoning_overlap` penalty: `seq_match` (default), `ngram16`, or `lcs`.
+  `reasoning_overlap` penalty: `seq_match`, `ngram16` (default), or `lcs`.
 - **`overlap_grading_rule`** — how `answer_score` and `reasoning_overlap` combine:
 
   | rule | reward |

--- a/resources_servers/lc_niah/README.md
+++ b/resources_servers/lc_niah/README.md
@@ -9,18 +9,19 @@ response on two signals at once:
    against `expected_answer` (a JSON list of nodes).
 2. **Reasoning/input overlap** — the model's reasoning (the `reasoning` item's
    summary text) should have *small* overlap with the input message, i.e. it should
-   not just copy the prompt back into its chain of thought. Three independent
-   overlap signals are computed (each in `[0, 1]`, higher = more copying):
-   - `overlap_seq_match` — `difflib.SequenceMatcher` ratio (global similarity)
-   - `overlap_ngram16` — fraction of the reasoning's 16-grams that appear in the input
-   - `overlap_lcs` — longest common substring length / reasoning length
+   not just copy the prompt back into its chain of thought. Three overlap signals are
+   available (each in `[0, 1]`, higher = more copying); exactly one is computed per
+   verification, selected by `overlap_metric_rule`:
+   - `seq_match` — `difflib.SequenceMatcher` ratio (global similarity)
+   - `ngram16` — fraction of the reasoning's 16-grams that appear in the input
+   - `lcs` — longest common substring length / reasoning length
 
 ## Reward
 
 Two config knobs decide the reward:
 
-- **`overlap_metric_rule`** — which overlap signal becomes the single `reasoning_overlap`
-  penalty: `seq_match`, `ngram16`, or `lcs` (default `lcs`).
+- **`overlap_metric_rule`** — which overlap signal is computed and becomes the single
+  `reasoning_overlap` penalty: `seq_match` (default), `ngram16`, or `lcs`.
 - **`overlap_grading_rule`** — how `answer_score` and `reasoning_overlap` combine:
 
   | rule | reward |
@@ -34,8 +35,9 @@ wrong answer scores `0`), so verbatim copying of the prompt into the reasoning i
 penalized even when the answer is right. `base` ignores the overlap entirely and
 rewards answer correctness alone.
 
-The verify response always exposes `answer_score`, the three `overlap_*` signals, and
-the combined `reasoning_overlap` for inspection, regardless of which rules are active.
+The verify response exposes `answer_score` and `reasoning_overlap` for inspection,
+regardless of which rules are active. Only the selected overlap signal is computed —
+the other two are never evaluated, which keeps verification cheap on long inputs.
 
 ## Config
 

--- a/resources_servers/lc_niah/app.py
+++ b/resources_servers/lc_niah/app.py
@@ -18,15 +18,15 @@
 #   2. The model's reasoning should NOT just copy the input message — we measure the
 #      overlap between the reasoning and the prompt (reasoning_overlap).
 #
-# Three independent overlap signals between the reasoning and the input are
-# computed (each in [0, 1], higher = more copying):
+# Three overlap signals between the reasoning and the input are available (each in
+# [0, 1], higher = more copying); exactly one is computed per verify() call:
 #   - seq_match : difflib SequenceMatcher ratio (global similarity)
 #   - ngram16   : fraction of the reasoning's 16-grams that appear in the input
 #   - lcs       : longest common substring length / reasoning length
 #
 # Two config knobs decide the reward:
 #   - overlap_metric_rule  : which signal becomes `reasoning_overlap`
-#                            (seq_match | ngram16 | lcs; default lcs)
+#                            (seq_match | ngram16 | lcs; default seq_match)
 #   - overlap_grading_rule : how answer_score and reasoning_overlap combine
 #       base     -> reward = answer_score
 #       multiply -> reward = answer_score * (1 - reasoning_overlap)  (default)
@@ -63,7 +63,7 @@ class OverlapGradingRule(str, Enum):
 class LCNIAHResourcesServerConfig(BaseResourcesServerConfig):
     name: str = "lc_niah"
     # Rule used to grade the final answer against expected_answer and reasoning_content against the input.
-    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.LCS
+    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.SEQ_MATCH
     overlap_grading_rule: OverlapGradingRule = OverlapGradingRule.MULTIPLY
 
 
@@ -82,10 +82,6 @@ class LCNIAHVerifyResponse(BaseVerifyResponse):
 
     # Score in [0, 1] for how well the final answer matches the expected answer.
     answer_score: float
-    # Individual reasoning/input overlap signals, each in [0, 1]; higher = more copying.
-    overlap_seq_match: float
-    overlap_ngram16: float
-    overlap_lcs: float
     # Combined overlap penalty actually used in the reward (see verify() to tweak).
     reasoning_overlap: float
 
@@ -148,18 +144,14 @@ class LCNIAHResourcesServer(SimpleResourcesServer):
 
         answer_score = self._grade_answer(answer_text, body.expected_answer)
 
-        # --- Overlap signals between reasoning and input (each in [0, 1], higher = more copying) ---
-        overlap_seq_match = self._overlap_seq_match(reasoning_text, input_text)
-        overlap_ngram16 = self._overlap_ngram(reasoning_text, input_text, n=16)
-        overlap_lcs = self._overlap_lcs(reasoning_text, input_text)
-
-        # --- Overlap function: which signal feeds the penalty (config.overlap_metric_rule) ---
+        # --- Overlap between reasoning and input in [0, 1] (higher = more copying); only the
+        # signal selected by config.overlap_metric_rule is computed. ---
         if self.config.overlap_metric_rule == OverlapMetricRule.SEQ_MATCH:
-            reasoning_overlap = overlap_seq_match
+            reasoning_overlap = self._overlap_seq_match(reasoning_text, input_text)
         elif self.config.overlap_metric_rule == OverlapMetricRule.NGRAM16:
-            reasoning_overlap = overlap_ngram16
+            reasoning_overlap = self._overlap_ngram(reasoning_text, input_text, n=16)
         elif self.config.overlap_metric_rule == OverlapMetricRule.LCS:
-            reasoning_overlap = overlap_lcs
+            reasoning_overlap = self._overlap_lcs(reasoning_text, input_text)
         else:
             raise ValueError(f"Invalid overlap metric rule: {self.config.overlap_metric_rule}")
 
@@ -178,9 +170,6 @@ class LCNIAHResourcesServer(SimpleResourcesServer):
             reward=reward,
             answer_score=answer_score,
             reasoning_overlap=reasoning_overlap,
-            overlap_seq_match=overlap_seq_match,
-            overlap_ngram16=overlap_ngram16,
-            overlap_lcs=overlap_lcs,
         )
 
     @classmethod

--- a/resources_servers/lc_niah/app.py
+++ b/resources_servers/lc_niah/app.py
@@ -26,7 +26,7 @@
 #
 # Two config knobs decide the reward:
 #   - overlap_metric_rule  : which signal becomes `reasoning_overlap`
-#                            (seq_match | ngram16 | lcs; default seq_match)
+#                            (seq_match | ngram16 | lcs; default ngram16)
 #   - overlap_grading_rule : how answer_score and reasoning_overlap combine
 #       base     -> reward = answer_score
 #       multiply -> reward = answer_score * (1 - reasoning_overlap)  (default)
@@ -63,7 +63,7 @@ class OverlapGradingRule(str, Enum):
 class LCNIAHResourcesServerConfig(BaseResourcesServerConfig):
     name: str = "lc_niah"
     # Rule used to grade the final answer against expected_answer and reasoning_content against the input.
-    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.SEQ_MATCH
+    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.NGRAM16
     overlap_grading_rule: OverlapGradingRule = OverlapGradingRule.MULTIPLY
 
 

--- a/resources_servers/lc_niah/configs/lc_niah.yaml
+++ b/resources_servers/lc_niah/configs/lc_niah.yaml
@@ -1,4 +1,4 @@
-# overlap_metric_rule options: seq_match (default), ngram16, lcs
+# overlap_metric_rule options: seq_match, ngram16 (default), lcs
 #   -> which overlap signal is computed and becomes reasoning_overlap
 # overlap_grading_rule options: base, multiply (default), minus
 #   -> how answer_score and reasoning_overlap combine into the reward:
@@ -11,7 +11,7 @@ lc_niah:
   resources_servers:
     lc_niah:
       entrypoint: app.py
-      overlap_metric_rule: seq_match
+      overlap_metric_rule: ngram16
       overlap_grading_rule: multiply
       domain: knowledge
       verified: false

--- a/resources_servers/lc_niah/configs/lc_niah.yaml
+++ b/resources_servers/lc_niah/configs/lc_niah.yaml
@@ -1,5 +1,5 @@
-# overlap_metric_rule options: seq_match, ngram16, lcs (default)
-#   -> which overlap signal becomes reasoning_overlap
+# overlap_metric_rule options: seq_match (default), ngram16, lcs
+#   -> which overlap signal is computed and becomes reasoning_overlap
 # overlap_grading_rule options: base, multiply (default), minus
 #   -> how answer_score and reasoning_overlap combine into the reward:
 #      base     : reward = answer_score
@@ -11,7 +11,7 @@ lc_niah:
   resources_servers:
     lc_niah:
       entrypoint: app.py
-      overlap_metric_rule: lcs
+      overlap_metric_rule: seq_match
       overlap_grading_rule: multiply
       domain: knowledge
       verified: false

--- a/resources_servers/lc_niah/tests/test_app.py
+++ b/resources_servers/lc_niah/tests/test_app.py
@@ -89,7 +89,7 @@ def _make_request(
 
 
 def _make_server(
-    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.SEQ_MATCH,
+    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.NGRAM16,
     overlap_grading_rule: OverlapGradingRule = OverlapGradingRule.MULTIPLY,
 ) -> LCNIAHResourcesServer:
     config = LCNIAHResourcesServerConfig(
@@ -373,5 +373,5 @@ class TestServerInstantiation:
 
     def test_default_rules(self) -> None:
         config = LCNIAHResourcesServerConfig(host="0.0.0.0", port=8080, entrypoint="")
-        assert config.overlap_metric_rule == OverlapMetricRule.SEQ_MATCH
+        assert config.overlap_metric_rule == OverlapMetricRule.NGRAM16
         assert config.overlap_grading_rule == OverlapGradingRule.MULTIPLY

--- a/resources_servers/lc_niah/tests/test_app.py
+++ b/resources_servers/lc_niah/tests/test_app.py
@@ -89,7 +89,7 @@ def _make_request(
 
 
 def _make_server(
-    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.LCS,
+    overlap_metric_rule: OverlapMetricRule = OverlapMetricRule.SEQ_MATCH,
     overlap_grading_rule: OverlapGradingRule = OverlapGradingRule.MULTIPLY,
 ) -> LCNIAHResourcesServer:
     config = LCNIAHResourcesServerConfig(
@@ -305,30 +305,40 @@ class TestVerify:
             input_text="graph prompt",
         )
         result = await server.verify(request)
-        assert result.overlap_seq_match == approx(0.0)
-        assert result.overlap_ngram16 == approx(0.0)
-        assert result.overlap_lcs == approx(0.0)
         assert result.reasoning_overlap == approx(0.0)
         assert result.reward == approx(1.0)
 
     @pytest.mark.parametrize(
-        "metric_rule, signal_field",
+        "metric_rule, expected_signal",
         [
-            (OverlapMetricRule.SEQ_MATCH, "overlap_seq_match"),
-            (OverlapMetricRule.NGRAM16, "overlap_ngram16"),
-            (OverlapMetricRule.LCS, "overlap_lcs"),
+            (OverlapMetricRule.SEQ_MATCH, lambda r, i: LCNIAHResourcesServer._overlap_seq_match(r, i)),
+            (OverlapMetricRule.NGRAM16, lambda r, i: LCNIAHResourcesServer._overlap_ngram(r, i, n=16)),
+            (OverlapMetricRule.LCS, lambda r, i: LCNIAHResourcesServer._overlap_lcs(r, i)),
         ],
     )
-    async def test_metric_rule_selects_signal(self, metric_rule: OverlapMetricRule, signal_field: str) -> None:
+    async def test_metric_rule_selects_signal(self, metric_rule: OverlapMetricRule, expected_signal) -> None:
         server = _make_server(metric_rule)
+        reasoning = "a partially overlapping reasoning trace with several words"
+        input_text = "a partially overlapping prompt with several extra words"
         request = _make_request(
             expected_answer='["a"]',
             answer="Final Answer: [a]",
-            reasoning="a partially overlapping reasoning trace with several words",
-            input_text="a partially overlapping prompt with several extra words",
+            reasoning=reasoning,
+            input_text=input_text,
         )
         result = await server.verify(request)
-        assert result.reasoning_overlap == approx(getattr(result, signal_field))
+        assert result.reasoning_overlap == approx(expected_signal(reasoning, input_text))
+
+    async def test_metric_rules_are_distinguishable(self) -> None:
+        """The three rules must not be interchangeable, or the parametrized test above is vacuous."""
+        reasoning = "a partially overlapping reasoning trace with several words"
+        input_text = "a partially overlapping prompt with several extra words"
+        signals = {
+            LCNIAHResourcesServer._overlap_seq_match(reasoning, input_text),
+            LCNIAHResourcesServer._overlap_ngram(reasoning, input_text, n=16),
+            LCNIAHResourcesServer._overlap_lcs(reasoning, input_text),
+        }
+        assert len(signals) == 3
 
     async def test_invalid_metric_rule_raises(self) -> None:
         server = _make_server()
@@ -349,18 +359,19 @@ class TestVerify:
         request = _make_request(expected_answer='["x"]', answer="Final Answer: [x]", reasoning="r", input_text="i")
         result = await server.verify(request)
         dump = result.model_dump()
-        for field in (
-            "reward",
-            "answer_score",
-            "overlap_seq_match",
-            "overlap_ngram16",
-            "overlap_lcs",
-            "reasoning_overlap",
-        ):
+        for field in ("reward", "answer_score", "reasoning_overlap"):
             assert field in dump
+        # Only the selected signal is computed, so the per-signal fields are no longer emitted.
+        for field in ("overlap_seq_match", "overlap_ngram16", "overlap_lcs"):
+            assert field not in dump
 
 
 class TestServerInstantiation:
     def test_default_name(self) -> None:
         config = LCNIAHResourcesServerConfig(host="0.0.0.0", port=8080, entrypoint="")
         assert config.name == "lc_niah"
+
+    def test_default_rules(self) -> None:
+        config = LCNIAHResourcesServerConfig(host="0.0.0.0", port=8080, entrypoint="")
+        assert config.overlap_metric_rule == OverlapMetricRule.SEQ_MATCH
+        assert config.overlap_grading_rule == OverlapGradingRule.MULTIPLY


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

This PR fixes timeout issue when using lc_niah env. Change default reasoning overlap metric LCS to ngram16.

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
