### PR TITLE
fix(responses): preserve provider refusal signals

### DIFF
--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -50,6 +50,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseInputTokensDetails,
     NeMoGymResponseOutputItem,
     NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputRefusal,
     NeMoGymResponseOutputText,
     NeMoGymResponseOutputTokensDetails,
     NeMoGymResponseReasoningItem,
@@ -95,13 +96,14 @@ class ResponsesConverterState(BaseModel):
     messages: List[NeMoGymChatCompletionMessageParam] = Field(default_factory=list)
 
     content_buffer: str = ""
+    refusal_buffer: str = ""
     tool_calls_buffer: List[NeMoGymChatCompletionMessageToolCallParam] = Field(default_factory=list)
     assistant_item_buffered: bool = False
 
     token_information: Optional[TokenIDLogProbMixin] = None
 
     def flush_assistant(self) -> None:
-        if not (self.assistant_item_buffered or self.content_buffer or self.tool_calls_buffer):
+        if not (self.assistant_item_buffered or self.content_buffer or self.refusal_buffer or self.tool_calls_buffer):
             self.token_information = None
             return
 
@@ -112,6 +114,8 @@ class ResponsesConverterState(BaseModel):
         # Omit rather than send `tool_calls: []` — OpenAI rejects empty arrays.
         if self.tool_calls_buffer:
             shared_params["tool_calls"] = self.tool_calls_buffer
+        if self.refusal_buffer:
+            shared_params["refusal"] = self.refusal_buffer
 
         if self.return_token_id_information and self.token_information is not None:
             message = NeMoGymChatCompletionAssistantMessageForTrainingParam(
@@ -124,6 +128,7 @@ class ResponsesConverterState(BaseModel):
         self.messages.append(message)
 
         self.content_buffer = ""
+        self.refusal_buffer = ""
         self.tool_calls_buffer = []
         self.assistant_item_buffered = False
         self.token_information = None
@@ -416,8 +421,19 @@ class ResponsesConverter(BaseModel):
                     # Tool-call only turns have "None" according to the official API spec.
                     pass
                 elif isinstance(content, list):
-                    content_str = "".join([part.get("text", "") for part in content])
-                    final_content += content_str
+                    text_parts: list[str] = []
+                    refusal_parts: list[str] = []
+                    for part in content:
+                        text = part.get("text")
+                        refusal = part.get("refusal")
+                        if isinstance(text, str):
+                            text_parts.append(text)
+                        if isinstance(refusal, str):
+                            refusal_parts.append(refusal)
+                        if not isinstance(text, str) and not isinstance(refusal, str):
+                            raise NotImplementedError(f"Unsupported assistant content part: {part!r}")
+                    final_content += "".join(text_parts)
+                    state.refusal_buffer += "".join(refusal_parts)
                 elif isinstance(content, str):
                     final_content += content
                 else:
@@ -647,6 +663,7 @@ class ResponsesConverter(BaseModel):
         response_output = []
 
         content = message_dict.get("content") or ""
+        refusal = message_dict.get("refusal") or ""
         if self.uses_reasoning_parser:
             reasoning_matches, content = self._extract_reasoning_from_content(content)
         else:
@@ -663,20 +680,30 @@ class ResponsesConverter(BaseModel):
             response_output.append(reasoning_item)
 
         tool_calls_raw = message_dict.get("tool_calls", []) or []
-        has_empty_output = not (response_output or tool_calls_raw)
+        has_empty_output = not (response_output or tool_calls_raw or refusal)
 
-        if content or has_empty_output:
+        if content or refusal or has_empty_output:
+            message_content = []
+            if content or has_empty_output:
+                message_content.append(
+                    NeMoGymResponseOutputText(
+                        type="output_text",
+                        text=content,
+                        annotations=[],
+                    )
+                )
+            if refusal:
+                message_content.append(
+                    NeMoGymResponseOutputRefusal(
+                        type="refusal",
+                        refusal=str(refusal),
+                    )
+                )
             response_output.append(
                 NeMoGymResponseOutputMessage(
                     id=f"msg_{uuid4().hex}",
                     role=message_dict.get("role"),
-                    content=[
-                        NeMoGymResponseOutputText(
-                            type="output_text",
-                            text=content,
-                            annotations=[],
-                        )
-                    ],
+                    content=message_content,
                     status="completed",
                     type="message",
                 )
@@ -782,6 +809,11 @@ class ResponsesConverter(BaseModel):
         elif choice.finish_reason == "content_filter":
             incomplete_details = {"reason": "content_filter"}
 
+        native_finish_reason = getattr(choice, "native_finish_reason", None)
+        provider_metadata = (
+            {"native_finish_reason": str(native_finish_reason)} if native_finish_reason is not None else {}
+        )
+
         # Chat Completion -> Response
         return NeMoGymResponse(
             # Under external token capture the chat completion's envelope id is
@@ -819,6 +851,7 @@ class ResponsesConverter(BaseModel):
             status="incomplete" if incomplete_details is not None else "completed",
             incomplete_details=incomplete_details,
             usage=usage,
+            **provider_metadata,
         )
 
 

--- a/responses_api_models/inference_provider/tests/test_app.py
+++ b/responses_api_models/inference_provider/tests/test_app.py
@@ -49,7 +49,14 @@ def _make_server(**overrides):
     return InferenceProvider(config=config, server_client=MagicMock(spec=ServerClient, global_config_dict={}))
 
 
-def _mock_chat_response(content="Hello!", finish_reason="stop", tool_calls=None, usage=None):
+def _mock_chat_response(
+    content="Hello!",
+    finish_reason="stop",
+    tool_calls=None,
+    usage=None,
+    refusal=None,
+    native_finish_reason=None,
+):
     response = {
         "id": "chatcmpl-test",
         "choices": [
@@ -70,6 +77,10 @@ def _mock_chat_response(content="Hello!", finish_reason="stop", tool_calls=None,
         response["choices"][0]["message"]["tool_calls"] = tool_calls
     if usage:
         response["usage"] = usage
+    if refusal is not None:
+        response["choices"][0]["message"]["refusal"] = refusal
+    if native_finish_reason is not None:
+        response["choices"][0]["native_finish_reason"] = native_finish_reason
     return response
 
 
@@ -455,6 +466,26 @@ class TestResponses:
         assert len(reasoning_items) == 0
         assert len(message_items) == 1
         assert message_items[0]["content"][0]["text"] == "<think>Let me reason about this...</think>The answer is 42."
+
+    async def test_responses_preserve_provider_refusal_signals(self) -> None:
+        server = _make_server()
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_data = _mock_chat_response(
+            content=None,
+            refusal="Policy refusal.",
+            native_finish_reason="refusal",
+        )
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_chat_completion = AsyncMock(return_value=mock_data)
+
+        response = client.post("/v1/responses", json={"input": "hello"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["native_finish_reason"] == "refusal"
+        assert data["output"][0]["content"] == [{"refusal": "Policy refusal.", "type": "refusal"}]
 
     async def test_responses_with_usage(self, monkeypatch: MonkeyPatch) -> None:
         server = _make_server()

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -37,6 +37,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseInputTokensDetails,
     NeMoGymResponseOutputMessage,
     NeMoGymResponseOutputMessageForTraining,
+    NeMoGymResponseOutputRefusal,
     NeMoGymResponseOutputText,
     NeMoGymResponseOutputTokensDetails,
     NeMoGymResponseReasoningItem,
@@ -434,6 +435,26 @@ def test_responses_to_chat_completion_assistant_invalid_content_raises(converter
             {"role": "assistant", "content": 42},
             ResponsesConverterState(return_token_id_information=False),
         )
+
+
+def test_responses_to_chat_completion_preserves_assistant_refusal(converter: ResponsesConverter):
+    params = converter.responses_to_chat_completion_create_params(
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                NeMoGymResponseOutputMessage(
+                    id="msg_refusal",
+                    role="assistant",
+                    status="completed",
+                    content=[NeMoGymResponseOutputRefusal(refusal="I cannot answer.")],
+                ),
+                NeMoGymEasyInputMessage(role="user", content="Why?"),
+            ]
+        )
+    )
+
+    assert params.messages[0]["role"] == "assistant"
+    assert params.messages[0]["content"] is None
+    assert params.messages[0]["refusal"] == "I cannot answer."
 
 
 def test_responses_to_chat_completion_function_call_and_output(converter: ResponsesConverter):
@@ -1133,6 +1154,30 @@ def test_postprocess_empty_output_emits_empty_message(converter: ResponsesConver
     assert output[0].content[0].text == ""
 
 
+def test_postprocess_refusal_preserves_provider_signal(converter: ResponsesConverter):
+    output = converter.postprocess_assistant_message_dict(
+        {"role": "assistant", "content": None, "refusal": "Policy refusal."}
+    )
+
+    assert len(output) == 1
+    assert isinstance(output[0], NeMoGymResponseOutputMessage)
+    assert output[0].content == [NeMoGymResponseOutputRefusal(refusal="Policy refusal.")]
+
+
+def test_postprocess_preserves_text_alongside_provider_refusal(converter: ResponsesConverter):
+    output = converter.postprocess_assistant_message_dict(
+        {"role": "assistant", "content": "Partial answer.", "refusal": "Policy refusal."}
+    )
+
+    assert len(output) == 1
+    assert isinstance(output[0], NeMoGymResponseOutputMessage)
+    assert [item.type for item in output[0].content] == ["output_text", "refusal"]
+    assert isinstance(output[0].content[0], NeMoGymResponseOutputText)
+    assert isinstance(output[0].content[1], NeMoGymResponseOutputRefusal)
+    assert output[0].content[0].text == "Partial answer."
+    assert output[0].content[1].refusal == "Policy refusal."
+
+
 def test_postprocess_tool_calls(converter: ResponsesConverter):
     output = converter.postprocess_assistant_message_dict(
         {
@@ -1370,6 +1415,28 @@ def test_chat_completion_to_response_preserves_unknown_usage_details(converter: 
     assert response.usage.input_tokens_details.cached_tokens is None
     assert response.usage.output_tokens_details.reasoning_tokens is None
     assert _cache_signal(response.usage.model_dump()) == (None, None)
+
+
+def test_chat_completion_to_response_preserves_native_finish_reason(converter: ResponsesConverter):
+    response = converter.chat_completion_to_response(
+        responses_create_params=NeMoGymResponseCreateParamsNonStreaming(model="", input="hello"),
+        chat_completion=NeMoGymChatCompletion(
+            id="",
+            created=0,
+            model="",
+            object="chat.completion",
+            choices=[
+                NeMoGymChoice(
+                    index=0,
+                    finish_reason="stop",
+                    native_finish_reason="refusal",
+                    message=NeMoGymChatCompletionMessage(role="assistant", content=None),
+                )
+            ],
+        ),
+    )
+
+    assert response.native_finish_reason == "refusal"
 
 
 # ===========================================================================


### PR DESCRIPTION
Preserves structured assistant refusals and provider-specific native_finish_reason metadata when converting between Chat Completions and Responses.
This is needed by evaluations such as BullshitBench, which distinguish provider-declared refusals from empty or substantive answers. The current conversion drops those signals and can therefore change benchmark grading.
The change is safe and conditional: ordinary text, reasoning, tool-call, usage, and empty-output paths remain unchanged. It uses Gym’s existing typed refusal content and the SDK-defined Chat assistant refusal field, with focused converter and endpoint coverage.

cc @bxyu-nvidia @ananthsub 

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
