### PR TITLE
test: verify suggest-reviewers live (throwaway, do not merge)

### DIFF
--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -23,9 +23,9 @@ permissions:
 jobs:
   suggest-reviewers:
     # TODO: pin to a released tag once NVIDIA-NeMo/FW-CI-templates#556 merges.
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@a0a89857ac3da812a76182a6aaa9cc326986cf30
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@184d565744d754a3c3f1fc7437021c764891129a
     with:
-      workflow_ref: a0a89857ac3da812a76182a6aaa9cc326986cf30
+      workflow_ref: 184d565744d754a3c3f1fc7437021c764891129a
       app-id: ${{ vars.BOT_ID }}
     secrets:
       BOT_KEY: ${{ secrets.BOT_KEY }}

--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -23,9 +23,9 @@ permissions:
 jobs:
   suggest-reviewers:
     # TODO: pin to a released tag once NVIDIA-NeMo/FW-CI-templates#556 merges.
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@be35284c8d2bb6c2e3e9101db0cd31bb288a98df
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@88511a5206b05cfe5a66666a08a1d7579e2c2f7a
     with:
-      workflow_ref: be35284c8d2bb6c2e3e9101db0cd31bb288a98df
+      workflow_ref: 88511a5206b05cfe5a66666a08a1d7579e2c2f7a
     secrets:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
       SLACK_TEAM_CHANNEL_WEBHOOK: ${{ secrets.SLACK_TEAM_CHANNEL_WEBHOOK }}

--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -23,9 +23,9 @@ permissions:
 jobs:
   suggest-reviewers:
     # TODO: pin to a released tag once NVIDIA-NeMo/FW-CI-templates#556 merges.
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@bbf3a5361149032a502fc0a5eee0b5750fed7d60
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@be35284c8d2bb6c2e3e9101db0cd31bb288a98df
     with:
-      workflow_ref: bbf3a5361149032a502fc0a5eee0b5750fed7d60
+      workflow_ref: be35284c8d2bb6c2e3e9101db0cd31bb288a98df
     secrets:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
       SLACK_TEAM_CHANNEL_WEBHOOK: ${{ secrets.SLACK_TEAM_CHANNEL_WEBHOOK }}

--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -23,9 +23,10 @@ permissions:
 jobs:
   suggest-reviewers:
     # TODO: pin to a released tag once NVIDIA-NeMo/FW-CI-templates#556 merges.
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@acb48e0d611da0c338d8a357b78519f42dc0e6b6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@a0a89857ac3da812a76182a6aaa9cc326986cf30
     with:
-      workflow_ref: acb48e0d611da0c338d8a357b78519f42dc0e6b6
+      workflow_ref: a0a89857ac3da812a76182a6aaa9cc326986cf30
+      app-id: ${{ vars.BOT_ID }}
     secrets:
-      NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
+      BOT_KEY: ${{ secrets.BOT_KEY }}
       SLACK_TEAM_CHANNEL_WEBHOOK: ${{ secrets.SLACK_TEAM_CHANNEL_WEBHOOK }}

--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -23,9 +23,9 @@ permissions:
 jobs:
   suggest-reviewers:
     # TODO: pin to a released tag once NVIDIA-NeMo/FW-CI-templates#556 merges.
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@88511a5206b05cfe5a66666a08a1d7579e2c2f7a
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_suggest_reviewers.yml@acb48e0d611da0c338d8a357b78519f42dc0e6b6
     with:
-      workflow_ref: 88511a5206b05cfe5a66666a08a1d7579e2c2f7a
+      workflow_ref: acb48e0d611da0c338d8a357b78519f42dc0e6b6
     secrets:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
       SLACK_TEAM_CHANNEL_WEBHOOK: ${{ secrets.SLACK_TEAM_CHANNEL_WEBHOOK }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -247,3 +247,5 @@ RUN export HOME=/home/nemo-runtime \
 USER root
 ENTRYPOINT ["gym"]
 CMD ["--help"]
+
+# no-op: touched to test suggest-reviewers workflow (docker/ -> individual suggestion)

--- a/nemo_gym/sandbox/config.py
+++ b/nemo_gym/sandbox/config.py
@@ -166,3 +166,5 @@ def resolve_provider_metadata(
             f"Sandbox '{SANDBOX_BLOCK_DEFAULT_METADATA_KEY}' from {source} must be a mapping, got: {metadata!r}"
         )
     return dict(metadata)
+
+# no-op: touched to test suggest-reviewers workflow (nemo_gym/sandbox/ -> team suggestion)


### PR DESCRIPTION
Throwaway PR to exercise .github/workflows/suggest-reviewers.yml and
.github/workflows/validate-codeowners-suggestions.yml end-to-end
before those land on main via #2665.

Touches:
- docker/Dockerfile -> should suggest @anwithk (individual case)
- nemo_gym/sandbox/config.py -> should suggest @nvidia-nemo/gym_core (team case)

Not meant to be merged -- will close/delete after verifying the
Reviewers sidebar and Actions logs.