### PR TITLE
docs(skills): clarify benchmark integration contracts

### DIFF
--- a/.agents/skills/add-benchmark/SKILL.md
+++ b/.agents/skills/add-benchmark/SKILL.md
@@ -1,260 +1,214 @@
 ---
 name: add-benchmark
 description: >
-  Guide for adding a new benchmark or training environment to NeMo-Gym.
-  Use when the user asks to add, create, or integrate a benchmark, evaluation,
-  training environment, or resources server into NeMo-Gym. Also use when wrapping
-  an existing 3rd-party benchmark library. Covers the full workflow: data preparation,
-  resources server implementation, agent wiring, YAML config, testing, and reward
-  profiling (baselining). Triggered by: "add benchmark", "new resources server",
-  "integrate benchmark", "wrap benchmark", "add training environment", "add eval".
+  Add or review a NeMo Gym benchmark, evaluation, training environment, resources
+  server, agent loop, or external harness integration. Covers choosing the integration
+  topology, defining dataset/prompt/verifier/metric contracts, preparing data, composing
+  config, writing behavior-focused tests, running real rollouts, and checking parity with
+  an upstream evaluator.
 ---
 
-# Add Benchmark to NeMo-Gym
+# Add or Review a NeMo Gym Benchmark
 
-## Determine Integration Type
+## Start With the Contract
 
-Before starting, determine which type of benchmark you're adding:
+Before changing code, inspect the upstream benchmark specification, the closest Gym
+implementations, and every runtime consumer of the prepared row. Do not infer a row
+schema from a neighboring benchmark alone.
 
-**Native benchmark** — verification logic implemented directly in a Gym resources server:
-- Resources server implements `verify()` with reward logic
-- Agent server orchestrates model calls (use `simple_agent` for single-turn, or custom agent for multi-turn)
-- Example: `code_gen`, `instruction_following`, `math_with_judge`
+Write down this mapping for the integration:
 
-**External benchmark** — wrapping a 3rd-party library that has its own orchestration:
-- Integrate at the agent server level (not resources server)
-- Agent's `/run` endpoint wraps the external library
-- Pre-process from Gym schema to library input, post-process back to `BaseVerifyResponse`
-- Reproduce publicly reported numbers with the original repo first, then reproduce again after Gym integration
-- Add the dependency in `requirements.txt`
+| Concern | Producer | Consumer | Invariant |
+| --- | --- | --- | --- |
+| task identity | source / `prepare.py` | rollout grouping and metrics | stable and unique |
+| prompt fields | `prepare.py` | `prompt_config` or custom agent | every placeholder exists |
+| verifier fields | `prepare.py` | resources-server request model | names and types match exactly |
+| selector fields | source / `prepare.py` | verifier and scorer | identify the same tests/groups |
+| reward | verifier | training and profiling | range and success meaning are explicit |
+| aggregate metrics | verifier `compute_metrics()` | benchmark report | reproduce the official aggregation |
 
-## Workflow
+For grouped, weighted, or partially overlapping tests, also specify the evaluation
+unit: one problem, one subtask, one test group, or one full episode. A selector is not
+just metadata if it changes which tests run or how scores are pooled.
 
-### Step 1: Scaffold the server
+## Choose the Integration Topology
 
-Run `gym env init` to generate the directory structure:
+Use the smallest topology that preserves the benchmark's behavior:
 
-```bash
-gym env init --resources-server my_benchmark
-```
+1. **Benchmark over an existing verifier** — add `benchmarks/<name>/prepare.py` and
+   `config.yaml`, then inherit an existing resources server and agent. This is the
+   common path for math, MCQ, translation, and code-generation evals.
+2. **Custom Gym verifier** — add a resources server when existing request, reward, or
+   metric contracts cannot express the benchmark.
+3. **Custom Gym agent loop** — add an agent when prompting, tool use, correction turns,
+   or state transitions cannot be handled by an existing agent.
+4. **External agent loop or rollout driver** — adapt an upstream harness when its
+   orchestration is part of the benchmark. Establish upstream results before adapting it.
+5. **Eval suite** — compose several benchmark configs with `config_paths`. A suite is
+   not a single benchmark: benchmark discovery requires exactly one locally declared
+   `type: benchmark` dataset per benchmark config.
 
-This creates:
-```
-resources_servers/my_benchmark/
-├── app.py              # Server template
-├── configs/my_benchmark.yaml
-├── data/.gitignore
-├── tests/test_app.py
-├── requirements.txt
-└── README.md
-```
+Read [references/patterns.md](references/patterns.md) for repository examples and
+config shapes before selecting a topology.
 
-For external benchmarks, create the agent server manually under `responses_api_agents/my_agent/` with the same structure.
+## Scaffold the Right Artifact
 
-### Step 2: Prepare data
-
-Convert your source dataset to Gym JSONL format. Each line must have `responses_create_params.input` (OpenAI message format). Task-specific verification data goes in `verifier_metadata`.
-
-```json
-{
-  "responses_create_params": {
-    "input": [
-      {"role": "system", "content": "System prompt"},
-      {"role": "user", "content": "Problem statement"}
-    ]
-  },
-  "verifier_metadata": {
-    "test_cases": [{"input": "...", "expected_output": "..."}],
-    "task_id": "unique_id"
-  }
-}
-```
-
-**Data conversion**: Write conversion scripts in the **source repo** (e.g. your dataset repository), not in NeMo-Gym. Prompt files also belong in the source repo. Exception: when there is no external source repo. See `references/patterns.md` § "Data Conversion Script Pattern".
-
-**`example.jsonl`**: Generate 5 entries for smoke testing. This file is committed directly to git in `data/example.jsonl`.
-
-**`train`/`validation` datasets**: Upload to the GitLab dataset registry — these must NOT be committed to git.
+Use the manifest-backed scaffold when the benchmark fits its publication contract:
 
 ```bash
-gym dataset upload --storage gitlab \
-    --name my_benchmark \
-    --revision 0.0.1 \
-    --input resources_servers/my_benchmark/data/my_dataset.jsonl
+# New verifier with the default custom-gym-verifier profile
+gym env init --benchmark my_benchmark
+
+# Reuse an existing verifier that exports VERIFIER_FIXTURE
+gym env init --benchmark my_benchmark \
+  --reuse-verifier shared_verifier \
+  --reward-range 0 1 \
+  --higher-is-better
+
+# Other extension points
+gym env init --benchmark my_benchmark --profile custom-gym-agent-loop
+gym env init --benchmark my_benchmark --profile external-agent-loop
+gym env init --benchmark my_benchmark --profile external-rollout-driver
 ```
 
-Requires MLflow credentials in `env.yaml` (or passed via CLI):
+Use `--environment` instead of `--benchmark` for a training environment. Use
+`gym env init --resources-server ...` only when the requested artifact is a standalone
+resources server rather than a complete benchmark/environment.
+
+The generated `config.yaml` is runtime-authoritative. Keep `manifest.yaml` aligned with
+it and replace all scaffold placeholders. Existing config-only benchmarks do not need
+an unrelated migration to a manifest. `--reuse-verifier` requires the selected server
+to export `VERIFIER_FIXTURE`. A manifest-backed benchmark also currently requires a
+standard prompt config; follow an existing config-only pattern when a self-contained
+custom-agent dataset must use `prompt_config: null` rather than inventing a dummy prompt.
+
+## Implement Data and Prompt Preparation
+
+A benchmark dataset declaration has this core contract:
+
 ```yaml
-mlflow_tracking_uri: <your-gitlab-mlflow-tracking-uri>
-mlflow_tracking_token: <your-gitlab-api-token>
+- name: my_benchmark
+  type: benchmark
+  jsonl_fpath: benchmarks/my_benchmark/data/my_benchmark.jsonl
+  prepare_script: benchmarks/my_benchmark/prepare.py
+  prompt_config: benchmarks/my_benchmark/prompts/default.yaml  # or null
+  num_repeats: 1
 ```
 
-**`data/.gitignore`**: The scaffold generates default patterns (`*train.jsonl`, `*validation.jsonl`, etc.). If your filename doesn't match (e.g. `my_eval.jsonl`), add a custom pattern (e.g. `*eval.jsonl`). If data was previously tracked, run `git rm --cached <file>`.
+`prepare.py` must:
 
-**Validate** your data:
-```bash
-# Validate example data (for PR submission)
-gym dataset collate --config resources_servers/my_benchmark/configs/my_benchmark.yaml \
-    --output-dir /tmp/prepare \
-    --mode example_validation
+- expose a synchronous `prepare()` callable that works with no arguments by default;
+- be importable from the repository-root environment used by `gym eval prepare`;
+- return a `Path` exactly matching the configured `jsonl_fpath`;
+- create deterministic rows from a pinned or otherwise auditable source;
+- validate source invariants that could otherwise produce a runnable but incorrectly
+  scored dataset, such as split, task count, IDs, labels, rubric weights, and test groups;
+- avoid replacing a known-good output with a partial result when preparation fails;
+- keep generated benchmark data ignored unless the repository intentionally tracks it.
 
-# Download and prepare train/validation from GitLab
-gym dataset collate --config resources_servers/my_benchmark/configs/my_benchmark.yaml \
-    --output-dir data/my_benchmark \
-    --mode train_preparation \
-    --download \
-    +data_source=gitlab
-```
+If preparation also emits NeMo Skills or another external format, validate that
+consumer's naming, registry, and discovery path with a clean invocation. Producing a
+directory is not sufficient if the downstream tool cannot resolve its public name.
 
-### Step 3: Implement verify()
+Choose exactly one prompt representation:
 
-Edit `app.py`. The `verify()` method receives model output + `verifier_metadata`, returns reward.
+- **Raw semantic fields plus `prompt_config`**: the template fills top-level row fields
+  at rollout time. Do not pre-populate `responses_create_params.input`.
+- **Materialized `responses_create_params.input` plus `prompt_config: null`**: use this
+  for multimodal content, upstream-owned tool schemas/prompts, or custom agents that
+  require a self-contained request.
 
-For code execution benchmarks, see `references/patterns.md` § "Subprocess Execution with Ray" and "Resources Server Pattern".
+`verifier_metadata` is not universally required. The real contract is the selected
+agent/resources-server request model: some servers consume top-level fields, some use
+`verifier_metadata`, and custom agents may consume a self-contained request. Preserve
+provenance separately from fields that affect scoring.
 
-Critical rules:
-- Return `reward` as 0.0 or 1.0 (binary)
-- Handle empty/missing model output gracefully — return 0.0, don't crash
-- Must handle 4k-65k concurrent requests without crashing
-- Use `asyncio.Semaphore` for subprocess concurrency control
-- For Ray remote tasks: `result = await future` (Ray futures are directly awaitable). Never call `ray.get()` in async context.
-- Decode subprocess output with `errors="replace"`
-- Strip `<think>`/`<thinking>` blocks before parsing model output (thinking models emit these)
-- Tests should `pytest.mark.skipif` when external tools aren't installed
-- If the benchmark auto-installs its tool (see Step 3b), add a `pytest_configure` hook in `conftest.py` to run the install before test collection — `skipif` evaluates at import time, before fixtures run
+For a training environment, declare the needed `train`, `validation`, and small
+`example` datasets with auditable `source` and license metadata. Check train/eval split
+leakage and reward density. Use `gym dataset collate` for those dataset types;
+`type: benchmark` preparation goes through `gym eval prepare` instead.
 
-### Step 3b: Auto-install external tools (if applicable)
+## Implement Verification and Metrics
 
-If the benchmark requires an external tool (compiler, runtime, etc.), auto-install it on server startup so users don't need manual setup. See `references/patterns.md` § "External Tool Auto-Install Pattern".
+Trace one prepared row through prompt materialization, the agent request, the resources
+server request model, `verify()`, and `compute_metrics()`. Validate the materialized row
+against the real request models where practical.
 
-Key points:
-- Create `setup_<tool>.py` with `ensure_<tool>()` — checks PATH, forks on `sys.platform` (brew on macOS, build from source on Linux)
-- Call it in `model_post_init()` before semaphore init
-- Build scripts should be idempotent and install into a local gitignored prefix
-- Add a `pytest_configure` hook in `tests/conftest.py` that calls `ensure_<tool>()` before collection
+- Define malformed-output behavior; bad model output should score or return a useful
+  error response rather than crash the service.
+- Declare the actual reward range. Do not assume every verifier is binary.
+- Keep per-rollout reward separate from benchmark-level aggregation.
+- For subtasks/groups, prove that a row runs exactly the intended tests and can receive
+  no more than its declared maximum. Synthetic selector names require an explicit
+  verifier mapping; otherwise use identifiers present in verifier metadata.
+- Test overlapping tests, missing groups, partial credit, duplicate outputs, ties, and
+  best-of/repeat pooling when those cases exist.
+- When adapting an upstream evaluator, compare both per-example verdicts and aggregate
+  metrics. Similar headline scores can hide different examples being accepted.
 
-### Step 4: Wire YAML config
+Follow the repository `AGENTS.md` for async HTTP, cookie propagation, concurrency,
+subprocess isolation, external-tool setup, licensing, and source-file requirements.
 
-Edit `configs/my_benchmark.yaml`. Define the resources server instance and agent pairing(s). See `references/patterns.md` § "YAML Config Pattern".
+## Test in Layers
 
-Key points:
-- `verified: false` is auto-added by pre-commit hook (set to `true` after baselining)
-- `license` is required for `train` and `validation` datasets
-- Agent references resources server and model server by instance name
+Tests should pin behavior at each boundary:
 
-For multi-turn benchmarks, either use `proof_refinement_agent` or create a custom agent. See `references/patterns.md` § "Agent Patterns".
+1. **Preparation** — import the module, replace network/data sources with fixtures,
+   assert the exact output path and semantic row contents, and cover source drift and
+   failed/partial writes.
+2. **Config and discovery** — resolve the config, assert the selected agent/resources
+   server, dataset, prompt mode, repeat count, and any verifier asset paths.
+3. **Prompt and request** — materialize at least one row and validate it against the
+   agent/resources-server request contract.
+4. **Verifier** — cover full reward, zero reward, malformed output, exceptions/timeouts,
+   and partial/grouped cases that affect reward.
+5. **Metrics** — test grouping and aggregation independently from `verify()`.
+6. **End to end** — run a known-good/reference solution and a known-bad output through
+   the real execution path. For agent/environment changes, collect real model rollouts
+   and inspect agent and verifier behavior; green unit tests are not sufficient.
 
-For `train`/`validation` datasets, add `gitlab_identifier` alongside `jsonl_fpath`:
-```yaml
-datasets:
-- name: my_dataset
-  type: train
-  jsonl_fpath: resources_servers/my_benchmark/data/my_dataset.jsonl
-  gitlab_identifier:
-    dataset_name: my_benchmark
-    version: 0.0.1
-    artifact_fpath: my_dataset.jsonl
-  license: MIT
-- name: example
-  type: example
-  jsonl_fpath: resources_servers/my_benchmark/data/example.jsonl
-```
+Network access and large downloads do not belong in unit tests. Use small fixtures that
+preserve the scoring-relevant structure.
 
-Both fields must coexist: `jsonl_fpath` is the local download destination, `gitlab_identifier` tells the system where to fetch from. `example` datasets don't need `gitlab_identifier` — they're committed to git directly.
+For a review task, read [references/review-checklist.md](references/review-checklist.md)
+and report concrete findings in severity order, with tight file/line references.
 
-### Step 5: Test
+## Validate the Integration
 
-```bash
-# Run server tests (creates isolated .venv, slow on first run)
-gym env test --resources-server my_benchmark
-
-# Run core library tests to check nothing broke
-pytest tests/unit_tests/ -x
-```
-
-Test coverage must be >= 95%. Write tests for: verify pass, verify fail (wrong output), verify fail (no code extracted), verify fail (compilation error if applicable), verify timeout.
-
-### Step 6: Smoke test end-to-end
-
-```bash
-# Start servers
-gym env start \
-    --config resources_servers/my_benchmark/configs/my_benchmark.yaml \
-    --model-type openai_model
-
-# Quick test with example data
-gym eval run --no-serve \
-  --agent my_benchmark_simple_agent \
-  --input resources_servers/my_benchmark/data/example.jsonl \
-  --output results/example_rollouts.jsonl \
-  --num-repeats 1 \
-  --max-output-tokens 16384 \
-  --temperature 1.0
-
-# Inspect results
-```
-
-### Step 7: Baseline (reward profiling)
-
-Run against multiple models to validate correctness. Recommended suite:
-- Your policy model of interest
-- At least one open-source instruct model (e.g. Qwen 3 30B A3B Instruct)
-- At least one open-source thinking model (e.g. Qwen 3 30B A3B Thinking)
-- At least one closed-source model (e.g. GPT-5 Nano or GPT-5)
+Use the target checkout's CLI help as the source of truth. A typical benchmark sequence is:
 
 ```bash
-# Collect rollouts
-gym eval run --no-serve \
-  --agent my_benchmark_simple_agent \
-  --input resources_servers/my_benchmark/data/my_dataset.jsonl \
-  --output results/rollouts.jsonl \
-  --num-repeats 5 \
-  --max-output-tokens 16384 \
-  --temperature 1.0
+python -m pytest benchmarks/my_benchmark/tests -q
+python -m pytest resources_servers/my_verifier/tests -q
 
-# Compute per-task pass rates
-gym eval profile --inputs resources_servers/my_benchmark/data/my_dataset.jsonl \
-  --rollouts results/rollouts.jsonl
-
-# Aggregate metrics (pass@1 = avg_reward, pass@k from max_reward)
-python scripts/print_aggregate_results.py +jsonl_fpath=results/profiled.jsonl
+gym list benchmarks my_benchmark
+gym eval prepare --benchmark my_benchmark
+gym env validate --benchmark my_benchmark
+gym eval run --benchmark my_benchmark --model-type <model_type>
 ```
 
-Increase `num_repeats` until variance < 1% across runs on the same model.
-
-Closed-source models should score at or above open-source models. If not, investigate for bugs. Inspect actual failure cases in the rollout JSONL, not just aggregate numbers.
-
-For external benchmarks: reproduce the original repo's published numbers first. Then reproduce after Gym integration. Scores should match.
-
-### Step 8: Pre-commit and PR
+For a manifest-backed entry, also run:
 
 ```bash
-pre-commit run --all-files
+gym env validate my_benchmark --kind benchmark
+gym env test my_benchmark --kind benchmark
+gym env publish my_benchmark --kind benchmark
 ```
 
-First run may fail as hooks auto-modify files (`verified: false` flag, README table). Stage changes and run again.
+Profile repeated rollouts with the `nemo-gym-reward-profiling` skill. Inspect individual
+rollouts, error rates, reward distribution, per-category/group metrics, and variance—not
+only the headline mean. Compare against official or previously reproduced results when
+an upstream benchmark exists.
 
-Set `verified: true` in YAML config after successful baselining. Include W&B links and screenshots of results in the PR description.
+Before handoff, run focused pre-commit checks on changed files, then the broader checks
+appropriate to the change. Commits require DCO sign-off with `git commit -s`;
+cryptographic `-S` signing is optional.
 
-To avoid committing unrelated auto-fixes from other servers, scope pre-commit to your files:
-```bash
-pre-commit run --files resources_servers/my_benchmark/**/*
-```
-If hooks modify files in other directories, discard those changes:
-```bash
-git checkout -- resources_servers/other_server/
-```
+## Reference Loading
 
-## Constraints
-
-- Use NeMo Gym's OpenAI client (`nemo_gym/openai_utils.py`), not LiteLLM/Anthropic/other
-- **Use aiohttp, not httpx, for async HTTP.** All async HTTP calls must go through `nemo_gym.server_utils.request()` (aiohttp). httpx has O(n^2) connection pooling that hangs at high concurrency. When wrapping external libraries that use httpx internally, replace their HTTP transport with an aiohttp adapter — see `resources_servers/tavily_search/app.py` (`TavilySearchAIOHTTPClient`) for the pattern and `fern/versions/latest/pages/infrastructure/engineering-notes/aiohttp-vs-httpx.mdx` for the rationale.
-- Pass configuration through Gym config (YAML), not environment variables
-- Code must run on Linux
-- `/run` endpoint must be async
-- Errors from tool execution or bad model output must return error responses, not crash
-- All commits require DCO sign-off (`-s`) and cryptographic signature (`-S`)
-
-## Reference
-
-For detailed code patterns, schemas, and examples: see [references/patterns.md](references/patterns.md).
+- [references/patterns.md](references/patterns.md) — choose a topology and borrow a
+  current repository pattern.
+- [references/review-checklist.md](references/review-checklist.md) — review data,
+  template, verifier, scoring, metrics, tests, and operational readiness.
+- Use `nemo-gym-reward-profiling` for rollout/profile commands and artifact semantics.
+- Use `nemo-gym-debugging` when preparation, serving, rollout collection, or judging fails.

--- a/.agents/skills/add-benchmark/references/patterns.md
+++ b/.agents/skills/add-benchmark/references/patterns.md
@@ -1,715 +1,311 @@
-# NeMo-Gym Benchmark Patterns Reference
+# Benchmark Integration Patterns
 
-Detailed patterns, schemas, and code examples for adding benchmarks to NeMo-Gym. Read this file when implementing a benchmark.
+Use this reference to choose an implementation shape. Repository files are examples,
+not universal schemas: always confirm the target checkout's config and request models.
 
-## Table of Contents
+## Runtime Sources of Truth
 
-1. [Resources Server Pattern](#resources-server-pattern)
-2. [YAML Config Pattern](#yaml-config-pattern)
-3. [JSONL Data Schema](#jsonl-data-schema)
-4. [Agent Patterns](#agent-patterns)
-5. [Code Extraction Patterns](#code-extraction-patterns)
-6. [Subprocess Execution with Ray](#subprocess-execution-with-ray)
-7. [Test Patterns](#test-patterns)
-8. [Data Conversion Script Pattern](#data-conversion-script-pattern)
-9. [Dataset Registry Pattern](#dataset-registry-pattern)
+Trace the benchmark through these boundaries:
 
----
+| Boundary | Source of truth | What to verify |
+| --- | --- | --- |
+| discovery/config | `nemo_gym/benchmarks.py`, `BenchmarkDatasetConfig` | one benchmark dataset, resolvable agent, paths, repeats |
+| preparation | `nemo_gym/cli/eval.py` | importable synchronous `prepare()`, exact returned path |
+| prompt materialization | `nemo_gym/prompt.py` | raw rows and `prompt_config`, or materialized input—not both |
+| rollout input | `BaseRunRequest` and selected agent request model | required fields and routing |
+| verification | selected resources-server request model and `verify()` | field meanings, reward, failures |
+| aggregation | selected server's `compute_metrics()` / `get_key_metrics()` | grouping, caps, pass@k, official score |
 
-## Resources Server Pattern
+The data producer and all consumers must agree on semantics, not merely field names.
 
-### Minimal verify-only server (e.g. `example_single_tool_call`)
+## Pattern 1: Reuse a Shared Verifier
 
-```python
-from nemo_gym.base_resources_server import (
-    SimpleResourcesServer, BaseResourcesServerConfig,
-    BaseVerifyRequest, BaseVerifyResponse,
-)
+Start here when the benchmark changes the dataset but not the grading algorithm.
 
-class MyConfig(BaseResourcesServerConfig):
-    pass
+Examples:
 
-class MyServer(SimpleResourcesServer):
-    config: MyConfig
+- `benchmarks/aime26/` reuses `math_with_judge` and emits `question` plus
+  `expected_answer` for a generic math prompt.
+- `benchmarks/gpqa/` and `benchmarks/mmlu_pro/` reuse `mcqa` with benchmark-specific
+  prompt templates.
+- `benchmarks/wmt24pp/` and `benchmarks/flores200/` reuse `wmt_translation` while
+  overriding evaluator settings needed by the dataset.
+- `benchmarks/livecodebench/v5_2408_2502/` reuses `code_gen` with a nested benchmark
+  identity (`livecodebench/v5_2408_2502/config`).
 
-    async def verify(self, body: BaseVerifyRequest) -> BaseVerifyResponse:
-        model_output = body.response.output_text
-        expected = (body.verifier_metadata or {}).get("expected_answer")
-        reward = 1.0 if model_output.strip() == expected else 0.0
-        return BaseVerifyResponse(**body.model_dump(), reward=reward)
-
-if __name__ == "__main__":
-    MyServer.run_webserver()
-```
-
-### Subprocess execution server (e.g. `code_gen`)
-
-```python
-from asyncio import Semaphore, get_running_loop
-from time import time
-from typing import Any, Dict, List, Optional
-import ray
-from nemo_gym.base_resources_server import (
-    SimpleResourcesServer, BaseResourcesServerConfig,
-    BaseRunRequest, BaseVerifyRequest, BaseVerifyResponse,
-)
-
-class MyConfig(BaseResourcesServerConfig):
-    num_processes: int = 8
-    timeout_secs: int = 30
-    debug: bool = False
-
-class MyVerifyRequest(BaseRunRequest, BaseVerifyRequest):
-    verifier_metadata: Optional[Dict[str, Any]] = None
-
-class MyVerifyResponse(BaseVerifyResponse):
-    extracted_code: Optional[str] = None
-    # ... benchmark-specific result fields
-
-class MyServer(SimpleResourcesServer):
-    config: MyConfig
-
-    def model_post_init(self, context):
-        self._semaphore: Semaphore = Semaphore(value=self.config.num_processes)
-
-    async def verify(self, body: MyVerifyRequest) -> MyVerifyResponse:
-        model_out = body.response.output_text
-        if not model_out or not model_out.strip():
-            return MyVerifyResponse(**body.model_dump(), reward=0.0)
-
-        code = extract_code(model_out)  # your extraction function
-        if not code:
-            return MyVerifyResponse(**body.model_dump(), reward=0.0)
-
-        async with self._semaphore:
-            future = run_tests_remote.remote(code, body.verifier_metadata)
-            result = await future
-
-        return MyVerifyResponse(
-            **body.model_dump(),
-            reward=1.0 if result["all_passed"] else 0.0,
-            extracted_code=code,
-        )
-```
-
-### Key rules
-
-- `verify()` must be async
-- Return `reward` as 0.0 or 1.0 (binary for RL)
-- Handle empty/missing model output gracefully (return 0.0, don't crash)
-- `verifier_metadata` is the opaque dict from JSONL — define whatever fields your benchmark needs
-- Guard optional nested fields: `(body.verifier_metadata or {}).get("key", default)`
-- Use `asyncio.Semaphore` to bound concurrent subprocess/external calls
-- For Ray remote tasks: `result = await future` (Ray futures are directly awaitable). Never call `ray.get()` in async context.
-
----
-
-## External Tool Auto-Install Pattern
-
-When a benchmark requires an external tool (compiler, runtime, etc.), auto-install it so users don't need manual setup.
-
-### setup module (`setup_<tool>.py`)
-
-```python
-import logging, os, shutil, subprocess, sys
-from pathlib import Path
-
-LOG = logging.getLogger(__name__)
-_SCRIPT_DIR = Path(__file__).resolve().parent
-_DEFAULT_PREFIX = _SCRIPT_DIR / ".toolname"
-_INSTALL_SCRIPT = _SCRIPT_DIR / "scripts" / "install_tool.sh"
-
-def ensure_tool() -> None:
-    if shutil.which("tool"):
-        LOG.info("tool found: %s", shutil.which("tool"))
-        return
-    LOG.warning("tool not found on PATH — attempting auto-install")
-    if sys.platform == "darwin":
-        subprocess.run(["brew", "install", "tool-package"], check=True)
-    elif sys.platform == "linux":
-        prefix = os.environ.get("TOOL_PREFIX", str(_DEFAULT_PREFIX))
-        env = os.environ.copy()
-        env["TOOL_PREFIX"] = prefix
-        subprocess.run(["bash", str(_INSTALL_SCRIPT)], check=True, env=env)
-        os.environ["PATH"] = str(Path(prefix) / "bin") + os.pathsep + os.environ.get("PATH", "")
-        os.environ["LD_LIBRARY_PATH"] = str(Path(prefix) / "lib") + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
-    else:
-        raise NotImplementedError(f"Unsupported platform: {sys.platform}")
-    # Verify
-    if not shutil.which("tool"):
-        raise RuntimeError("Install completed but tool still not on PATH")
-```
-
-### Server integration (`app.py`)
-
-```python
-def model_post_init(self, context):
-    ensure_tool()  # auto-install before any requests
-    self._semaphore = Semaphore(value=self.config.num_processes)
-```
-
-### Test integration (`tests/conftest.py`)
-
-`pytest.mark.skipif` evaluates at **module import time** (during collection), before any fixtures run. To auto-install before skip checks, use `pytest_configure`:
-
-```python
-from setup_tool import ensure_tool
-
-def pytest_configure(config):
-    try:
-        ensure_tool()  # runs before test collection
-    except Exception:
-        pass
-    # Now skipif(shutil.which("tool") is None) will find the tool
-```
-
-### Build script (`scripts/install_tool.sh`)
-
-- Versions as variables at the top
-- Configurable prefix via env var (default: `../.toolname/`)
-- Idempotent: skip steps if artifacts already exist
-- Check for prerequisites (`gcc`, `make`, `wget`/`curl`)
-
-### Gitignore
-
-Add `.toolname/` to the server's `.gitignore`.
-
----
-
-## YAML Config Pattern
-
-A single YAML file in `configs/` defines both the resources server and its agent pairing(s):
+Typical config:
 
 ```yaml
-# Resources server instance
-my_benchmark:
-  resources_servers:
-    my_benchmark:                    # must match subdirectory name
-      entrypoint: app.py
-      domain: coding                 # or: math, other
-      # server-specific config fields:
-      num_processes: 8
-      timeout_secs: 30
-      debug: false
+config_paths:
+  - resources_servers/math_with_judge/configs/math_with_judge.yaml
 
-# Simple agent pairing (single-turn)
+my_benchmark_resources_server:
+  _inherit_from: math_with_judge
+
 my_benchmark_simple_agent:
+  _inherit_from: math_with_judge_simple_agent
   responses_api_agents:
     simple_agent:
-      entrypoint: app.py
       resources_server:
-        type: resources_servers
-        name: my_benchmark           # matches instance name above
-      model_server:
-        type: responses_api_models
-        name: policy_model           # defined in env.yaml or policy config
+        name: my_benchmark_resources_server
       datasets:
-      - name: my_dataset
-        type: train
-        jsonl_fpath: resources_servers/my_benchmark/data/my_dataset.jsonl
-        gitlab_identifier:
-          dataset_name: my_benchmark
-          version: 0.0.1
-          artifact_fpath: my_dataset.jsonl
-        license: MIT                 # required for train/validation
-        num_repeats: 1
-      - name: example
-        type: example
-        jsonl_fpath: resources_servers/my_benchmark/data/example.jsonl
-
-# Optional: custom agent pairing (multi-turn)
-my_benchmark_eval_agent:
-  responses_api_agents:
-    my_eval_agent:
-      entrypoint: app.py
-      resources_server:
-        type: resources_servers
-        name: my_benchmark
-      model_server:
-        type: responses_api_models
-        name: policy_model
-      max_correction_turns: 3
-      datasets:
-      - name: my_dataset
-        type: train
-        jsonl_fpath: resources_servers/my_benchmark/data/my_dataset.jsonl
-        gitlab_identifier:
-          dataset_name: my_benchmark
-          version: 0.0.1
-          artifact_fpath: my_dataset.jsonl
-        license: MIT
-        num_repeats: 1
-      - name: example
-        type: example
-        jsonl_fpath: resources_servers/my_benchmark/data/example.jsonl
+        - name: my_benchmark
+          type: benchmark
+          jsonl_fpath: benchmarks/my_benchmark/data/my_benchmark.jsonl
+          prompt_config: benchmarks/my_benchmark/prompts/default.yaml
+          prepare_script: benchmarks/my_benchmark/prepare.py
+          num_repeats: 1
 ```
 
-### Key rules
+Create an isolated inherited resources-server instance when the benchmark overrides
+grader assets or settings. Point the agent at that isolated instance; otherwise the
+override may affect or bypass a different composition.
 
-- The `verified: false` flag is auto-added by pre-commit hook. Set to `true` after baselining.
-- `license` is required for `train` and `validation` datasets.
-- Valid license values: `Apache 2.0`, `MIT`, `CC-BY-4.0`, etc.
-- `domain` should be one of: `coding`, `math`, `other`, or check `config_types.py` for current enum.
-- Dataset `type` must be one of: `train`, `validation`, `example`.
-- `gitlab_identifier` is required for `train`/`validation` datasets. `jsonl_fpath` is the local download path. Both fields coexist.
-- `example` datasets don't have `gitlab_identifier` — they're committed to git directly.
+Do not add a new resources server just to rename input fields. Prefer converting the
+source rows to an existing, well-tested request contract when the grading semantics are
+actually the same.
 
----
+## Pattern 2: Reuse a Structured or Grouped Verifier
 
-## JSONL Data Schema
+Coding, rubric, and grouped-test evaluators usually consume more than a question and
+answer. Treat their request model and aggregation logic as a single contract.
 
-Each line is a JSON object with this structure:
+Examples:
+
+- `benchmarks/ioi/` emits competition, problem, subtask, score, and question fields,
+  plus a separate metadata artifact consumed by
+  `resources_servers/competitive_coding_challenges/`.
+- `benchmarks/livecodebench/` converts official runner cases into the `code_gen`
+  request shape.
+- `benchmarks/finance_agent_v2/` preserves upstream rubrics, modifiers, prompts, and
+  tools because each can change the score or agent trajectory.
+
+For each selector or group field, answer all of the following:
+
+1. Is the value present in the verifier's loaded metadata?
+2. Does it select tests, label results, cap a score, or only annotate output?
+3. If tests overlap across groups, does the evaluator award a group only after every
+   required test ran and passed?
+4. Does per-rollout reward use the same unit as aggregate metrics?
+5. Can one row accidentally contribute credit to a different group or contribute the
+   same test more than once?
+
+Never introduce a synthetic selector in `prepare.py` unless the verifier explicitly
+maps it to canonical tests and a score cap. A human-readable grouping label is not a
+valid execution selector by itself.
+
+Additional grader assets must be declared, generated, and tested as a set. If
+`prepare()` writes the primary JSONL plus metadata, scripts, databases, or archives,
+the config must point to the exact generated paths and a test must assert their mutual
+consistency.
+
+## Pattern 3: Choose Raw or Materialized Prompts
+
+### Raw semantic rows
+
+Use top-level semantic fields and a non-null `prompt_config` when the prompt can be
+rendered from text values at rollout time:
+
+```json
+{"question": "...", "expected_answer": "...", "uuid": "stable-id"}
+```
+
+```yaml
+prompt_config: benchmarks/my_benchmark/prompts/default.yaml
+```
+
+Every template placeholder must exist in every row. Prompt templates use Python-style
+`str.format_map`; literal braces must be doubled. This mode supports prompt sweeps
+without re-preparing the dataset.
+
+### Materialized request rows
+
+Use a pre-populated `responses_create_params.input` and `prompt_config: null` when the
+request contains images, upstream-owned tool schemas, or agent-specific structure:
 
 ```json
 {
   "responses_create_params": {
-    "input": [
-      {"role": "system", "content": "System prompt here"},
-      {"role": "user", "content": "Problem description here"}
-    ]
+    "input": [{"role": "user", "content": "..."}],
+    "tools": []
   },
-  "verifier_metadata": {
-    "test_cases": [...],
-    "task_id": "unique_id",
-    "category": "optional_category"
-  }
+  "instance_id": "stable-id"
 }
 ```
 
-### Required fields
+Examples:
 
-- `responses_create_params.input`: list of message dicts with `role` and `content`. Follows OpenAI message format.
+- `benchmarks/hle/config_vision.yaml` uses materialized multimodal inputs, while the
+  text-only `benchmarks/hle/config.yaml` uses raw fields plus a prompt template.
+- `benchmarks/finance_agent_v2/` materializes the upstream prompt and tool schemas.
+- `benchmarks/legal_agent_bench/`, `benchmarks/scicode/`, and `benchmarks/osworld/`
+  use custom-agent-compatible rows and `prompt_config: null`.
 
-### Optional fields
+These modes are mutually exclusive. `nemo_gym/prompt.py` rejects rows with a non-empty
+`responses_create_params.input` when a `prompt_config` is also configured.
 
-- `responses_create_params.tools`: function tool definitions if the benchmark uses tool calls
-- `responses_create_params.temperature`, `max_output_tokens`, etc.
-- `verifier_metadata`: arbitrary dict passed through to `verify()`. Define whatever your benchmark needs.
-- Any other top-level fields — they pass through to the resources server via `BaseRunRequest`.
+## Pattern 4: Add a Custom Verifier or Agent Loop
 
-### Data conversion
+Use a custom verifier when reward or aggregate metrics are new. Use a custom agent
+when the trajectory—not only the final answer—is part of the benchmark.
 
-Convert from source format to Gym JSONL using a conversion script. See [Data Conversion Script Pattern](#data-conversion-script-pattern) for the script template and [Dataset Registry Pattern](#dataset-registry-pattern) for the upload workflow.
+Current scaffold profiles correspond to different extension points:
 
----
+| Profile | Use when |
+| --- | --- |
+| `custom-gym-verifier` | Gym owns the verification logic; an existing agent can run it |
+| `custom-gym-agent-loop` | Gym owns a custom multi-step agent loop |
+| `external-agent-loop` | an upstream harness owns the interaction loop |
+| `external-rollout-driver` | an external driver owns rollout orchestration |
 
-## Agent Patterns
+Examples to inspect:
 
-### Simple agent (default — no custom code needed)
+- `resources_servers/scicode/` plus `responses_api_agents/scicode_agent/` for a
+  benchmark-specific, multi-step scientific-coding loop.
+- `benchmarks/legal_agent_bench/` plus its Harbor agent/resources server for an
+  upstream task bundle adapted into Gym with shared cache paths.
+- `benchmarks/osworld/` plus `responses_api_agents/osworld_agent/` for an external
+  environment with execution-backend profiles and operational tooling.
+- `resources_servers/evalplus/` with `benchmarks/human_eval/` and `benchmarks/mbpp/`
+  for multiple datasets sharing an official code-evaluation backend.
 
-For single-turn benchmarks (model generates once, verify). Just reference `simple_agent` in YAML config.
+Agent loops must propagate session cookies through downstream calls. Training-capable
+multi-turn loops must preserve monotonic trajectories and token metadata required by
+the training stack. Follow `AGENTS.md` for async HTTP and concurrency rules.
 
-### Multi-turn correction agent (e.g. `proof_refinement_agent`)
+When wrapping an upstream library:
 
-For benchmarks where the model gets error feedback and retries:
+1. run its official evaluator first and save versioned per-example outputs;
+2. pin the upstream version and data revision;
+3. map Gym inputs and outputs at a narrow adapter boundary;
+4. compare Gym and upstream verdicts example by example;
+5. separately compare aggregate metrics and unsupported/error cases.
 
-```python
-from nemo_gym.base_responses_api_agent import (
-    BaseResponsesAPIAgentConfig, Body, SimpleResponsesAPIAgent,
-)
-from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
-from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
-from nemo_gym.server_utils import raise_for_status
+## Pattern 5: Compose an Eval Suite
 
-class MyAgentConfig(BaseResponsesAPIAgentConfig):
-    resources_server: ResourcesServerRef
-    model_server: ModelServerRef
-    max_correction_turns: int = 3
+An eval suite is a composition, not a discoverable single benchmark. Keep each
+benchmark independently preparable and runnable, then compose config paths:
 
-class MyAgent(SimpleResponsesAPIAgent):
-    config: MyAgentConfig
-
-    async def responses(self, request, response, body=Body()):
-        # Forward to model server, return NeMoGymResponse
-        model_response = await self.server_client.post(
-            server_name=self.config.model_server.name,
-            url_path="/v1/responses",
-            json=body,
-            cookies=request.cookies,
-        )
-        await raise_for_status(model_response)
-        return NeMoGymResponse.model_validate(await model_response.json())
-
-    async def run(self, request, body):
-        cookies = request.cookies
-
-        # 1. Seed session
-        seed = await self.server_client.post(
-            self.config.resources_server.name, "/seed_session",
-            json=body.model_dump(), cookies=cookies,
-        )
-        cookies = seed.cookies
-
-        current_input = body.responses_create_params
-        for turn in range(self.config.max_correction_turns + 1):
-            # 2. Generate
-            gen = await self.server_client.post(
-                self.config.name, "/v1/responses",
-                json=current_input, cookies=cookies,
-            )
-            cookies = gen.cookies
-            model_json = await gen.json()
-
-            # 3. Verify
-            verify_data = body.model_dump()
-            verify_data["response"] = model_json
-            verify = await self.server_client.post(
-                self.config.resources_server.name, "/verify",
-                json=verify_data, cookies=cookies,
-            )
-            cookies = verify.cookies
-            result = await verify.json()
-
-            if result.get("reward", 0.0) == 1.0:
-                break
-            if turn >= self.config.max_correction_turns:
-                break
-
-            # 4. Build correction prompt from errors
-            current_input = {"input": [{"role": "user", "content": build_correction(result)}]}
-
-        return result
-```
-
-### Key rules
-
-- Propagate cookies through every server call: `cookies=request.cookies`, then update with `response.cookies`. This is critical for stateful environments that track per-task sessions.
-- Call `raise_for_status()` after every inter-server call
-- The agent calls itself (`self.config.name`) for `/v1/responses` to keep middleware chain intact
-- Use `ConfigDict(extra="allow")` on request/response models for flexible field forwarding
-- **Token ID propagation**: model responses include `prompt_token_ids`, `generation_token_ids`, and `generation_log_probs`. Propagate these from each model response into the next turn's input — required for RL training. See `swe_agents/app.py` for the implementation pattern.
-- **Monotonic trajectories**: NeMo RL requires the token sequence across multi-turn rollouts to only grow. Never summarize, truncate, or modify prior turns between steps.
-- **Thinking model compatibility**: thinking models emit `<think>`/`<thinking>` blocks. Strip these before parsing tool calls from model output, or parsing will break. See `harbor_agent` for the handling pattern.
-- **Concurrency control for external services**: if the agent calls external services (Docker containers, APIs), use `asyncio.Semaphore` to throttle concurrent calls — external services may not handle thousands of simultaneous requests.
-
----
-
-## Code Extraction Patterns
-
-For benchmarks that need to extract code from model output:
-
-1. Strip `<think>`/`<thinking>` blocks (reasoning traces from thinking models)
-2. Extract from markdown code fences (` ```lang ``` `)
-3. Fall back to language-specific markers
-4. Validate extracted code has required structure
-
-Handle these edge cases:
-- Orphaned closing tags (`</think>` without matching `<think>`)
-- Unclosed code fences
-- Multiple code blocks (pick longest)
-- No code fences at all (raw code in response)
-
----
-
-## Subprocess Execution with Ray
-
-For benchmarks that compile/run code:
-
-```python
-import ray
-import subprocess
-import tempfile
-from pathlib import Path
-
-@ray.remote
-def run_tests_remote(code, test_cases, timeout=30):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Write source, compile, run tests
-        src = Path(tmpdir) / "program.ext"
-        src.write_text(code)
-
-        try:
-            result = subprocess.run(
-                ["compiler", str(src)],
-                capture_output=True, timeout=timeout,
-            )
-        except subprocess.TimeoutExpired:
-            return {"all_passed": False, "error": "timeout"}
-        except FileNotFoundError:
-            return {"all_passed": False, "error": "compiler not found"}
-
-        # ... run test cases, compare output
-        return {"all_passed": all_passed, ...}
-```
-
-### Key rules
-
-- Decode subprocess output with `errors="replace"` to handle non-UTF8
-- Implement fail-fast after N consecutive timeouts
-- Handle `FileNotFoundError` for missing compilers/tools
-- Use `tempfile.TemporaryDirectory` for isolation
-- Executables must run on Linux
-
----
-
-## Test Patterns
-
-### Resources server tests
-
-```python
-import shutil
-import pytest
-from unittest.mock import MagicMock
-from nemo_gym.server_utils import ServerClient
-from resources_servers.my_benchmark.app import MyServer, MyConfig
-
-SKIP_REASON = "tool-name not installed"
-
-@pytest.mark.skipif(
-    shutil.which("tool-name") is None, reason=SKIP_REASON
-)
-class TestMyServer:
-    def setup_method(self):
-        self.config = MyConfig(host="0.0.0.0", port=8080, entrypoint="", name="")
-        self.server = MyServer(config=self.config, server_client=MagicMock(spec=ServerClient))
-
-    # Test cases: verify_pass, verify_fail_compile, verify_fail_wrong_output,
-    #             verify_no_code, verify_timeout, code_extraction
-```
-
-### Agent tests
-
-Mock `server_client.post()` to simulate server responses without running actual servers.
-
----
-
-## Data Conversion Script Pattern
-
-Conversion scripts and prompt files belong in the **source repo** (e.g. your dataset repository), not in NeMo-Gym. Only the converted JSONL files are uploaded to the GitLab dataset registry.
-
-**Exception**: When there is no external source repo, keep the conversion script in the resources server directory.
-
-Reference script template (for use in the source repo):
-
-```python
-import argparse
-import json
-from pathlib import Path
-
-def convert_problem(problem: dict, system_prompt: str) -> dict:
-    return {
-        "responses_create_params": {
-            "input": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": problem["prompt"]},
-            ]
-        },
-        "verifier_metadata": {
-            "test_cases": problem["tests"],
-            "task_id": problem["id"],
-        },
-    }
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--input", required=True)
-    parser.add_argument("--output", required=True)
-    parser.add_argument("--system-prompt", required=True, help="Path to system prompt text file")
-    parser.add_argument("--example-output", help="Path to example.jsonl (first 5 entries)")
-    args = parser.parse_args()
-
-    system_prompt = Path(args.system_prompt).read_text().strip()
-
-    with open(args.input) as f:
-        data = json.load(f)
-
-    with open(args.output, "w") as out:
-        for problem in data:
-            record = convert_problem(problem, system_prompt)
-            out.write(json.dumps(record) + "\n")
-
-    if args.example_output:
-        with open(args.input) as f:
-            data = json.load(f)
-        with open(args.example_output, "w") as out:
-            for problem in data[:5]:
-                record = convert_problem(problem, system_prompt)
-                out.write(json.dumps(record) + "\n")
-
-if __name__ == "__main__":
-    main()
-```
-
-Externalize system prompts to text files, pass via `--system-prompt` argument. Multiple prompt tiers enable ablation studies.
-
----
-
-## Dataset Registry Pattern
-
-### Dataset types and where they live
-
-| Type | Location | Committed to git? | `gitlab_identifier`? |
-|------|----------|-------------------|---------------------|
-| `example` | `data/example.jsonl` | Yes | No |
-| `train` | GitLab dataset registry | No | Yes |
-| `validation` | GitLab dataset registry | No | Yes |
-
-### `data/.gitignore` default patterns
-
-Generated by `gym env init`:
-```
-*train.jsonl
-*validation.jsonl
-*train_prepare.jsonl
-*validation_prepare.jsonl
-*example_prepare.jsonl
-```
-
-If your filename doesn't match (e.g. `my_eval.jsonl`), add a custom pattern (e.g. `*eval.jsonl`).
-
-### Upload workflow
-
-1. **Generate** the JSONL file using your conversion script (in the source repo)
-2. **Upload** to GitLab dataset registry:
-   ```bash
-   gym dataset upload --storage gitlab \
-       --name my_benchmark \
-       --revision 0.0.1 \
-       --input resources_servers/my_benchmark/data/my_dataset.jsonl
-   ```
-3. **Add `gitlab_identifier`** to the dataset entry in YAML config:
-   ```yaml
-   - name: my_dataset
-     type: train
-     jsonl_fpath: resources_servers/my_benchmark/data/my_dataset.jsonl
-     gitlab_identifier:
-       dataset_name: my_benchmark
-       version: 0.0.1
-       artifact_fpath: my_dataset.jsonl
-     license: MIT
-   ```
-4. **Ensure `.gitignore`** covers the filename (add custom pattern if needed)
-5. **Remove from git** if previously tracked: `git rm --cached <file>`
-
-### MLflow credentials
-
-Upload/download requires MLflow credentials in `env.yaml`:
 ```yaml
-mlflow_tracking_uri: <your-gitlab-mlflow-tracking-uri>
-mlflow_tracking_token: <your-gitlab-api-token>
+config_paths:
+  - benchmarks/gpqa/config.yaml
+  - benchmarks/scicode/config.yaml
+  - benchmarks/hle/config.yaml
+  - responses_api_models/vllm_model/configs/vllm_model.yaml
 ```
 
-The tracking URI format is `https://<gitlab-host>/api/v4/projects/<PROJECT_ID>/ml/mlflow`.
+See `benchmarks/nemotron_3.5_super/eval_container_config.yaml` for a heterogeneous
+suite and `nemotron_recipes/lightning-3.5/base/base-suite.yaml` for an external
+evaluator task suite.
 
-### Verification with `gym dataset collate`
+Suite checks should cover:
 
-Validate example data (for PR submission):
+- config composition conflicts and intentional overrides;
+- unique output/task identities across benchmarks;
+- model capabilities required by each member (vision, tools, completions, logprobs);
+- per-benchmark completion/error rates before computing a suite summary;
+- repeat/sampling policy, caching, and aggregation per benchmark rather than one
+  accidental global default.
+
+Do not place several locally declared `type: benchmark` datasets in a config expected
+to work with `gym eval prepare --benchmark <name>`; benchmark discovery intentionally
+rejects that shape as a suite.
+
+## Manifest-Backed Scaffolding
+
+For a new complete benchmark that fits the manifest contract, use:
+
 ```bash
-gym dataset collate --config resources_servers/my_benchmark/configs/my_benchmark.yaml \
-    --output-dir /tmp/prepare \
-    --mode example_validation
+gym env init --benchmark my_benchmark
 ```
 
-Download and prepare train/validation from GitLab:
+The scaffold creates the catalog artifact, config, manifest, and component/fixture
+extension points appropriate to its profile. Reuse is available only when the existing
+resources server exports `VERIFIER_FIXTURE`:
+
 ```bash
-gym dataset collate --config resources_servers/my_benchmark/configs/my_benchmark.yaml \
-    --output-dir data/my_benchmark \
-    --mode train_preparation \
-    --download \
-    +data_source=gitlab
+gym env init --benchmark my_benchmark \
+  --reuse-verifier shared_verifier \
+  --reward-range 0 1 \
+  --higher-is-better
 ```
 
----
+The manifest declares the public contract (kind, profile, domain, reward range,
+determinism, components, and datasets) and mirrors resolved config fields. The config
+remains authoritative for runtime wiring. Validate both static structure and verifier
+fixtures with the manifest-aware commands before publication.
 
-## External Benchmark Integration
+A benchmark manifest currently requires a standard prompt config. For a self-contained
+materialized/custom-agent dataset that must keep `prompt_config: null`, follow the
+existing config-only patterns rather than adding a dummy prompt. Likewise, do not add a
+fixture or migrate a legacy shared verifier merely to make an otherwise focused
+benchmark PR use `--reuse-verifier`.
 
-When wrapping a 3rd-party benchmark library (e.g. SWE-bench, BigCodeBench), integrate at the agent server level:
+Use the standalone `gym env init --resources-server my_server` only when adding one
+component outside a complete catalog entry.
 
-```python
-class ExternalBenchmarkAgent(SimpleResponsesAPIAgent):
-    config: ExternalBenchmarkAgentConfig
+## Preparation Pattern
 
-    async def responses(self, request, response, body=Body()):
-        raise NotImplementedError("Use /run endpoint directly")
+The CLI imports the module and calls `prepare(**prepare_script_args)`. The returned
+path must exactly match `jsonl_fpath`. Keep default preparation callable with no args;
+optional keyword arguments are useful for focused local preparation.
 
-    async def run(self, request, body):
-        # 1. Pre-process: Gym schema → library input
-        library_input = preprocess(body)
+Robust preparation has these properties:
 
-        # 2. Call external library
-        library_result = await run_external(library_input)
+- expensive or optional preparation dependencies are imported lazily when practical;
+- dependencies needed by `gym eval prepare` are available in the repository-root
+  environment, not only a resources server's isolated requirements;
+- network calls check failures and source versions/revisions are recorded;
+- ordering and serialization are deterministic;
+- IDs and evaluation-critical fields are validated before publication;
+- a temporary file is flushed and atomically replaces the destination only after all
+  validation succeeds;
+- failure leaves an existing valid output untouched.
 
-        # 3. Post-process: library result → BaseVerifyResponse
-        return BaseVerifyResponse(
-            **body.model_dump(),
-            reward=1.0 if library_result.passed else 0.0,
-            response=library_result.response,
-        )
-```
+`benchmarks/legal_agent_bench/prepare.py` demonstrates deterministic rendering and an
+atomic replace. `benchmarks/wmt24pp/tests/` demonstrates source-drift and failed-write
+tests. `benchmarks/finance_agent_v2/tests/` demonstrates pinning rubric, modifier,
+prompt, and tool semantics rather than only row counts.
 
-Add the dependency in `requirements.txt`. If needs are more complex than pip packages, use `setup.py` or `pyproject.toml`.
+Keep large generated JSONL and grader assets ignored unless they are intentional small
+fixtures. Commit small examples only when they are needed for offline smoke tests.
 
-Reproduction requirement: run the original repo first, reproduce published numbers, then integrate into Gym and reproduce again. This decouples Gym integration bugs from benchmark bugs.
+## Verifier and Metric Pattern
 
-### Replacing httpx with aiohttp in external libraries
+A resources server normally defines a typed request and response around `verify()`.
+The exact row shape varies by server, so validate against that type rather than a
+generic imagined schema.
 
-Many external libraries use `httpx.AsyncClient` internally. NeMo Gym requires all async HTTP to go through its global aiohttp client (`nemo_gym.server_utils.request()`) because httpx/httpcore has O(n^2) connection pooling that causes hangs at high concurrency. See `fern/versions/latest/pages/infrastructure/engineering-notes/aiohttp-vs-httpx.mdx`.
+Verification tests should distinguish:
 
-When wrapping such a library, create an adapter class that mimics the library's expected HTTP interface but routes calls through aiohttp. The `tavily_search` resources server demonstrates this pattern:
+- valid full-credit output;
+- valid but wrong/partial output;
+- empty, malformed, or unparsable model output;
+- grader exception, timeout, and missing external dependency;
+- state isolation and cookie behavior for stateful environments.
 
-```python
-from nemo_gym.server_utils import request
+Metric tests should be separate. Exercise every grouping key, cap, weight, tie rule,
+deduplication rule, repeat policy, and missing-result behavior. For a benchmark with
+subtasks, include at least one fixture where test membership overlaps; for a benchmark
+with rubrics, include unequal weights and a missing criterion.
 
-class AIOHTTPAdapter(BaseModel):
-    headers: Dict[str, str]
-    base_url: str
+`resources_servers/competitive_coding_challenges/tests/test_app.py` is a useful example
+of testing request forwarding, partial subtask reward, full-problem reward, score caps,
+and cross-rollout aggregation. It does not remove the need for benchmark-specific tests
+that prove prepared selectors match the metadata loaded by that server.
 
-    async def post(self, endpoint: str, content: str, **kwargs) -> AdapterResponse:
-        response = await request(
-            method="POST",
-            url=f"{self.base_url}{endpoint}",
-            headers=self.headers,
-            data=content,
-        )
-        return AdapterResponse(status_code=response.status, data=await response.json())
+## Test Pattern by Boundary
 
-    @classmethod
-    def from_httpx_client(cls, client: AsyncClient) -> "AIOHTTPAdapter":
-        return cls(headers=dict(client.headers), base_url=str(client.base_url))
-```
+| Boundary | Good repository examples | Important assertions |
+| --- | --- | --- |
+| prepare/import | `benchmarks/scicode/tests/test_prepare.py` | correct split, exact IDs and output path |
+| deterministic/atomic output | `benchmarks/legal_agent_bench/tests/test_prepare.py` | stable bytes, count, failure preserves output |
+| source drift | `benchmarks/finance_agent_v2/tests/test_prepare.py` | rubric/modifier/tool mapping fails loudly |
+| prompt modes | `benchmarks/hle/prepare.py`, `nemo_gym/prompt.py` tests | raw vs materialized exclusivity |
+| config resolution | `benchmarks/legal_agent_bench/tests/test_prepare.py` | isolated instances, agent routing, paths |
+| reward and metrics | resources-server `tests/test_app.py` files | verdicts plus aggregation semantics |
+| external operation | `benchmarks/osworld/tests/` | backend selection, sharding, scripts, cleanup |
 
-Then in `model_post_init()`, replace the library's internal client:
-```python
-def model_post_init(self, context):
-    self._external_client = ExternalLibraryClient(api_key=key)
-    self._external_client._http_client = AIOHTTPAdapter.from_httpx_client(
-        self._external_client._http_client
-    )
-```
-
----
-
-## Reward Profiling Best Practices
-
-### Model selection
-
-Recommended model suite (as of Feb 2026):
-- Your policy model of interest
-- GPT-5 Nano, GPT-5 (closed-source baseline)
-- Qwen 3 30B A3B Instruct 2507 (open-source instruct)
-- Qwen 3 30B A3B Thinking 2507 (open-source thinking)
-- If 30B models are too weak: Qwen 3 235B A22B variants, Kimi K2 Instruct, or GLM-4.7
-
-### Validation checks
-
-- Open-source models should achieve 30%+ on your benchmark. If not, investigate bugs.
-- Closed-source models should score at or above open-source models. The reverse is rare and usually indicates a bug.
-- Run both instruct and thinking models — the benchmark should be model-agnostic.
-- Inspect actual failure cases in the rollout JSONL, not just aggregate numbers.
-
-### Variance control
-
-Run the highest-scoring open-source model multiple times. Increase `num_repeats` until variance < 1%.
-
-### Training environments
-
-If adding a training environment (not just a benchmark), additionally run training with NeMo RL:
-- GRPO algorithm, 64 prompts per step, 16 rollouts per prompt (adjustable)
-- Train with both instruct and thinking models
-- Include W&B links and train/validation curve screenshots in the PR
-
----
-
-## Token ID Propagation (Multi-Turn Training)
-
-During training, model responses include `prompt_token_ids`, `generation_token_ids`, and `generation_log_probs` on response messages. When constructing multi-turn input for the next model call, propagate these fields from the previous model response. This is required for RL training to work correctly.
+Unit tests must not depend on downloading the full benchmark. Preserve a tiny fixture
+with the same evaluation-critical structure, then run separate real-data and rollout
+checks before declaring the integration complete.

--- a/.agents/skills/add-benchmark/references/review-checklist.md
+++ b/.agents/skills/add-benchmark/references/review-checklist.md
@@ -1,0 +1,224 @@
+# Benchmark Review Checklist
+
+Use this checklist for benchmark, eval, verifier, agent, or preparation changes. Review
+the runtime contract first; style findings matter only after the evaluation is correct.
+
+## 1. Establish the Intended Evaluation
+
+- Identify the upstream benchmark version, split, task count, license, official prompt,
+  official evaluator, and headline metric.
+- State the evaluation unit: row, problem, subtask, test group, episode, or suite member.
+- Identify whether the change reuses a Gym verifier, changes a shared verifier, adds an
+  agent loop, or wraps an external harness.
+- List every generated artifact and every consumer of it.
+- If the PR claims parity, find the per-example comparison or reproduce it. A similar
+  aggregate alone is weak evidence.
+
+Build a contract ledger before reviewing implementation details:
+
+| Semantic value | Source field | Prepared field | Prompt/agent consumer | Verifier consumer | Metric consumer |
+| --- | --- | --- | --- | --- | --- |
+| task ID | | | | | |
+| question/input | | | | | |
+| reference/rubric | | | | | |
+| test/group selector | | | | | |
+| weight/max score | | | | | |
+
+Any blank scoring-relevant cell is a likely bug or missing test.
+
+## 2. Code and Repository Consistency
+
+### Scope and layout
+
+- The change uses an existing verifier/agent when semantics already match.
+- New components live in the expected top-level directory; benchmark-only data and
+  composition live under `benchmarks/`.
+- A single benchmark config locally declares exactly one `type: benchmark` dataset.
+  Multiple benchmark declarations are treated as an eval suite.
+- Instance names are isolated when a benchmark overrides shared verifier settings.
+- There are no unrelated generated files or drive-by changes.
+- New source files have the NVIDIA SPDX header and dependencies are license-compatible.
+
+### Imports and dependencies
+
+- `prepare.py` imports successfully as a repository-root module, the same way
+  `gym eval prepare` imports it.
+- Package-local imports are package-correct; they do not depend on running the script's
+  directory as `sys.path[0]`.
+- Dependencies used during preparation exist in the repository-root environment.
+  A package listed only in a resources server's isolated requirements is insufficient.
+- Optional heavy dependencies are lazy where appropriate, and missing optional packages
+  fail with a useful message.
+- Async HTTP follows `AGENTS.md`; external libraries do not silently introduce an
+  incompatible HTTP/concurrency path.
+
+### Generated artifacts
+
+- `prepare()` returns the exact configured `jsonl_fpath` as a `Path`.
+- Side artifacts such as metadata, test archives, databases, scripts, or graders are
+  written to the paths used by config.
+- Cross-repository outputs are resolvable through the downstream consumer's public
+  name, registry, or search path; their directory layout alone is not treated as proof.
+- `.gitignore` covers generated artifacts without hiding intentional fixtures.
+- Preparation is deterministic and does not publish partial output over a valid file.
+- Network failures, truncated sources, missing tables/columns, and upstream schema drift
+  fail loudly before output publication.
+
+## 3. Prompt and Template Contract
+
+Check exactly one mode:
+
+### Raw rows with `prompt_config`
+
+- Rows do not contain a non-empty `responses_create_params.input`.
+- Every prompt placeholder exists on every row and has the intended type/format.
+- Literal braces are escaped for `str.format_map`.
+- The template preserves the upstream problem statement, instructions, examples,
+  constraints, output format, and scoring explanation in their semantic order.
+- Text extraction from HTML/PDF/Markdown preserves references such as "above",
+  "below", labels, footnotes, formulas, tables, and captions.
+
+### Materialized requests with `prompt_config: null`
+
+- `responses_create_params.input` is a valid Responses-style input.
+- Tool schemas, image/audio blocks, system messages, and sampling fields match the
+  intended upstream contract.
+- The row is self-contained enough for the selected custom agent.
+- Prompt/tool snapshots have provenance and a drift guard when copied from upstream.
+
+For either mode, inspect rendered prompts from several structurally different tasks,
+not just the first row. Include the hardest cases: images, long tables, multiple code
+blocks, nested choices, or task-specific instructions.
+
+## 4. Data, Request, and Routing Contract
+
+- Prepared rows validate as JSON objects and contain stable unique identifiers.
+- The selected agent actually receives the intended dataset. If routing is ambiguous,
+  the dataset's `agent` pin names a valid connected agent.
+- `agent_ref`, when present, matches a configured agent instance.
+- Top-level fields and `verifier_metadata` match the selected request model exactly;
+  neither location is assumed universal.
+- Config paths resolve from a clean checkout and, for nested/flavored benchmarks, the
+  expected `--benchmark` token is discoverable.
+- Manifest-backed reuse targets a resources server that exports `VERIFIER_FIXTURE`;
+  config-only/materialized integrations do not add dummy manifest fields to look valid.
+- Runtime-only secrets/model settings do not block `gym eval prepare`.
+- Stateful downstream calls propagate cookies and isolate task/session state.
+- README commands use current CLI names and flags and work from a clean checkout.
+
+## 5. Selector, Reward, and Metric Contract
+
+This is the highest-risk area for grouped tests and partial credit.
+
+### Selectors and test membership
+
+- Every row selector exists in the verifier's canonical metadata, or an explicit tested
+  mapping translates it.
+- A selector runs the intended tests—not all tests, no tests, or another group's tests.
+- Overlapping test membership cannot award unrelated groups accidentally.
+- The evaluator only awards a group after all tests required by its aggregation rule
+  have run and passed.
+- Missing selectors and empty result sets fail closed with zero reward or a clear error.
+
+### Reward
+
+- The declared reward range matches actual responses.
+- Full, partial, and zero reward conditions are unambiguous.
+- A row cannot receive more than its declared maximum.
+- Malformed output, compile/runtime failure, timeout, judge failure, and tool failure
+  have intentional outcomes.
+- If reward is binary but official scoring is fractional, both mappings are documented
+  and tested.
+
+### Aggregate metrics
+
+- Task grouping uses stable IDs and repeat indices correctly.
+- Pass@k/majority/best-of logic uses the intended per-rollout score.
+- Subtask/rubric weights and caps match the official specification.
+- Duplicate or overlapping test outputs are deduplicated where required.
+- Missing and partial rollouts cannot inflate the aggregate.
+- Suite aggregation reports per-benchmark errors/completion before any combined score.
+
+Always test reward and aggregate metrics separately. A correct `verify()` does not prove
+that `compute_metrics()` groups or weights results correctly.
+
+## 6. Test Quality
+
+Expect tests at the boundaries the change touches:
+
+### Preparation tests
+
+- Import through the package path used by the CLI.
+- Replace downloads with fixtures; assert source repo/config/split/revision arguments.
+- Assert exact scoring-relevant row fields, not only count or file existence.
+- Cover multiple source shapes and an upstream schema-drift failure.
+- Assert deterministic output and exact returned path.
+- Assert a failed preparation leaves a prior output unchanged.
+
+### Config and prompt tests
+
+- Resolve the full config and assert agent/resources-server wiring and overridden paths.
+- Verify benchmark discovery name, dataset path, prepare path, prompt mode, and repeats.
+- Materialize representative rows and validate the resulting request.
+- For extracted statements, snapshot or semantically assert sections whose ordering
+  affects meaning.
+
+### Verifier and metric tests
+
+- Known-good and known-bad outputs.
+- Empty/malformed output, exception, timeout, and missing-dependency behavior.
+- Partial credit and boundary scores.
+- Unknown and synthetic selectors.
+- Overlapping groups/tests and deduplication.
+- Multiple problems, subtasks, and repeats in metric aggregation.
+
+### End-to-end evidence
+
+- A reference solution/output passes through the real grader path.
+- A deliberately wrong solution/output fails through the same path.
+- External integrations show per-example parity with a pinned upstream run.
+- Agent/environment changes include inspected real model rollouts, not only mocks.
+
+Reject vacuous tests that mock away the contract under review, assert only that a
+function was called, or duplicate implementation logic in the expected value.
+
+## 7. Validation Commands
+
+Adapt paths and names to the change:
+
+```bash
+python -m pytest benchmarks/<name>/tests -q
+python -m pytest resources_servers/<verifier>/tests -q
+
+gym list benchmarks <name>
+gym eval prepare --benchmark <name>
+gym env validate --benchmark <name>
+gym eval run --benchmark <name> --model-type <model_type>
+```
+
+For manifest-backed entries:
+
+```bash
+gym env validate <name> --kind benchmark
+gym env test <name> --kind benchmark
+gym env publish <name> --kind benchmark
+```
+
+Also run focused pre-commit checks and the relevant core tests. Run the real grader or
+rollout path only in an appropriate isolated environment; do not execute untrusted
+benchmark harnesses directly on a workstation.
+
+## 8. Reporting Findings
+
+Report actionable findings first. Each finding should include:
+
+- severity and concise title;
+- the tightest relevant file/line range;
+- the violated producer/consumer contract;
+- a concrete input or execution path that triggers it;
+- the resulting wrong reward, metric, prompt, or failure mode;
+- the missing test that would have caught it, when useful.
+
+Separate confirmed bugs from follow-up validation gaps. If no actionable bug is found,
+state what was checked and which real-data, external-service, or rollout paths remain
+unverified.


### PR DESCRIPTION
## Summary

- reframe `add-benchmark` around five integration topologies: shared verifier, custom verifier, custom Gym agent loop, external harness/driver, and eval suite
- align the workflow with current manifest-backed scaffolding, benchmark discovery, `gym eval prepare`, prompt materialization, request models, reward contracts, and metric aggregation
- replace the generic patterns reference with concrete examples from AIME/GPQA, WMT/FLORES, LiveCodeBench/IOI, HLE, Finance Agent v2, SciCode, Legal Agent Bench, OSWorld, EvalPlus, and the Nemotron eval suites
- add a review checklist for code consistency, prompt/template fidelity, producer-consumer contracts, grouped scoring, aggregate metrics, tests, and operational readiness

## Motivation

The previous skill treated most benchmark additions as new resources servers and described one universal JSONL shape. That does not match the repository's common benchmark-only integrations, raw-row `prompt_config` flow, materialized custom-agent rows, or manifest-backed onboarding. It also gave too little guidance for selectors, overlapping test groups, score caps, cross-repository discovery, and independent metric tests.

This update makes the runtime consumers the source of truth and explicitly asks authors/reviewers to trace each scoring-relevant field from preparation through prompt/agent routing, verification, and aggregation.

## Validation

- skill-creator `quick_validate.py` on `.agents/skills/add-benchmark` — passed
- `python -m pytest tests/unit_tests/test_environment_scaffold.py tests/unit_tests/test_benchmarks.py tests/unit_tests/test_prompt.py -q` — 122 passed
- verified documented CLI flags against `gym ... --help`
- `git diff --check`

No model rollouts were run because this PR changes only agent guidance and reference Markdown; it does not change an environment, agent, verifier, or dataset.
