### PR TITLE
[GDPVal] Refresh AA reference ELO anchors + advertise the real exec tool name in the prompt

### DIFF
--- a/resources_servers/gdpval/configs/gdpval_minimax_multistage_judge.yaml
+++ b/resources_servers/gdpval/configs/gdpval_minimax_multistage_judge.yaml
@@ -62,6 +62,15 @@ gdpval_resources_server:
       reward_mode: comparison
       # Reference models the anchored Bradley-Terry MLE ELO is fit against. The
       # multi-stage driver picks the `num_models` nearest anchors per stage.
+      #
+      # ANCHOR VINTAGE: Artificial Analysis GDPval-AA v2 live board, read
+      # 2026-09-09. Anchors are held FIXED in the fit, so a stale anchor shifts
+      # every candidate score by roughly the anchor error — the previous set was
+      # 30-76 points above the current board and inflated results accordingly.
+      # deepseek_v4_pro is the plain "DeepSeek V4 Pro (Reasoning, Max Effort)"
+      # row (1223), NOT "DeepSeek V4 Pro 0813" (1493): the deliverables in this
+      # reference set were collected 2026-07-04, before the 0813 release. Check
+      # the variant, not just the family name, when refreshing.
       # This is the ultra-v3 "9-ref no-gold" set (human_gold and gptoss_20b are
       # DELIBERATELY excluded — incomplete/missing deliverables inflate the fit).
       # Each deliverables_dir resolves to $GDPVAL_REFS_ROOT/<id>, defaulting to
@@ -84,31 +93,31 @@ gdpval_resources_server:
       reference_models:
         deepseek_v4_pro:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/deepseek_v4_pro
-          elo: 1299
+          elo: 1223
         glm51_fp8:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/glm51_fp8
-          elo: 1250
+          elo: 1181
         kimi_k26:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/kimi_k26
-          elo: 1191
+          elo: 1115
         nemotron3_ultra:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/nemotron3_ultra
-          elo: 1160
+          elo: 1091
         qwen36_35b:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/qwen36_35b
-          elo: 1045
+          elo: 992
         qwen35_397b:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/qwen35_397b
-          elo: 960
+          elo: 905
         gptoss_120b:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/gptoss_120b
-          elo: 795
+          elo: 745
         gemma4_26b:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/gemma4_26b
-          elo: 752
+          elo: 713
         qwen3_30b_thinking:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/qwen3_30b_thinking
-          elo: 267
+          elo: 274
       # Pairwise trials per (task x reference x repeat). 4 debiases position with
       # swap/no-swap; lower to 2 for a faster smoke test.
       num_comparison_trials: 4

--- a/responses_api_agents/stirrup_agent/prompts/gdpval_user_prompt.txt
+++ b/responses_api_agents/stirrup_agent/prompts/gdpval_user_prompt.txt
@@ -2,7 +2,7 @@ You are tasked with completing a specific assignment.
 
 ## Environment
 
-The `run_shell` tool provides access to a Linux-based execution environment that includes a full file system where you can create, read, and modify files.
+The `code_exec` tool provides access to a Linux-based execution environment that includes a full file system where you can create, read, and modify files.
 
 Your environment comes preinstalled with a comprehensive set of Python packages and system tools:
 

--- a/responses_api_agents/stirrup_agent/tests/test_gdpval_prompt_paths.py
+++ b/responses_api_agents/stirrup_agent/tests/test_gdpval_prompt_paths.py
@@ -41,3 +41,13 @@ def test_nested_reference_paths_keep_their_subdirectory(tmp_path):
 
 def test_no_reference_files_renders_none(tmp_path):
     assert "None" in _section(_build_gdpval_user_prompt("t", None))
+
+
+def test_prompt_advertises_the_registered_exec_tool_name():
+    # Stirrup registers the exec tool as `code_exec` (get_code_exec_tool default,
+    # which apptainer_provider does not override). Advertising `run_shell` named a
+    # tool the model was never given.
+    prompt = _build_gdpval_user_prompt("t", None)
+
+    assert "`code_exec` tool" in prompt
+    assert "run_shell" not in prompt


### PR DESCRIPTION
Two GDPVal correctness fixes, both surfaced while running the Super 3.5 / Qwen3.8 GDPVal campaign.

## 1. Prompt advertises a tool that is never registered

`gdpval_user_prompt.txt` told the model its shell was reached through a **`run_shell`** tool. No such tool is ever registered: `apptainer_provider.py:206` calls Stirrup's `get_code_exec_tool()` with no `name=` override, so the model actually receives **`code_exec`**. `run_shell` appears nowhere else in the agent path, and AA's own methodology documents the tool as `code_exec`.

Naming a nonexistent tool costs turns on models that trust the prompt over the schema, which biases the deliverable and therefore the pairwise ELO. The unused `user_prompt.j2` in this tree already had it right, which is likely how it went unnoticed.

One line, plus a regression test pinning the advertised name to the registered one.

## 2. Reference ELO anchors are stale

The anchored Bradley-Terry MLE holds reference ELOs **fixed** (`comparison.py::calculate_mle_elo`), so a stale anchor shifts every candidate score by roughly the anchor error. The committed set sits 30-76 points above the current AA GDPval-AA v2 board:

| reference | committed | current AA | Δ |
|---|---:|---:|---:|
| `deepseek_v4_pro` | 1299 | **1223** | −76 |
| `glm51_fp8` | 1250 | **1181** | −69 |
| `kimi_k26` | 1191 | **1115** | −76 |
| `nemotron3_ultra` | 1160 | **1091** | −69 |
| `qwen36_35b` | 1045 | **992** | −53 |
| `qwen35_397b` | 960 | **905** | −55 |
| `gptoss_120b` | 795 | **745** | −50 |
| `gemma4_26b` | 752 | **713** | −39 |
| `qwen3_30b_thinking` | 267 | **274** | +7 |

**Measured impact.** Refitting completed runs against these anchors (same battles, anchors only) moves stage-1 `eval_elo` down consistently:

| run | coverage | as-run | re-fit | Δ |
|---|---|---:|---:|---:|
| `470a5e324` (Super 3.5 `iter_12500`) | 220/220 | 1286.797 | **1214.609** | −72.2 |
| `c1bfcda585e501f1` (Super 3.5 text) | 218/220 | 1335.517 | 1258.327 | −77.2 |

The refit was done with a faithful port of `calculate_mle_elo`, validated by reproducing each run's own published `eval_elo` exactly from its rollouts before changing any anchor.

### The variant trap, worth naming

AA lists **several** DeepSeek V4 Pro rows: `0813 (Reasoning, Max Effort)` at 1493, plain `(Reasoning, Max Effort)` at **1223**, plain `(High Effort)` at 1219. This reference set's deliverables were collected **2026-07-04**, before the 0813 release, so 1223 is the correct match. Matching on family name alone produced a 270-point error before it was caught. The config now records the anchor vintage and this caveat inline.

### Not covered here

`glm51_fp8` is matched to AA's `GLM-5.1 (Reasoning)` row and the remaining refs to their obvious rows, but I have **not** verified quantization or effort-level variants for those the way I did for DeepSeek. If someone knows the FP8 build maps to a different row, that anchor should move too.

## Testing

- `gdpval_minimax_multistage_judge.yaml` parses; anchors updated by reference id (not by value) so no unrelated number could be rewritten.
- Prompt regression test asserts the advertised tool name matches the registered one.
- The shipped prompt test imports `ray` (a per-server extra absent from the base venv), so it was verified directly against the tree rather than executed under pytest — flagging that rather than claiming a green run.