### PR TITLE
fix(swebench-pro): bound verification attempts so one instance cannot hold a run open

### DIFF
--- a/resources_servers/swebench_pro/app.py
+++ b/resources_servers/swebench_pro/app.py
@@ -107,8 +107,11 @@ class SWEBenchProResourcesServerConfig(BaseResourcesServerConfig):
     inconclusive_verification_retries: int = 2
     # Ceiling on ONE verification attempt, covering sandbox creation as well as
     # the verification run. `evaluation_timeout` bounds only the test command
-    # inside the sandbox, so creation is otherwise unbounded here.
-    verification_attempt_timeout: float | None = 1800.0
+    # inside the sandbox, so creation is otherwise unbounded here. 1200s is
+    # ~2.6x the p99 of observed per-rollout verification (461s) and above the
+    # healthy maximum (735s), while still cutting the multi-attempt pile-ups
+    # that leave dozens of verifications in flight at a job's wall clock.
+    verification_attempt_timeout: float | None = 1200.0
     # Ceiling on ALL attempts for one rollout. Without it the worst case is
     # `1 + inconclusive_verification_retries` times the per-attempt ceiling,
     # which can exceed what remains of the job's wall clock -- and a rollout

--- a/resources_servers/swebench_pro/app.py
+++ b/resources_servers/swebench_pro/app.py
@@ -15,6 +15,7 @@
 
 """SWE-bench Pro resources server."""
 
+import asyncio
 import sys
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -74,6 +75,29 @@ HARNESS_ENV_TO_SCRUB = (
 )
 
 
+def _verification_deadline(total_timeout: float | None) -> float | None:
+    """Wall-clock instant by which all attempts for one rollout must be done."""
+    return None if total_timeout is None else time() + total_timeout
+
+
+def _budget_spent(deadline: float | None) -> bool:
+    return deadline is not None and time() >= deadline
+
+
+def _attempt_budget(attempt_timeout: float | None, deadline: float | None) -> float | None:
+    """The smaller of this attempt's ceiling and what is left of the rollout's budget.
+
+    ``asyncio.timeout(None)`` is a no-op, so both being unset preserves the old
+    unbounded behaviour for anyone who wants it back.
+    """
+    remaining = None if deadline is None else max(deadline - time(), 0.0)
+    if attempt_timeout is None:
+        return remaining
+    if remaining is None:
+        return attempt_timeout
+    return min(attempt_timeout, remaining)
+
+
 class SWEBenchProResourcesServerConfig(BaseResourcesServerConfig):
     is_verifying_golden_patch: bool = False
     apply_anti_cheating: bool = True
@@ -81,6 +105,19 @@ class SWEBenchProResourcesServerConfig(BaseResourcesServerConfig):
     evaluation_timeout: int | None = None
     # A verdict-less run is retried on a new sandbox; see `inconclusive_reason`.
     inconclusive_verification_retries: int = 2
+    # Ceiling on ONE verification attempt, covering sandbox creation as well as
+    # the verification run. `evaluation_timeout` bounds only the test command
+    # inside the sandbox, so creation is otherwise unbounded here.
+    verification_attempt_timeout: float | None = 1800.0
+    # Ceiling on ALL attempts for one rollout. Without it the worst case is
+    # `1 + inconclusive_verification_retries` times the per-attempt ceiling,
+    # which can exceed what remains of the job's wall clock -- and a rollout
+    # that never returns holds the whole run open, because collection ends only
+    # when the last rollout does.
+    verification_total_timeout: float | None = 2700.0
+    # Cleanup gets its own, smaller ceiling: a stop() that hangs in `finally`
+    # would defeat the attempt timeout it runs after.
+    verification_stop_timeout: float | None = 120.0
     # Which container repairs to apply; see `ENVIRONMENT_REPAIRS`.
     environment_repairs: tuple[str, ...] = DEFAULT_ENVIRONMENT_REPAIRS
     image_repository: str = "docker.io/jefzda/sweap-images"
@@ -348,20 +385,22 @@ class SWEBenchProResourcesServer(SimpleResourcesServer):
         eval_sandbox_start_time_taken = 0.0
         patch_verification_time_taken = 0.0
         attempts = 1 + max(self.config.inconclusive_verification_retries, 0)
+        deadline = _verification_deadline(self.config.verification_total_timeout)
         for attempt in range(1, attempts + 1):
             eval_sandbox: AsyncSandbox | None = None
             start_time = time()
             try:
-                eval_sandbox = await self._create_sandbox(body, files=sandbox_files)
-                eval_sandbox_start_time_taken = time() - start_time
-                verification_start = time()
-                result = await run_verification(
-                    sandbox=eval_sandbox,
-                    inputs=inputs,
-                    log_dir=run_log_dir,
-                    timeout_s=self.config.evaluation_timeout,
-                )
-                patch_verification_time_taken = time() - verification_start
+                async with asyncio.timeout(_attempt_budget(self.config.verification_attempt_timeout, deadline)):
+                    eval_sandbox = await self._create_sandbox(body, files=sandbox_files)
+                    eval_sandbox_start_time_taken = time() - start_time
+                    verification_start = time()
+                    result = await run_verification(
+                        sandbox=eval_sandbox,
+                        inputs=inputs,
+                        log_dir=run_log_dir,
+                        timeout_s=self.config.evaluation_timeout,
+                    )
+                    patch_verification_time_taken = time() - verification_start
             except Exception as exc:
                 eval_sandbox_start_time_taken = time() - start_time
                 patch_verification_time_taken = 0.0
@@ -375,11 +414,20 @@ class SWEBenchProResourcesServer(SimpleResourcesServer):
             finally:
                 if eval_sandbox is not None:
                     try:
-                        await eval_sandbox.stop()
+                        async with asyncio.timeout(self.config.verification_stop_timeout):
+                            await eval_sandbox.stop()
                     except Exception:
                         print("Failed to stop verification sandbox", format_exc(), file=sys.stderr)
 
             reason = inconclusive_reason(result, asdict(inputs))
+            if reason is not None and _budget_spent(deadline):
+                print(
+                    f"Verification for {body.instance_id} gave up after {attempt} attempt(s): "
+                    f"the {self.config.verification_total_timeout}s budget for this rollout is spent "
+                    f"({reason})",
+                    file=sys.stderr,
+                )
+                break
             if reason is None or attempt == attempts:
                 if reason is not None:
                     print(

--- a/resources_servers/swebench_pro/configs/swebench_pro.yaml
+++ b/resources_servers/swebench_pro/configs/swebench_pro.yaml
@@ -7,7 +7,13 @@ swebench_pro_resources_server:
       domain: coding
       verified: false
 
+      # Bounds only the test command inside the sandbox.
       evaluation_timeout: 3600
+      # Bound the surrounding work too: one attempt (creation + verification)
+      # and the whole retry sequence for a rollout. Healthy attempts finish far
+      # inside these, and a rollout that never returns holds the entire run open.
+      verification_attempt_timeout: 1800
+      verification_total_timeout: 2700
       image_repository: docker.io/jefzda/sweap-images
       apply_anti_cheating: true
       is_verifying_golden_patch: false

--- a/resources_servers/swebench_pro/configs/swebench_pro.yaml
+++ b/resources_servers/swebench_pro/configs/swebench_pro.yaml
@@ -12,7 +12,7 @@ swebench_pro_resources_server:
       # Bound the surrounding work too: one attempt (creation + verification)
       # and the whole retry sequence for a rollout. Healthy attempts finish far
       # inside these, and a rollout that never returns holds the entire run open.
-      verification_attempt_timeout: 1800
+      verification_attempt_timeout: 1200
       verification_total_timeout: 2700
       image_repository: docker.io/jefzda/sweap-images
       apply_anti_cheating: true

--- a/resources_servers/swebench_pro/tests/test_app.py
+++ b/resources_servers/swebench_pro/tests/test_app.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -27,6 +28,8 @@ from resources_servers.swebench_pro.app import (
     SWEBenchProResourcesServer,
     SWEBenchProResourcesServerConfig,
     SWEBenchProSeedSessionRequest,
+    _attempt_budget,
+    _budget_spent,
 )
 from resources_servers.swebench_pro.verification import VerificationResult
 
@@ -66,7 +69,12 @@ def fake_pty(session_id: str = "pty-session") -> SimpleNamespace:
     return SimpleNamespace(create=AsyncMock(return_value=session))
 
 
-def make_server(*, golden: bool, apply_anti_cheating: bool = True) -> SWEBenchProResourcesServer:
+def make_server(
+    *,
+    golden: bool,
+    apply_anti_cheating: bool = True,
+    **overrides: object,
+) -> SWEBenchProResourcesServer:
     config = SWEBenchProResourcesServerConfig(
         host="0.0.0.0",
         port=8080,
@@ -77,6 +85,7 @@ def make_server(*, golden: bool, apply_anti_cheating: bool = True) -> SWEBenchPr
         is_verifying_golden_patch=golden,
         apply_anti_cheating=apply_anti_cheating,
         prefetch_go_modules=True,
+        **overrides,
     )
     return SWEBenchProResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
 
@@ -374,3 +383,75 @@ async def test_shutdown_stops_abandoned_session_sandboxes() -> None:
     first.stop.assert_awaited_once()
     second.stop.assert_awaited_once()
     assert server._session_id_to_sandbox == {}
+
+
+def inconclusive_result() -> VerificationResult:
+    """A verdict-less run: `inconclusive_reason` reports "no usable output"."""
+    return VerificationResult(completed=True, resolved=False, patch_applied=True, test_results=None)
+
+
+def test_verify_bounds_an_attempt_that_never_returns(monkeypatch: MonkeyPatch) -> None:
+    """A hung attempt must fail the rollout, not hold the run open until the wall clock."""
+    server = make_server(golden=True, verification_attempt_timeout=0.05, inconclusive_verification_retries=0)
+
+    async def _hang(*args: object, **kwargs: object) -> None:
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(server, "_create_sandbox", _hang)
+
+    response = TestClient(server.setup_webserver()).post("/verify", json=request_body())
+
+    assert response.status_code == 200
+    assert response.json()["evaluation_completed"] is False
+    assert response.json()["reward"] == 0.0
+    assert "Verification failed" in response.json()["error"]
+
+
+def test_verify_stops_retrying_once_the_rollout_budget_is_spent(monkeypatch: MonkeyPatch) -> None:
+    """The retry sequence is bounded in aggregate, not just per attempt."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr("resources_servers.swebench_pro.app.time", lambda: clock["t"])
+    server = make_server(golden=True, verification_total_timeout=1500.0)
+    monkeypatch.setattr(server, "_create_sandbox", AsyncMock(return_value=SimpleNamespace(stop=AsyncMock())))
+
+    async def _verify(**kwargs: object) -> VerificationResult:
+        clock["t"] += 1000.0
+        return inconclusive_result()
+
+    verify = AsyncMock(side_effect=_verify)
+    monkeypatch.setattr("resources_servers.swebench_pro.app.run_verification", verify)
+
+    response = TestClient(server.setup_webserver()).post("/verify", json=request_body())
+
+    assert response.status_code == 200
+    # Budget is 1500s and each attempt burns 1000s: the second attempt still
+    # starts (500s left, which is what its own ceiling is clamped to) and the
+    # third never does.
+    assert verify.await_count == 2
+
+
+def test_verify_uses_every_attempt_when_no_budget_is_set(monkeypatch: MonkeyPatch) -> None:
+    """Leaving both ceilings unset preserves the previous unbounded behaviour."""
+    server = make_server(golden=True, verification_attempt_timeout=None, verification_total_timeout=None)
+    monkeypatch.setattr(server, "_create_sandbox", AsyncMock(return_value=SimpleNamespace(stop=AsyncMock())))
+    verify = AsyncMock(return_value=inconclusive_result())
+    monkeypatch.setattr("resources_servers.swebench_pro.app.run_verification", verify)
+
+    response = TestClient(server.setup_webserver()).post("/verify", json=request_body())
+
+    assert response.status_code == 200
+    assert verify.await_count == 3
+
+
+def test_attempt_budget_takes_the_smaller_of_the_two_ceilings(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("resources_servers.swebench_pro.app.time", lambda: 100.0)
+    assert _attempt_budget(None, None) is None
+    assert _attempt_budget(30.0, None) == 30.0
+    assert _attempt_budget(None, 150.0) == 50.0
+    assert _attempt_budget(30.0, 150.0) == 30.0
+    assert _attempt_budget(80.0, 150.0) == 50.0
+    # A spent budget yields zero rather than a negative timeout.
+    assert _attempt_budget(30.0, 90.0) == 0.0
+    assert _budget_spent(None) is False
+    assert _budget_spent(90.0) is True
+    assert _budget_spent(150.0) is False


### PR DESCRIPTION
## What is wrong

`swebench_pro` retries an inconclusive verification on a fresh sandbox
(`inconclusive_verification_retries`, default 2 → 3 attempts at `app.py:350`). The one timeout that
exists does not cover most of an attempt, and **nothing bounds the attempts in aggregate**:

- `evaluation_timeout` (shipped as `3600`) is passed to `run_verification(timeout_s=...)`, so it
  bounds **only the test command inside the sandbox**.
- `self._create_sandbox(...)` is not covered by it.
- `eval_sandbox.stop()` in the `finally` block is not covered by it.
- 3 × 3600 s is therefore a legal budget for one rollout — more than what remains of a 4 h job.

Because rollout collection ends only when the last rollout does, one instance can hold an entire run
open. Every other rollout can be finished and every GPU idle, and the job still runs to its wall
clock and is killed.

## Evidence

A 2193-rollout SWE-bench Pro run on 20 nodes, killed at a 4 h wall with 2192 rollouts complete.
2185 of 2193 were done at 2.22 h; the 2192nd landed at 2.93 h; the last one never did. From ~2:03
elapsed the serving cluster was idle — decode reporting `Running: 3-7 reqs`.

The one unrecorded rollout had finished its agent phase at +0.94 h. Reconstructed from the on-disk
verification artifacts (`logs/run_evaluation/<session>/<instance>/` mtimes):

| event | duration |
|---|---|
| verification attempt 1 | **3630 s** |
| verification attempt 2 | **3641 s** |
| attempt 3 | started, ~53 min elapsed when Slurm killed the job |

Both completed attempts ran to the full `evaluation_timeout` and **returned**; the third was inside
its budget when the wall hit. The rollout consumed **2 h 55 m** of verification and was on track for
~3 h 01 m. Nothing hung — the budget is simply larger than the job.

For scale, per-rollout verification totals derived from the same artifacts are **p50 66 s, p99 461 s**,
and the healthy maximum is 735 s. (`patch_verification_time_taken` in the rollout record is
last-attempt-only — `app.py` overwrites it each attempt and zeroes it on exception — so it reports
66/431/735 and is structurally unable to show this failure.)

The instance is **not** systematically bad: across four runs it has 13 verification sessions, and 12
of them took **115–644 s**. The trigger was this rollout's own patch — it changes a hook's return
signature across 9 files, the patch applied cleanly, and the jest run started and never terminated.
A model patch that hangs a test suite is normal and expected. Spending three hours on it is not.
That is also why quarantining the instance is not the fix.

## What this changes

- `verification_attempt_timeout` (default 1200 s) bounds one attempt, sandbox creation included.
  That is ~2.6× the observed p99 of 461 s and above the healthy max of 735 s.
- `verification_total_timeout` (default 2700 s) bounds all attempts for one rollout — the
  load-bearing cap. Each attempt's ceiling is clamped to whatever is left of it.
- `verification_stop_timeout` (default 120 s) bounds the teardown in `finally`, which would
  otherwise defeat the attempt timeout it runs after.
- A timed-out attempt takes the existing failure path, so the rollout is scored and recorded.
- Setting the ceilings to `null` restores the previous behaviour exactly.

Tests cover a hung attempt, the aggregate budget cutting the retry sequence short, the unset-ceiling
path still using all three attempts, and the clamping arithmetic.
`resources_servers/swebench_pro/tests/` is green (48 passed).

## Independent confirmation: a replay of the shipped certificate fails the same way

The configuration behind this benchmark's published certificate was re-run unchanged — same
container, same Gym pin, same 4P/6D shape on 10 nodes, composed from the published release tag. The
original run of that configuration completed in 3:47:35. The replay **TIMED OUT at 04:00:17 with
2192 of 2193 rollouts**.

The single missing rollout was in verification. Its instance has a `Retrying verification ... on a
new sandbox` line in the resources-server log with no successor — no "still inconclusive after 3
attempt(s)", no completion — and the log stopped writing 22 minutes before the wall.

That is the same signature as the 20-node run described above, five days apart and at a different
node count. Two independent runs now end one rollout short with that rollout inside the retry
budget. It also rules out the alternative explanation we were carrying, that a recent serving-stack
change had caused a throughput regression: the pre-change configuration does not reliably finish
either. Aggregate throughput is not what decides these runs; the verification tail is.

## Scope: this does not fix every SWE-bench Pro timeout

Across four TIMEOUT runs of this benchmark, **86 of 89 unrecorded rollouts were sitting in
verification** and 3 were still in the agent — so verification dominates. But the proximate causes
differ, and only one of the four is the defect fixed here:

- **20-node run:** one rollout, 2 h 55 m of verification. Without it the job finishes with 59 minutes
  to spare. Fully attributable.
- **Two 10-node runs:** missed the wall by 4.0 and 4.2 minutes with 4 and 3 rollouts outstanding.
  Fixing verification perfectly still leaves them short. These are makespan misses.
- **A fourth run:** 81 rollouts short, with **56 verification attempts in flight and incomplete** at
  the wall, ages 768–1950 s against a p50 of 60 s — all *within* their 3600 s budget. That looks like
  verification-tier contention, not one unbounded rollout. The 1200 s per-attempt default would have
  cut 55 of those 56; the aggregate cap alone would have cut none.

## For the benchmark PIC — a separate scoring question

On one run, **558 of 2189 rollouts (25.5%)** across **225 of 731 instances** exhausted all three
attempts and were still inconclusive (360 "N of M graded tests never reported an outcome", 198
"parser reported no tests at all"), and are scored 0.

These look correct rather than buggy: `test_stderr.log` shows the graded suites failing to *compile*
against the model's patch (`unknown field clientFunc`, `not enough arguments in call to sess.dial`,
`Cannot find module ...`, `[build failed]`), 67 of the 225 affected instances have at least one
conclusive rollout elsewhere in the same job and 61 have a reward-1.0 rollout, and retries recover
only **4 of 562 (0.7%)** — deterministic, not flaky infrastructure.

So this is a scoring-policy question, not a verifier bug: should a rollout whose patch prevents the
graded suite from reporting be scored 0, or excluded and reported as a coverage number? Worth a
decision either way, since it moves a quarter of the sample.

