### PR TITLE
fix(responses): preserve refusal conversion semantics

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -804,6 +804,7 @@ def accumulate_response_usage(
 class NeMoGymResponse(Response):
     output: List[NeMoGymResponseOutputItem]
     usage: Optional[NeMoGymResponseUsage] = None
+    native_finish_reason: Optional[str] = Field(default=None, exclude_if=lambda value: value is None)
 
 
 ########################################
@@ -849,6 +850,7 @@ NeMoGymChatCompletionOutputMessage: TypeAlias = Annotated[
 
 class NeMoGymChoice(Choice):
     message: NeMoGymChatCompletionOutputMessage
+    native_finish_reason: Optional[str] = Field(default=None, exclude_if=lambda value: value is None)
 
 
 class NeMoGymChatCompletion(ChatCompletion):

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -96,14 +96,19 @@ class ResponsesConverterState(BaseModel):
     messages: List[NeMoGymChatCompletionMessageParam] = Field(default_factory=list)
 
     content_buffer: str = ""
-    refusal_buffer: str = ""
+    refusal_buffer: Optional[str] = None
     tool_calls_buffer: List[NeMoGymChatCompletionMessageToolCallParam] = Field(default_factory=list)
     assistant_item_buffered: bool = False
 
     token_information: Optional[TokenIDLogProbMixin] = None
 
     def flush_assistant(self) -> None:
-        if not (self.assistant_item_buffered or self.content_buffer or self.refusal_buffer or self.tool_calls_buffer):
+        if not (
+            self.assistant_item_buffered
+            or self.content_buffer
+            or self.refusal_buffer is not None
+            or self.tool_calls_buffer
+        ):
             self.token_information = None
             return
 
@@ -114,7 +119,7 @@ class ResponsesConverterState(BaseModel):
         # Omit rather than send `tool_calls: []` — OpenAI rejects empty arrays.
         if self.tool_calls_buffer:
             shared_params["tool_calls"] = self.tool_calls_buffer
-        if self.refusal_buffer:
+        if self.refusal_buffer is not None:
             shared_params["refusal"] = self.refusal_buffer
 
         if self.return_token_id_information and self.token_information is not None:
@@ -128,7 +133,7 @@ class ResponsesConverterState(BaseModel):
         self.messages.append(message)
 
         self.content_buffer = ""
-        self.refusal_buffer = ""
+        self.refusal_buffer = None
         self.tool_calls_buffer = []
         self.assistant_item_buffered = False
         self.token_information = None
@@ -426,15 +431,35 @@ class ResponsesConverter(BaseModel):
                     for part in content:
                         text = part.get("text")
                         refusal = part.get("refusal")
+                        if isinstance(text, str) and isinstance(refusal, str):
+                            raise NotImplementedError(
+                                f"Assistant content part cannot contain both text and refusal: {part!r}"
+                            )
                         if isinstance(text, str):
+                            if refusal_parts or state.refusal_buffer is not None:
+                                raise NotImplementedError(
+                                    "Responses assistant content with text after a refusal has no lossless "
+                                    "Chat Completions representation."
+                                )
                             text_parts.append(text)
                         if isinstance(refusal, str):
+                            if refusal_parts or state.refusal_buffer is not None:
+                                raise NotImplementedError(
+                                    "Responses assistant content with multiple refusal parts has no lossless "
+                                    "Chat Completions representation."
+                                )
                             refusal_parts.append(refusal)
                         if not isinstance(text, str) and not isinstance(refusal, str):
                             raise NotImplementedError(f"Unsupported assistant content part: {part!r}")
                     final_content += "".join(text_parts)
-                    state.refusal_buffer += "".join(refusal_parts)
+                    if refusal_parts:
+                        state.refusal_buffer = refusal_parts[0]
                 elif isinstance(content, str):
+                    if content and state.refusal_buffer is not None:
+                        raise NotImplementedError(
+                            "Responses assistant content with text after a refusal has no lossless "
+                            "Chat Completions representation."
+                        )
                     final_content += content
                 else:
                     raise NotImplementedError(
@@ -663,7 +688,8 @@ class ResponsesConverter(BaseModel):
         response_output = []
 
         content = message_dict.get("content") or ""
-        refusal = message_dict.get("refusal") or ""
+        refusal = message_dict.get("refusal")
+        has_refusal = refusal is not None
         if self.uses_reasoning_parser:
             reasoning_matches, content = self._extract_reasoning_from_content(content)
         else:
@@ -680,9 +706,9 @@ class ResponsesConverter(BaseModel):
             response_output.append(reasoning_item)
 
         tool_calls_raw = message_dict.get("tool_calls", []) or []
-        has_empty_output = not (response_output or tool_calls_raw or refusal)
+        has_empty_output = not (response_output or tool_calls_raw or has_refusal)
 
-        if content or refusal or has_empty_output:
+        if content or has_refusal or has_empty_output:
             message_content = []
             if content or has_empty_output:
                 message_content.append(
@@ -692,11 +718,11 @@ class ResponsesConverter(BaseModel):
                         annotations=[],
                     )
                 )
-            if refusal:
+            if has_refusal:
                 message_content.append(
                     NeMoGymResponseOutputRefusal(
                         type="refusal",
-                        refusal=str(refusal),
+                        refusal=refusal,
                     )
                 )
             response_output.append(
@@ -809,11 +835,6 @@ class ResponsesConverter(BaseModel):
         elif choice.finish_reason == "content_filter":
             incomplete_details = {"reason": "content_filter"}
 
-        native_finish_reason = getattr(choice, "native_finish_reason", None)
-        provider_metadata = (
-            {"native_finish_reason": str(native_finish_reason)} if native_finish_reason is not None else {}
-        )
-
         # Chat Completion -> Response
         return NeMoGymResponse(
             # Under external token capture the chat completion's envelope id is
@@ -851,7 +872,7 @@ class ResponsesConverter(BaseModel):
             status="incomplete" if incomplete_details is not None else "completed",
             incomplete_details=incomplete_details,
             usage=usage,
-            **provider_metadata,
+            native_finish_reason=choice.native_finish_reason,
         )
 
 

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -1433,6 +1433,7 @@ def test_response_field_set_is_pinned() -> None:
         "metadata",
         "model",
         "moderation",
+        "native_finish_reason",
         "object",
         "output",
         "parallel_tool_calls",

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -457,6 +457,79 @@ def test_responses_to_chat_completion_preserves_assistant_refusal(converter: Res
     assert params.messages[0]["refusal"] == "I cannot answer."
 
 
+def test_responses_to_chat_completion_preserves_empty_assistant_refusal(converter: ResponsesConverter):
+    params = converter.responses_to_chat_completion_create_params(
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                NeMoGymResponseOutputMessage(
+                    id="msg_refusal",
+                    role="assistant",
+                    status="completed",
+                    content=[NeMoGymResponseOutputRefusal(refusal="")],
+                ),
+            ]
+        )
+    )
+
+    assert params.messages[0]["content"] is None
+    assert params.messages[0]["refusal"] == ""
+
+
+def test_responses_to_chat_completion_rejects_text_after_refusal(converter: ResponsesConverter):
+    with pytest.raises(NotImplementedError, match="text after a refusal"):
+        converter.responses_to_chat_completion_create_params(
+            NeMoGymResponseCreateParamsNonStreaming(
+                input=[
+                    NeMoGymResponseOutputMessage(
+                        id="msg_refusal",
+                        role="assistant",
+                        status="completed",
+                        content=[
+                            NeMoGymResponseOutputRefusal(refusal="I cannot answer."),
+                            NeMoGymResponseOutputText(text="Additional text.", annotations=[]),
+                        ],
+                    ),
+                ]
+            )
+        )
+
+
+def test_responses_to_chat_completion_rejects_part_with_text_and_refusal(converter: ResponsesConverter):
+    with pytest.raises(NotImplementedError, match="cannot contain both text and refusal"):
+        converter._format_message(
+            {
+                "role": "assistant",
+                "content": [{"type": "refusal", "text": "answer", "refusal": "I cannot answer."}],
+            },
+            ResponsesConverterState(return_token_id_information=False),
+        )
+
+
+def test_responses_to_chat_completion_rejects_multiple_refusals(converter: ResponsesConverter):
+    with pytest.raises(NotImplementedError, match="multiple refusal parts"):
+        converter._format_message(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "refusal", "refusal": "First refusal."},
+                    {"type": "refusal", "refusal": "Second refusal."},
+                ],
+            },
+            ResponsesConverterState(return_token_id_information=False),
+        )
+
+
+def test_responses_to_chat_completion_rejects_text_message_after_refusal(converter: ResponsesConverter):
+    state = ResponsesConverterState(return_token_id_information=False)
+    converter._format_message(
+        {"role": "assistant", "content": [{"type": "refusal", "refusal": "I cannot answer."}]},
+        state,
+    )
+
+    with pytest.raises(NotImplementedError, match="text after a refusal"):
+        converter._format_message({"role": "assistant", "content": "Additional text."}, state)
+
+
 def test_responses_to_chat_completion_function_call_and_output(converter: ResponsesConverter):
     params = converter.responses_to_chat_completion_create_params(
         NeMoGymResponseCreateParamsNonStreaming(
@@ -1164,6 +1237,14 @@ def test_postprocess_refusal_preserves_provider_signal(converter: ResponsesConve
     assert output[0].content == [NeMoGymResponseOutputRefusal(refusal="Policy refusal.")]
 
 
+def test_postprocess_empty_refusal_preserves_provider_signal(converter: ResponsesConverter):
+    output = converter.postprocess_assistant_message_dict({"role": "assistant", "content": None, "refusal": ""})
+
+    assert len(output) == 1
+    assert isinstance(output[0], NeMoGymResponseOutputMessage)
+    assert output[0].content == [NeMoGymResponseOutputRefusal(refusal="")]
+
+
 def test_postprocess_preserves_text_alongside_provider_refusal(converter: ResponsesConverter):
     output = converter.postprocess_assistant_message_dict(
         {"role": "assistant", "content": "Partial answer.", "refusal": "Policy refusal."}
@@ -1354,6 +1435,7 @@ def test_chat_completion_to_response_sanity(converter: ResponsesConverter, finis
     )
 
     assert expected_response == actual_response
+    assert "native_finish_reason" not in actual_response.model_dump(mode="json")
 
 
 @pytest.mark.parametrize(
@@ -1437,6 +1519,9 @@ def test_chat_completion_to_response_preserves_native_finish_reason(converter: R
     )
 
     assert response.native_finish_reason == "refusal"
+    assert response.model_dump(mode="json")["native_finish_reason"] == "refusal"
+    assert "native_finish_reason" in NeMoGymChoice.model_json_schema()["properties"]
+    assert "native_finish_reason" in NeMoGymResponse.model_json_schema()["properties"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Follow-up to #3165 that closes the remaining refusal-conversion gaps.

- Preserve an explicitly present empty refusal instead of converting it into empty text.
- Reject Responses histories whose refusal/text ordering or multiple refusal parts cannot be represented losslessly by Chat Completions.
- Declare `native_finish_reason` on Gym’s Chat Completion choice and Response models while omitting it from serialized output when absent.

@MahanFathi 