### PR TITLE
design: Prototype shared sandbox runtime abstraction

### DIFF
--- a/fern/versions/latest/pages/agent-server/runtime.mdx
+++ b/fern/versions/latest/pages/agent-server/runtime.mdx
@@ -1,0 +1,167 @@
+---
+title: "Agent Runtime Placement"
+description: "Run an agent harness process inside a per-task sandbox using shared base-class configuration."
+position: 8
+---
+
+# Agent Runtime Placement
+
+<Note>
+This is a proof of concept. The runtime configuration is inherited from
+`BaseResponsesAPIAgentConfig`; the launcher integration is provided by
+`SimpleResponsesAPIAgent`. Local placement remains the default.
+</Note>
+
+Runtime placement runs the harness's Python process and its child processes in
+the task sandbox. The harness can use normal filesystem access and subprocesses.
+It does not need separate local and sandbox execution branches.
+
+## Use an environment's task sandbox
+
+For SWE-bench, compose
+`responses_api_agents/opencode_agent/configs/opencode_swebench.yaml` with the
+SWE-bench resources config, a model config, and a connect-capable provider such as
+OpenSandbox. The agent's relevant configuration is:
+
+```yaml
+runtime:
+  type: sandbox
+  sandbox_source: environment
+  dependencies:
+    enabled: true
+    python_version: 3.13.14
+  timeout_s: 10800
+  concurrency: 8
+  agent_config:
+    repo_dir: /testbed
+    workspace_root: /tmp/opencode-workspaces
+```
+
+Dependency installation is enabled by default. Gym snapshots the current checkout's
+core code and selected harness, including uncommitted changes, uploads the snapshot,
+and creates a sandbox-local virtual environment with Python 3.13.14. It installs Gym
+and the harness's `requirements.txt` (including `overrides.txt` when present) or its
+`pyproject.toml`. The task's existing Python environment is left intact. OpenCode's
+normal startup then installs its CLI if it is missing.
+
+The sandbox needs a POSIX shell, `curl`, `tar`, and outbound access to the Python,
+uv, package, and harness distribution endpoints. Gym uses an existing `uv` binary
+or bootstraps version 0.12.3 without modifying shell profiles. Python, dependency
+caches, and source files live in the per-task worker directory outside the task
+repository. Each new runtime gets a fresh installation; this proof of concept does
+not cache installed environments across tasks.
+
+The host needs a Git checkout. Set `runtime.dependencies.source_root` when it is
+not the checkout containing the running Gym module. Custom harness layouts also
+set `runtime.dependencies.harness_path`, relative to that checkout. Only Gym core
+and the selected harness are bundled; environments with additional local source
+dependencies should use a prepared image or provision those dependencies explicitly.
+Host virtual environments, ignored files, symlinks, task datasets, and verifier code
+are excluded. Python dependencies resolve from the declared manifests, not `uv.lock`.
+
+For a prepared image, disable installation and select its existing interpreter:
+
+```yaml
+runtime:
+  type: sandbox
+  dependencies:
+    enabled: false
+  python: /opt/nemo-gym/bin/python
+```
+
+`runtime.uploads` (local file to sandbox destination) and `runtime.setup_command`
+remain available for OS packages or custom provisioning and run before automatic
+Python installation. The setup timeout is controlled by `runtime.setup_timeout_s`.
+`runtime.env` supplies the worker and setup process environment.
+`runtime.agent_config` overrides harness settings only inside the sandbox; it
+cannot override runtime placement.
+
+The resources server selects the task image and provider. Agent runtime resource
+specs are therefore rejected with `sandbox_source: environment`.
+
+## Create an agent-owned runtime
+
+For an environment that does not provide a task sandbox, the runtime host can
+create one:
+
+```yaml
+runtime:
+  type: sandbox
+  sandbox_source: runtime
+  provider: sandbox
+  spec:
+    image: your-registry/gym-harness:your-version
+    workdir: /workspace
+    ttl_s: 1800
+    resources:
+      cpu: 2
+      memory_mib: 4096
+  dependencies:
+    enabled: true
+```
+
+`provider` resolves a named provider block in the merged Gym configuration.
+`spec` uses the fields of `SandboxSpec`. In this mode the host creates and stops
+the sandbox. It rejects a resources server that supplies a different workspace,
+because silently running the harness elsewhere would disconnect it from the task.
+
+## Execution lifecycle
+
+1. The server factory selects a generic runtime host before constructing the harness.
+2. `/run` calls the resources server's `/seed_session`.
+3. The host connects to the environment workspace or creates its own runtime.
+4. A per-task Python worker constructs the configured harness and invokes its
+   existing `/v1/responses` ASGI route, including the rollout capture prefix.
+5. The host retrieves the JSON response and calls `/verify` with the original
+   task metadata and session cookies.
+6. Cleanup runs after success, failure, or cancellation.
+
+The worker uses JSON files outside the task repository, so no inbound HTTP port
+is required. Model and resources-server endpoints must still be reachable from
+the sandbox. Override their root URLs when necessary:
+
+```yaml
+runtime:
+  type: sandbox
+  sandbox_source: environment
+  server_urls:
+    policy_model: http://gym-model.internal:8000
+```
+
+The worker receives the configured harness settings and referenced server routes.
+It does not receive the entire global configuration or the run's verifier metadata.
+
+## Resources-server integration
+
+The resources-server base provides a workspace registry and an idempotent
+`/cleanup_session` endpoint. After preparing a sandbox in `/seed_session`, publish it:
+
+```python
+workspace = await self.register_sandbox_workspace(request, sandbox, self.config.sandbox_provider)
+return BaseSeedSessionResponse(workspace=workspace)
+```
+
+During verification, `self.session_sandbox(request)` returns the original object.
+The resource server can extract a patch and evaluate it in a fresh sandbox, as
+SWE-bench does. The provider must support `serialize()` and `connect()` for this
+handoff. Workspace registration is process-local: seed, verify, and cleanup must
+reach the same resources-server process.
+
+## Compatibility limits
+
+- Gym's launcher uses `create_server()`. Programmatic callers must also use
+  `HarnessClass.create_server(config, server_client)` to enable placement;
+  constructing the class directly does not move the process.
+- The harness must be importable inside the runtime and able to execute through
+  `/responses` independently of its own `/run`. Custom `/run` setup and
+  postprocessing are not executed by the generic host.
+- The host preserves verifier response fields and OpenCode's existing observation
+  envelope. It does not reproduce arbitrary harness-specific `/run` return fields.
+- Sandbox mode requires `/run`; a direct `/responses` request to the outer host
+  has no task workspace and is rejected.
+- This implements agent placement and environment workspace ownership. It does
+  not relocate the resources-server process or add a separate generic verifier
+  runtime. SWE-bench continues to manage its fresh verification sandbox.
+- Provider-side command cancellation varies. Cleanup destroys an owned sandbox
+  or asks the environment to destroy its workspace; it does not promise to
+  preserve a cancelled worker's partial transcript.

--- a/nemo_gym/base_resources_server.py
+++ b/nemo_gym/base_resources_server.py
@@ -16,8 +16,8 @@ from abc import abstractmethod
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-from fastapi import FastAPI
-from pydantic import BaseModel, ConfigDict, Field
+from fastapi import FastAPI, Request
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 
 if TYPE_CHECKING:
@@ -33,7 +33,9 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.reward_profile import AggregateMetricsMixin, compute_aggregate_metrics
 from nemo_gym.rollout_correlation import RolloutContextMiddleware
-from nemo_gym.server_utils import BaseRunServerInstanceConfig, BaseServer, SimpleServer
+from nemo_gym.sandbox import AsyncSandbox
+from nemo_gym.sandbox.workspace import SandboxWorkspace
+from nemo_gym.server_utils import SESSION_ID_KEY, BaseRunServerInstanceConfig, BaseServer, SimpleServer
 from nemo_gym.telemetry.endpoints import traced_verify_endpoint
 
 
@@ -66,7 +68,7 @@ def normalize_tool_name(name: str, server_name: Optional[str] = None) -> str:
 
 
 # Tool names that would collide with the resources server's own endpoints if advertised over MCP.
-RESERVED_MCP_TOOL_NAMES = frozenset({"verify", "seed_session", "aggregate_metrics", "mcp"})
+RESERVED_MCP_TOOL_NAMES = frozenset({"verify", "seed_session", "cleanup_session", "aggregate_metrics", "mcp"})
 
 
 class ReverifyMode(str, Enum):
@@ -130,7 +132,7 @@ class BaseSeedSessionRequest(BaseModel):
 
 
 class BaseSeedSessionResponse(BaseModel):
-    pass
+    workspace: Optional[SandboxWorkspace] = Field(default=None, exclude_if=lambda value: value is None)
 
 
 class MCPServerMetadata(BaseModel):
@@ -144,6 +146,35 @@ class MCPServerMetadata(BaseModel):
 
 class SimpleResourcesServer(BaseResourcesServer, AggregateMetricsMixin, SimpleServer):
     config: BaseResourcesServerConfig
+    _session_sandboxes: dict[str, AsyncSandbox] = PrivateAttr(default_factory=dict)
+
+    async def register_sandbox_workspace(
+        self, request: Request, sandbox: AsyncSandbox, provider: str
+    ) -> SandboxWorkspace:
+        """Publish an environment-owned workspace for a runtime-placed agent."""
+        session_id = request.session[SESSION_ID_KEY]
+        if session_id in self._session_sandboxes:
+            if self._session_sandboxes[session_id] is not sandbox:
+                await sandbox.stop()
+            raise ValueError("Session already owns a sandbox workspace")
+        self._session_sandboxes[session_id] = sandbox
+        try:
+            return SandboxWorkspace(provider=provider, descriptor=await sandbox.serialize())
+        except BaseException:
+            await self.cleanup_session(request)
+            raise
+
+    def session_sandbox(self, request: Request) -> AsyncSandbox:
+        return self._session_sandboxes[request.session[SESSION_ID_KEY]]
+
+    async def cleanup_session(self, request: Request) -> BaseSeedSessionResponse:
+        """Idempotent cleanup; retain the handle if stopping fails so callers can retry."""
+        session_id = request.session[SESSION_ID_KEY]
+        sandbox = self._session_sandboxes.get(session_id)
+        if sandbox is not None:
+            await sandbox.stop()
+            self._session_sandboxes.pop(session_id, None)
+        return BaseSeedSessionResponse()
 
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
@@ -152,6 +183,7 @@ class SimpleResourcesServer(BaseResourcesServer, AggregateMetricsMixin, SimpleSe
         app.add_middleware(RolloutContextMiddleware)
 
         app.post("/seed_session")(self.seed_session)
+        app.post("/cleanup_session")(self.cleanup_session)
         # Wrapped outside judge_failsafe so the span covers the failsafe's own handling too.
         app.post("/verify")(
             traced_verify_endpoint(

--- a/nemo_gym/base_responses_api_agent.py
+++ b/nemo_gym/base_responses_api_agent.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 from warnings import warn
 
 from fastapi import Body, FastAPI, Request
+from pydantic import Field
 
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
@@ -38,6 +39,7 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.reward_profile import AggregateMetricsMixin, compute_aggregate_metrics
 from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body, rollout_context
+from nemo_gym.sandbox.agent_runtime_config import AgentRuntimeConfig
 from nemo_gym.server_utils import (
     BaseRunServerInstanceConfig,
     BaseServer,
@@ -50,6 +52,7 @@ from nemo_gym.telemetry.span_groups import GymSpanGroup
 
 
 class BaseResponsesAPIAgentConfig(BaseRunServerInstanceConfig):
+    runtime: AgentRuntimeConfig = Field(default_factory=AgentRuntimeConfig)
     skip_verification: bool = False
     skip_verification_reward: float = 0.0
     # Whether this agent's rollouts participate in training token capture.
@@ -66,6 +69,15 @@ class BaseResponsesAPIAgent(BaseServer):
 
 class SimpleResponsesAPIAgent(BaseResponsesAPIAgent, AggregateMetricsMixin, SimpleServer):
     config: BaseResponsesAPIAgentConfig
+
+    @classmethod
+    def create_server(cls, config, server_client):
+        """Choose process placement before executing harness initialization."""
+        if config.runtime.type == "sandbox":
+            from nemo_gym.sandbox.agent_runtime import SandboxedAgentHost
+
+            return SandboxedAgentHost(config=config, server_client=server_client, harness_class=cls)
+        return super().create_server(config, server_client)
 
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()

--- a/nemo_gym/sandbox/agent_dependencies.py
+++ b/nemo_gym/sandbox/agent_dependencies.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provision the current Gym checkout and one harness in a sandbox-local venv."""
+
+import asyncio
+import shlex
+import subprocess
+import tarfile
+from pathlib import Path
+
+from nemo_gym.sandbox import AsyncSandbox
+from nemo_gym.sandbox.agent_runtime_config import AgentRuntimeConfig
+
+
+def build_source_archive(runtime: AgentRuntimeConfig, harness: str, destination: Path) -> str:
+    """Snapshot selected source files, including edits, without copying the host environment."""
+    deps = runtime.dependencies
+    root = Path(deps.source_root).resolve() if deps.source_root else Path(__file__).resolve().parents[2]
+    if not (root / "pyproject.toml").is_file():
+        raise ValueError("Automatic dependencies need a Gym checkout: set runtime.dependencies.source_root")
+    module = harness.split(":", 1)[0]
+    if deps.harness_path:
+        harness_path = Path(deps.harness_path)
+    elif module.startswith("responses_api_agents."):
+        harness_path = Path(*module.split(".")[:2])
+    else:
+        raise ValueError("Custom harnesses must set runtime.dependencies.harness_path relative to source_root")
+    if harness_path.is_absolute() or ".." in harness_path.parts or not harness_path.parts:
+        raise ValueError("runtime.dependencies.harness_path must be a relative directory inside source_root")
+    harness_dir = root / harness_path
+    if not harness_dir.resolve().is_relative_to(root):
+        raise ValueError("Harness source must stay inside source_root")
+    manifests = [name for name in ("requirements.txt", "pyproject.toml") if (harness_dir / name).is_file()]
+    if len(manifests) != 1:
+        raise ValueError("Harness must declare exactly one of requirements.txt or pyproject.toml")
+    selectors = ["pyproject.toml", "README.md", "LICENSE", "MANIFEST.in", "nemo_gym", str(harness_path)]
+    for parent in harness_path.parents:
+        if parent != Path("."):
+            selectors.append(str(parent / "__init__.py"))
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", *selectors],
+        capture_output=True,
+        check=True,
+    )
+    excluded = {"tests", "data", "outputs", "results", "cache", "__pycache__", ".venv"}
+    with tarfile.open(destination, "w:gz") as archive:
+        for name in sorted(set(result.stdout.decode(errors="replace").split("\0")) - {""}):
+            path = Path(name)
+            if any(part in excluded or part.startswith(".") for part in path.parts):
+                continue
+            source = root / path
+            if source.is_symlink() or not source.is_file():
+                continue
+            archive.add(source, arcname=path.as_posix(), recursive=False)
+    return harness_path.as_posix()
+
+
+async def install_agent_dependencies(
+    sandbox: AsyncSandbox, runtime: AgentRuntimeConfig, harness: str, remote_dir: str, local_dir: Path
+) -> tuple[str, dict[str, str]]:
+    """Return the installed Python and worker environment without modifying task dependencies."""
+    archive = local_dir / "source.tar.gz"
+    harness_path = await asyncio.to_thread(build_source_archive, runtime, harness, archive)
+    await sandbox.upload(archive, f"{remote_dir}/source.tar.gz")
+    quote = shlex.quote
+    deps = runtime.dependencies
+    source = f"{remote_dir}/source"
+    venv = f"{remote_dir}/venv"
+    python = f"{venv}/bin/python"
+    env = runtime.env | {
+        "UV_CACHE_DIR": f"{remote_dir}/uv-cache",
+        "UV_PYTHON_INSTALL_DIR": f"{remote_dir}/python",
+        "UV_UNMANAGED_INSTALL": f"{remote_dir}/uv",
+    }
+    command = f"""set -eu
+if command -v uv >/dev/null 2>&1; then
+    uv_bin=$(command -v uv)
+else
+    curl -fLsS --retry 3 https://astral.sh/uv/{deps.uv_version}/install.sh -o {quote(remote_dir + "/uv-install.sh")}
+    sh {quote(remote_dir + "/uv-install.sh")}
+    uv_bin={quote(remote_dir + "/uv/uv")}
+fi
+mkdir -p {quote(source + "/cache")}
+tar -xzf {quote(remote_dir + "/source.tar.gz")} -C {quote(source)}
+"$uv_bin" venv --seed --python {quote(deps.python_version)} {quote(venv)}
+cd {quote(source + "/" + harness_path)}
+if [ -f requirements.txt ]; then
+    if [ -f overrides.txt ]; then
+        "$uv_bin" pip install --python {quote(python)} -e {quote(source)} -r requirements.txt --override overrides.txt
+    else
+        "$uv_bin" pip install --python {quote(python)} -e {quote(source)} -r requirements.txt
+    fi
+else
+    "$uv_bin" pip install --python {quote(python)} -e {quote(source)} -e .
+fi
+"""
+    result = await sandbox.exec(command, env=env, timeout_s=runtime.setup_timeout_s)
+    if result.error_type or result.return_code != 0:
+        raise RuntimeError(
+            f"Agent dependency installation failed (exit={result.return_code}, error={result.error_type}): "
+            f"{(result.stderr or '')[-2000:]}"
+        )
+    # Keep both task cwd and its Python environment intact; only the worker uses this venv.
+    return python, env

--- a/nemo_gym/sandbox/agent_runtime.py
+++ b/nemo_gym/sandbox/agent_runtime.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared host for running an unchanged harness process in a task sandbox."""
+
+import asyncio
+import json
+import logging
+import shlex
+import tempfile
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from fastapi import HTTPException, Request
+from pydantic import ConfigDict, PrivateAttr
+
+from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
+from nemo_gym.base_responses_api_agent import Body, SimpleResponsesAPIAgent
+from nemo_gym.global_config import get_first_server_config_dict
+from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.rollout_observability import AgentObservationBundle, SandboxObservation
+from nemo_gym.sandbox import AsyncSandbox, SandboxSpec, create_provider
+from nemo_gym.sandbox.agent_dependencies import install_agent_dependencies
+from nemo_gym.sandbox.config import resolve_provider_config
+from nemo_gym.sandbox.workspace import SandboxWorkspace
+from nemo_gym.server_utils import get_response_json, raise_for_status
+
+
+LOG = logging.getLogger(__name__)
+
+
+class RuntimeRunRequest(BaseRunRequest):
+    model_config = ConfigDict(extra="allow")
+
+
+class RuntimeVerifyResponse(BaseVerifyResponse):
+    model_config = ConfigDict(extra="allow")
+
+
+class SandboxedAgentHost(SimpleResponsesAPIAgent):
+    """Own seed/execute/verify/cleanup while the harness owns only /responses.
+
+    Constructed by SimpleResponsesAPIAgent.create_server(), never by a harness.
+    Dependencies are provisioned automatically unless explicitly disabled.
+    """
+
+    harness_class: type
+    _sem: asyncio.Semaphore = PrivateAttr()
+
+    def model_post_init(self, context: Any) -> None:
+        self._sem = asyncio.Semaphore(self.config.runtime.concurrency)
+
+    def _harness_import(self) -> str:
+        module = self.harness_class.__module__
+        if module == "__main__":
+            block = self.server_client.global_config_dict[self.config.name]["responses_api_agents"]
+            implementation = next(iter(block))
+            module = (
+                f"responses_api_agents.{implementation}.{self.config.entrypoint.removesuffix('.py').replace('/', '.')}"
+            )
+        return f"{module}:{self.harness_class.__name__}"
+
+    def _worker_payload(self, body: RuntimeRunRequest, cookies: dict) -> dict:
+        runtime = self.config.runtime
+        config = self.config.model_dump(mode="json") | runtime.agent_config
+        config["runtime"] = {"type": "local"}
+        config["token_id_capture"] = self._token_id_capture_enabled()
+        # Only route information crosses into the agent; never the verifier config,
+        # task answers, provider credentials, or the complete global configuration.
+        global_config = {
+            key: self.server_client.global_config_dict.get(key, False) for key in ("observability_enabled",)
+        }
+        global_config["token_id_capture"] = {
+            "enabled": self._token_id_capture_enabled(),
+            "all_agents": False,
+        }
+
+        def collect_refs(value):
+            if isinstance(value, dict):
+                if value.get("type") in {"responses_api_models", "resources_servers", "responses_api_agents"}:
+                    name = value["name"]
+                    source = get_first_server_config_dict(self.server_client.global_config_dict, name)
+                    route = {"host": source["host"], "port": source["port"]}
+                    if name in runtime.server_urls:
+                        route["runtime_base_url"] = runtime.server_urls[name].rstrip("/")
+                    global_config[name] = {value["type"]: {"route": route}}
+                else:
+                    for child in value.values():
+                        collect_refs(child)
+            elif isinstance(value, list):
+                for child in value:
+                    collect_refs(child)
+
+        collect_refs(config)
+        return {
+            "harness": self._harness_import(),
+            "config": config,
+            "global_config": global_config,
+            "body": body.responses_create_params.model_dump(mode="json"),
+            "path": self.url_path_for_run("/v1/responses", body),
+            "cookies": cookies,
+        }
+
+    async def _execute(self, sandbox: AsyncSandbox, body: RuntimeRunRequest, cookies: dict) -> dict:
+        runtime = self.config.runtime
+        for local_path, remote_path in runtime.uploads.items():
+            await sandbox.upload(local_path, remote_path)
+        if runtime.setup_command:
+            setup = await sandbox.exec(runtime.setup_command, env=runtime.env, timeout_s=runtime.setup_timeout_s)
+            if setup.error_type or setup.return_code != 0:
+                raise RuntimeError(f"Agent runtime setup failed (exit={setup.return_code}, error={setup.error_type})")
+        remote_dir = f"/tmp/nemo-gym-agent-{uuid4().hex}"
+        created = await sandbox.exec(f"mkdir -m 700 {shlex.quote(remote_dir)}", timeout_s=runtime.setup_timeout_s)
+        if created.error_type or created.return_code != 0:
+            raise RuntimeError("Failed to create agent worker directory")
+        with tempfile.TemporaryDirectory(prefix="nemo-gym-agent-") as temp:
+            python, worker_env = runtime.python, runtime.env
+            if runtime.dependencies.enabled:
+                python, worker_env = await install_agent_dependencies(
+                    sandbox, runtime, self._harness_import(), remote_dir, Path(temp)
+                )
+            payload_path = Path(temp) / "request.json"
+            payload_path.write_text(json.dumps(self._worker_payload(body, cookies)))
+            await sandbox.upload(payload_path, f"{remote_dir}/request.json")
+            await sandbox.upload(Path(__file__).with_name("agent_runtime_worker.py"), f"{remote_dir}/worker.py")
+            result = await sandbox.exec(
+                shlex.join(
+                    [
+                        python,
+                        f"{remote_dir}/worker.py",
+                        f"{remote_dir}/request.json",
+                        f"{remote_dir}/response.json",
+                    ]
+                ),
+                timeout_s=runtime.timeout_s,
+                env=worker_env,
+            )
+            if result.error_type or result.return_code != 0:
+                raise RuntimeError(
+                    f"Agent worker failed (exit={result.return_code}, error={result.error_type}): {(result.stderr or '')[-2000:]}"
+                )
+            output_path = Path(temp) / "response.json"
+            await sandbox.download(f"{remote_dir}/response.json", output_path)
+            return json.loads(output_path.read_text())
+
+    async def responses(
+        self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()
+    ) -> NeMoGymResponse:
+        raise HTTPException(status_code=400, detail="Sandbox placement requires /run to establish a task workspace")
+
+    async def run(self, request: Request, body: RuntimeRunRequest) -> RuntimeVerifyResponse:
+        async with self._sem:
+            resources = getattr(self.config, "resources_server", None)
+            if resources is None:
+                raise ValueError("Sandbox placement requires a resources_server reference")
+            runtime = self.config.runtime
+            cookies = dict(request.cookies)
+            sandbox = None
+            provider = None
+            environment_workspace = False
+            try:
+                seed = await self.server_client.post(
+                    server_name=resources.name,
+                    url_path="/seed_session",
+                    json=body.model_dump(),
+                    cookies=cookies,
+                )
+                await raise_for_status(seed)
+                cookies |= dict(seed.cookies)
+                seeded = await get_response_json(seed)
+                environment_workspace = bool(seeded.get("workspace"))
+                if runtime.sandbox_source == "environment":
+                    if not environment_workspace:
+                        raise ValueError("runtime.sandbox_source=environment requires a workspace from /seed_session")
+                    workspace = SandboxWorkspace.model_validate(seeded["workspace"])
+                    provider = create_provider(
+                        resolve_provider_config(workspace.provider, self.server_client.global_config_dict)
+                    )
+                    sandbox = await AsyncSandbox.connect(workspace.descriptor, provider=provider)
+                else:
+                    if environment_workspace:
+                        raise ValueError(
+                            "Environment supplied a task workspace; use runtime.sandbox_source=environment"
+                        )
+                    provider = create_provider(
+                        resolve_provider_config(runtime.provider, self.server_client.global_config_dict)
+                    )
+                    sandbox = await AsyncSandbox(provider).start(SandboxSpec(**runtime.spec))
+                output = await self._execute(sandbox, body, cookies)
+                cookies |= output.get("cookies", {})
+                raw_response = output["response"]
+                observations = raw_response.pop("_ng_agent_observations", None)
+                response = NeMoGymResponse.model_validate(raw_response)
+                if self.config.skip_verification:
+                    verified = body.model_dump() | {
+                        "response": response,
+                        "reward": self.config.skip_verification_reward,
+                    }
+                else:
+                    verification = await self.server_client.post(
+                        server_name=resources.name,
+                        url_path="/verify",
+                        json=body.model_dump() | {"response": response.model_dump(mode="json")},
+                        cookies=cookies,
+                    )
+                    await raise_for_status(verification)
+                    verified = await get_response_json(verification)
+                if observations is not None:
+                    bundle = AgentObservationBundle.model_validate(observations)
+                    # Host execution is sandboxed even when the inner harness uses subprocesses.
+                    bundle.gaps = [gap for gap in bundle.gaps if gap.code != "no_sandbox_runtime"]
+                    bundle.records.append(
+                        SandboxObservation(role="agent", provider=provider.name, outcome="completed")
+                    )
+                    verifier_observation = verified.pop("verifier_sandbox_observation", None)
+                    if verifier_observation is not None:
+                        bundle.records.append(SandboxObservation.model_validate(verifier_observation))
+                    verified["ng_agent_observations"] = bundle
+                return RuntimeVerifyResponse.model_validate(verified)
+            finally:
+                if environment_workspace:
+                    try:
+                        cleanup = await self.server_client.post(
+                            server_name=resources.name,
+                            url_path="/cleanup_session",
+                            json={},
+                            cookies=cookies,
+                        )
+                        await raise_for_status(cleanup)
+                    except Exception:
+                        LOG.exception("Failed to clean up environment workspace")
+                elif sandbox is not None:
+                    try:
+                        await sandbox.stop()
+                    except Exception:
+                        LOG.exception("Failed to stop agent runtime")
+                if provider is not None and (environment_workspace or sandbox is None):
+                    try:
+                        await provider.aclose()
+                    except Exception:
+                        LOG.exception("Failed to close agent runtime provider")

--- a/nemo_gym/sandbox/agent_runtime_config.py
+++ b/nemo_gym/sandbox/agent_runtime_config.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process placement configuration shared by Gym agent harnesses."""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class AgentDependenciesConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    python_version: str = Field(default="3.13.14", pattern=r"^\d+\.\d+\.\d+$")
+    uv_version: str = Field(default="0.12.3", pattern=r"^\d+\.\d+\.\d+$")
+    # Defaults to the checkout containing Gym. Installed distributions need an explicit checkout.
+    source_root: str | None = None
+    # Relative to source_root; inferred for built-in responses_api_agents modules.
+    harness_path: str | None = None
+
+
+class AgentRuntimeConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["local", "sandbox"] = "local"
+    sandbox_source: Literal["environment", "runtime"] = "environment"
+    provider: str = "sandbox"
+    spec: dict[str, Any] = Field(default_factory=dict)
+    python: str = "python3"
+    dependencies: AgentDependenciesConfig = Field(default_factory=AgentDependenciesConfig)
+    env: dict[str, str] = Field(default_factory=dict)
+    setup_command: str | None = None
+    setup_timeout_s: float = Field(default=900, gt=0)
+    timeout_s: float = Field(default=10800, gt=0)
+    concurrency: int = Field(default=8, gt=0)
+    # Local file -> absolute destination in the sandbox (e.g. a wheel or installer).
+    uploads: dict[str, str] = Field(default_factory=dict)
+    # Overrides applied only inside the sandbox, e.g. repository and command paths.
+    agent_config: dict[str, Any] = Field(default_factory=dict)
+    # Reachable root URLs of referenced Gym servers.
+    server_urls: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_placement(self):
+        if "runtime" in self.agent_config:
+            raise ValueError("runtime.agent_config cannot override runtime placement")
+        if self.sandbox_source == "environment" and self.spec:
+            raise ValueError("runtime.spec requires sandbox_source=runtime; the environment owns its task spec")
+        return self

--- a/nemo_gym/sandbox/agent_runtime_worker.py
+++ b/nemo_gym/sandbox/agent_runtime_worker.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One-task agent process. Invoked by the runtime host inside the task sandbox."""
+
+import asyncio
+import importlib
+import json
+import os
+import sys
+from http.cookies import SimpleCookie
+from pathlib import Path
+
+
+async def invoke(payload: dict) -> dict:
+    # Set before importing Gym or the harness: both may consult configuration at import time.
+    os.environ["NEMO_GYM_CONFIG_DICT"] = json.dumps(payload["global_config"])
+    for key in ("IS_NEMO_GYM_FASTAPI_WORKER", "IS_NEMO_GYM_FASTAPI_ENTRYPOINT", "NEMO_GYM_FASTAPI_NUM_WORKERS"):
+        os.environ.pop(key, None)
+    from omegaconf import OmegaConf
+
+    from nemo_gym.config_types import BaseServerConfig
+    from nemo_gym.server_utils import ServerClient
+
+    class RuntimeServerClient(ServerClient):
+        def _build_server_base_url(self, server_config_dict):
+            return server_config_dict.get("runtime_base_url") or super()._build_server_base_url(server_config_dict)
+
+    module_name, class_name = payload["harness"].split(":", 1)
+    cls = getattr(importlib.import_module(module_name), class_name)
+    config = cls.model_fields["config"].annotation.model_validate(payload["config"])
+    client = RuntimeServerClient(
+        head_server_config=BaseServerConfig(host="127.0.0.1", port=1),
+        global_config_dict=OmegaConf.create(payload["global_config"]),
+    )
+    agent = cls(config=config, server_client=client)
+    app = agent.setup_webserver()
+    content = json.dumps(payload["body"]).encode()
+    cookies = SimpleCookie()
+    for key, value in payload["cookies"].items():
+        cookies[key] = value
+    headers = [(b"content-type", b"application/json"), (b"cookie", cookies.output(header="", sep=";").encode())]
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": payload["path"],
+        "raw_path": payload["path"].encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers,
+        "server": ("localhost", 1),
+        "client": ("127.0.0.1", 1),
+    }
+    received = False
+    completed = asyncio.Event()
+    response_body = bytearray()
+    response_cookies = SimpleCookie()
+    status = None
+
+    async def receive():
+        nonlocal received
+        if not received:
+            received = True
+            return {"type": "http.request", "body": content, "more_body": False}
+        await completed.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        nonlocal status
+        if message["type"] == "http.response.start":
+            status = message["status"]
+            for key, value in message.get("headers", []):
+                if key.lower() == b"set-cookie":
+                    response_cookies.load(value.decode("latin-1"))
+        elif message["type"] == "http.response.body":
+            response_body.extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                completed.set()
+
+    async with app.router.lifespan_context(app):
+        await app(scope, receive, send)
+    if status != 200:
+        raise RuntimeError(f"Harness /responses returned HTTP {status}")
+    return {
+        "response": json.loads(response_body),
+        "cookies": {key: value.value for key, value in response_cookies.items()},
+    }
+
+
+if __name__ == "__main__":
+    payload = json.loads(Path(sys.argv[1]).read_text())
+    result = asyncio.run(invoke(payload))
+    Path(sys.argv[2]).write_text(json.dumps(result))

--- a/nemo_gym/sandbox/workspace.py
+++ b/nemo_gym/sandbox/workspace.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment-owned workspace handoff returned by /seed_session."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SandboxWorkspace(BaseModel):
+    """The environment owns cleanup; the agent borrows execution and file access.
+
+    ``provider`` references a provider block in the merged Gym configuration.
+    ``descriptor`` is produced by AsyncSandbox.serialize(), not a bare sandbox ID.
+    The environment must accept an idempotent POST to ``/cleanup_session`` using
+    the seed response's cookies, including when execution or verification fails.
+    """
+
+    provider: str = Field(min_length=1)
+    descriptor: dict[str, Any] = Field(min_length=1)

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -613,6 +613,11 @@ class BaseServer(BaseModel):
     config: BaseRunServerInstanceConfig
 
     @classmethod
+    def create_server(cls, config, server_client):
+        """Construct a server, allowing agent bases to select process placement."""
+        return cls(config=config, server_client=server_client)
+
+    @classmethod
     def load_config_from_global_config(cls) -> "BaseRunServerInstanceConfig":
         config_path_str = getenv(NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME)
         global_config_dict = get_global_config_dict()
@@ -1005,7 +1010,7 @@ repr(e): {repr(e)}"""
             head_server_config=ServerClient.load_head_server_config(),
             global_config_dict=global_config_dict,
         )
-        server = cls(config=server_config, server_client=server_client)
+        server = cls.create_server(server_config, server_client)
 
         if global_config_dict[DRY_RUN_KEY_NAME]:
             return

--- a/resources_servers/swebench/app.py
+++ b/resources_servers/swebench/app.py
@@ -241,11 +241,6 @@ class SWEBenchSeedSessionResponse(BaseSeedSessionResponse):
 class SwebenchResourcesServer(SimpleResourcesServer):
     config: SwebenchResourcesServerConfig
 
-    def model_post_init(self, context: Any, /) -> None:
-        super().model_post_init(context)
-
-        self._session_id_to_sandbox: Dict[str, AsyncSandbox] = dict()
-
     async def _create_sandbox(self, test_spec: TestSpec) -> AsyncSandbox:
         # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
         global_config_dict = get_global_config_dict()
@@ -298,7 +293,6 @@ class SwebenchResourcesServer(SimpleResourcesServer):
     async def seed_session(self, request: Request, body: SWEBenchSeedSessionRequest) -> SWEBenchSeedSessionResponse:
         test_spec = self._make_test_spec(body)
         eval_sandbox = await self._create_sandbox(test_spec)
-        self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox
 
         if self.config.apply_anti_cheating:
             # Remove the current Git repo's future history beyond the current commit to prevent the model from cheating.
@@ -315,7 +309,11 @@ Stdout:
 Stderr:
 {result.stderr}""")
 
-        return SWEBenchSeedSessionResponse(sandbox_handle=eval_sandbox._handle.sandbox_id)
+        workspace = await self.register_sandbox_workspace(request, eval_sandbox, self.config.sandbox_provider)
+        return SWEBenchSeedSessionResponse(
+            sandbox_handle=eval_sandbox._handle.sandbox_id,
+            workspace=workspace,
+        )
 
     async def verify(self, request: Request, body: SWEBenchVerifyRequest) -> SWEBenchVerifyResponse:
         """
@@ -349,7 +347,7 @@ Stderr:
         if self.config.is_verifying_golden_patch:
             model_patch = body.patch
         else:
-            original_sandbox = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
+            original_sandbox = self.session_sandbox(request)
             try:
                 original_workdir = (await eval_sandbox.exec("pwd")).stdout.strip()
                 model_patch_result = await original_sandbox.exec(f"cd {original_workdir} && git --no-pager diff")
@@ -357,7 +355,7 @@ Stderr:
             except:
                 print("Failed to extract patch from container", format_exc(), file=sys.stderr)
             try:
-                await original_sandbox.stop()
+                await self.cleanup_session(request)
             except:
                 print("Failed to stop original sandbox", format_exc(), file=sys.stderr)
 

--- a/resources_servers/swebench/configs/swebench.yaml
+++ b/resources_servers/swebench/configs/swebench.yaml
@@ -2,7 +2,7 @@
 swebench_resources_server:          # instance name — how agents/CLI refer to this server
   resources_servers:                              # server type: resources_servers | responses_api_agents | responses_api_models
     swebench:                        # implementation directory under resources_servers/
-      allowed_agents: [opencode_sandboxed_agent]
+      allowed_agents: [opencode_sandboxed_agent, opencode_agent]
       entrypoint: app.py                        # server entry module
       domain: other                             # task domain; one of: math, coding, agent, knowledge,
                                                 #   instruction_following, long_context, safety, games, translation,

--- a/resources_servers/swebench/tests/test_app.py
+++ b/resources_servers/swebench/tests/test_app.py
@@ -23,7 +23,7 @@ from pytest import MonkeyPatch
 
 from nemo_gym.sandbox import SandboxExecResult, SandboxHandle
 from nemo_gym.sandbox.utils import CPU_CAP_ENV_VARS
-from nemo_gym.server_utils import ServerClient
+from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 from resources_servers.swebench.app import (
     DockerContainer,
     SwebenchResourcesServer,
@@ -48,6 +48,55 @@ def make_sandbox(
 
 
 class TestApp:
+    async def test_seed_hands_off_complete_descriptor_and_cleanup_is_idempotent(self, monkeypatch):
+        config = SwebenchResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            sandbox_provider="task_runtime",
+            sandbox_config={},
+            apply_anti_cheating=False,
+        )
+        server = SwebenchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        sandbox = make_sandbox()
+        descriptor = {"sandbox_id": "sandbox-123", "workdir": "/testbed", "opaque": {"lease": "123"}}
+        sandbox.serialize = AsyncMock(return_value=descriptor)
+        monkeypatch.setattr(SwebenchResourcesServer, "_make_test_spec", MagicMock())
+        monkeypatch.setattr(SwebenchResourcesServer, "_create_sandbox", AsyncMock(return_value=sandbox))
+        request = MagicMock(session={SESSION_ID_KEY: "task-session"})
+
+        response = await server.seed_session(request, MagicMock())
+
+        assert response.sandbox_handle == "sandbox-123"
+        assert response.workspace.provider == "task_runtime"
+        assert response.workspace.descriptor == descriptor
+        sandbox.stop.assert_not_awaited()
+        await server.cleanup_session(request)
+        await server.cleanup_session(request)
+        sandbox.stop.assert_awaited_once()
+        assert server._session_sandboxes == {}
+
+    async def test_failed_workspace_serialization_cleans_up(self, monkeypatch):
+        config = SwebenchResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            sandbox_provider="task_runtime",
+            sandbox_config={},
+            apply_anti_cheating=False,
+        )
+        server = SwebenchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        sandbox = make_sandbox()
+        sandbox.serialize = AsyncMock(side_effect=RuntimeError("cannot serialize"))
+        monkeypatch.setattr(SwebenchResourcesServer, "_make_test_spec", MagicMock())
+        monkeypatch.setattr(SwebenchResourcesServer, "_create_sandbox", AsyncMock(return_value=sandbox))
+        with pytest.raises(RuntimeError, match="cannot serialize"):
+            await server.seed_session(MagicMock(session={SESSION_ID_KEY: "task-session"}), MagicMock())
+        sandbox.stop.assert_awaited_once()
+        assert server._session_sandboxes == {}
+
     def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
         config = SwebenchResourcesServerConfig(
             host="0.0.0.0",

--- a/responses_api_agents/opencode_agent/configs/opencode_swebench.yaml
+++ b/responses_api_agents/opencode_agent/configs/opencode_swebench.yaml
@@ -1,29 +1,37 @@
-# Legacy compatibility config. The unified runtime proof of concept is at
-# responses_api_agents/opencode_agent/configs/opencode_swebench.yaml.
-opencode_sandboxed_agent:
+# Proof of concept: the OpenCode harness borrows SWE-bench's prepared workspace.
+# Compose with resources_servers/swebench/configs/swebench.yaml, a model config,
+# and a connect-capable sandbox provider config (for example OpenSandbox).
+# Use runtime.type: local in the ordinary opencode_agent config for host execution.
+# Sandbox mode requires /run; direct /v1/responses has no environment workspace.
+opencode_agent:
   responses_api_agents:
-    opencode_sandboxed_agent:
+    opencode_agent:
       entrypoint: app.py
       num_workers: 4
       resources_server:
         type: resources_servers
-        name: ???
+        name: swebench_resources_server
       model_server:
         type: responses_api_models
         name: policy_model
       token_id_capture: true
-
-      debug: false
-
+      runtime:
+        type: sandbox
+        sandbox_source: environment
+        dependencies:
+          enabled: true
+          python_version: 3.13.14
+        timeout_s: 10800
+        agent_config:
+          repo_dir: /testbed
+          workspace_root: /tmp/opencode-workspaces
+      model: dummy_model
+      command: opencode
+      setup_timeout: 900
+      timeout: 10800
+      context_window: 262144
+      max_output_tokens: 262144
       opencode_version: 1.17.11
-      # @bxyu-nvidia: This needs to be set appropriately for every model!
-      opencode_max_context_window: 262144
-
-      remote_opencode_install_script_path: null
-      remote_opencode_binary_path: null
-      remote_opencode_musl_binary_path: null
-
-      # Taken from https://github.com/sdevare-nv/nv-opencode/blob/f261004b4e4269a6e193fd242e5ec8ced9a7aec0/packages/opencode/src/bench/cli.ts#L198-L325
       opencode_config:
         permission:
           "*": allow
@@ -142,26 +150,4 @@ opencode_sandboxed_agent:
           task: true
           skill: false
           todowrite: true
-
-      sandbox_timeout: 10800  # 3hr default for harness execution
-
-      sandbox_provider: sandbox
-      sandbox_config:
-        ttl_s: 18000
-        ready_timeout_s: 1200
-        env:
-          # execd holds each finished command's response open for this long (default 1s);
-          # a short grace keeps every command and the readiness probe from paying that tail.
-          EXECD_API_GRACE_SHUTDOWN: "50ms"
-        resources:
-          cpu: 0.25
-          memory_mib: 512
-          # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range
-          # (an explicit 20 is rejected there) and fine as an ephemeral request elsewhere.
-          disk_gib: 30
-        provider_options: {}
-        metadata:
-          benchmark: swebench-verified
-          harness: mini-swe-agent
-
       datasets: []

--- a/tests/unit_tests/test_agent_dependencies.py
+++ b/tests/unit_tests/test_agent_dependencies.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import tarfile
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nemo_gym.sandbox import SandboxExecResult
+from nemo_gym.sandbox.agent_dependencies import build_source_archive, install_agent_dependencies
+from nemo_gym.sandbox.agent_runtime_config import AgentRuntimeConfig
+
+
+@pytest.fixture
+def source(tmp_path):
+    root = tmp_path / "checkout"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    files = {
+        "pyproject.toml": "[project]\nname = 'nemo-gym'\nversion = '1.0'\n",
+        "README.md": "Gym",
+        "LICENSE": "Apache-2.0",
+        "nemo_gym/__init__.py": "",
+        "nemo_gym/new_runtime.py": "# uncommitted runtime changes\n",
+        "responses_api_agents/__init__.py": "",
+        "responses_api_agents/example/app.py": "# selected harness\n",
+        "responses_api_agents/example/requirements.txt": "-e nemo-gym @ ../../\n",
+        "responses_api_agents/example/setup.sh": "echo setup\n",
+        "responses_api_agents/example/.venv/secret.txt": "excluded",
+        "responses_api_agents/example/data/rollouts.json": "excluded",
+        "resources_servers/verifier/answers.json": "excluded",
+        "env.yaml": "secret: excluded",
+    }
+    for name, content in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return root
+
+
+def config(source):
+    return AgentRuntimeConfig(dependencies={"source_root": str(source)})
+
+
+def test_source_bundle_contains_current_harness_and_core_only(source, tmp_path):
+    (source / "nemo_gym/escape.py").symlink_to(source / "env.yaml")
+    archive = tmp_path / "source.tar.gz"
+    relative = build_source_archive(config(source), "responses_api_agents.example.app:Agent", archive)
+    assert relative == "responses_api_agents/example"
+    with tarfile.open(archive) as bundle:
+        names = set(bundle.getnames())
+        assert "nemo_gym/new_runtime.py" in names
+        assert "responses_api_agents/example/setup.sh" in names
+        assert "responses_api_agents/example/requirements.txt" in names
+        assert "responses_api_agents/__init__.py" in names
+        assert "env.yaml" not in names
+        assert "nemo_gym/escape.py" not in names
+        assert not any("secret" in name or "rollouts" in name or "answers" in name for name in names)
+
+
+@pytest.mark.parametrize("harness_path", ["../outside", "/tmp/outside"])
+def test_rejects_source_escape(source, tmp_path, harness_path):
+    runtime = AgentRuntimeConfig(dependencies={"source_root": str(source), "harness_path": harness_path})
+    with pytest.raises(ValueError, match="relative directory"):
+        build_source_archive(runtime, "custom:Agent", tmp_path / "source.tar.gz")
+
+
+def test_rejects_ambiguous_dependencies(source, tmp_path):
+    (source / "responses_api_agents/example/pyproject.toml").write_text("[project]\n")
+    with pytest.raises(ValueError, match="exactly one"):
+        build_source_archive(config(source), "responses_api_agents.example.app:Agent", tmp_path / "source.tar.gz")
+
+
+async def test_provisions_isolated_python_and_installs_harness_manifest(source, tmp_path):
+    sandbox = AsyncMock()
+    sandbox.exec.return_value = SandboxExecResult(stdout="installed", stderr="", return_code=0)
+    runtime = config(source)
+    runtime.env = {"CUSTOM_INDEX_SETTING": "preserved"}
+    python, env = await install_agent_dependencies(
+        sandbox, runtime, "responses_api_agents.example.app:Agent", "/tmp/task-worker", tmp_path
+    )
+    assert python == "/tmp/task-worker/venv/bin/python"
+    assert env["CUSTOM_INDEX_SETTING"] == "preserved"
+    assert env["UV_PYTHON_INSTALL_DIR"] == "/tmp/task-worker/python"
+    command = sandbox.exec.await_args.args[0]
+    assert "venv --seed --python 3.13.14 /tmp/task-worker/venv" in command
+    assert "cd /tmp/task-worker/source/responses_api_agents/example" in command
+    assert "-r requirements.txt" in command
+    assert "--override overrides.txt" in command
+    assert "-e ." in command
+    assert "--system" not in command
+    assert sandbox.upload.await_args.args[1] == "/tmp/task-worker/source.tar.gz"
+
+
+async def test_install_failure_reports_stderr(source, tmp_path):
+    sandbox = AsyncMock()
+    sandbox.exec.return_value = SandboxExecResult(stdout="", stderr="cannot download Python", return_code=1)
+    with pytest.raises(RuntimeError, match="cannot download Python"):
+        await install_agent_dependencies(
+            sandbox, config(source), "responses_api_agents.example.app:Agent", "/tmp/task-worker", tmp_path
+        )

--- a/tests/unit_tests/test_agent_runtime.py
+++ b/tests/unit_tests/test_agent_runtime.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, Body, SimpleResponsesAPIAgent
+from nemo_gym.config_types import BaseServerConfig, ResourcesServerRef
+from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.sandbox.agent_runtime import RuntimeRunRequest, SandboxedAgentHost
+from nemo_gym.sandbox.agent_runtime_config import AgentRuntimeConfig
+from nemo_gym.server_utils import ServerClient
+
+
+class FileAgentConfig(BaseResponsesAPIAgentConfig):
+    resources_server: ResourcesServerRef
+    marker: str
+
+
+class FileAgent(SimpleResponsesAPIAgent):
+    config: FileAgentConfig
+
+    def model_post_init(self, context):
+        Path(self.config.marker).write_text(str(os.getpid()))
+
+    async def responses(self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()):
+        assert request.cookies["resource_session"] == "task-cookie"
+        Path("answer.txt").write_text(body.input)
+        return NeMoGymResponse(
+            id="response",
+            created_at=0,
+            model="file-agent",
+            object="response",
+            output=[],
+            parallel_tool_calls=False,
+            tool_choice="auto",
+            tools=[],
+        )
+
+    async def run(self, request, body):
+        raise AssertionError("Inner /run must never be called")
+
+
+class Response:
+    ok = True
+    cookies = {"resource_session": "task-cookie"}
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def read(self):
+        return json.dumps(self.payload).encode()
+
+
+def make_host(tmp_path, **runtime):
+    config = FileAgentConfig(
+        host="localhost",
+        port=8001,
+        entrypoint="app.py",
+        name="agent",
+        resources_server=ResourcesServerRef(type="resources_servers", name="resources"),
+        marker=str(tmp_path / "initialized"),
+        runtime={
+            "type": "sandbox",
+            "sandbox_source": "runtime",
+            "provider": "sandbox",
+            "python": sys.executable,
+            "dependencies": {"enabled": False},
+            "env": {"PYTHONPATH": str(Path.cwd())},
+            "spec": {"workdir": str(tmp_path)},
+            "timeout_s": 30,
+            **runtime,
+        },
+    )
+    client = ServerClient(
+        head_server_config=BaseServerConfig(host="localhost", port=1),
+        global_config_dict=OmegaConf.create(
+            {
+                "sandbox": {"local": {}},
+                "resources": {"resources_servers": {"test": {"host": "localhost", "port": 8002, "answer": "SECRET"}}},
+            }
+        ),
+    )
+    return FileAgent.create_server(config, client)
+
+
+def test_factory_places_initialization_inside_runtime(tmp_path):
+    host = make_host(tmp_path)
+    assert isinstance(host, SandboxedAgentHost)
+    assert isinstance(host.config, FileAgentConfig)
+    assert not (tmp_path / "initialized").exists()
+    local_config = host.config.model_copy(update={"runtime": AgentRuntimeConfig()})
+    assert isinstance(FileAgent.create_server(local_config, host.server_client), FileAgent)
+    assert (tmp_path / "initialized").read_text() == str(os.getpid())
+
+
+async def test_unchanged_harness_executes_in_separate_process_before_verification(tmp_path):
+    host = make_host(tmp_path)
+    calls = []
+
+    async def post(server_name, url_path, json, cookies):
+        calls.append(url_path)
+        if url_path == "/seed_session":
+            return Response({})
+        assert url_path == "/verify"
+        assert cookies["resource_session"] == "task-cookie"
+        assert json["task_id"] == "task-1"
+        assert (tmp_path / "answer.txt").read_text() == "42"
+        assert (tmp_path / "initialized").read_text() != str(os.getpid())
+        return Response(json | {"reward": 1.0, "custom_metric": 3})
+
+    with patch.object(ServerClient, "post", AsyncMock(side_effect=post)):
+        result = await host.run(
+            MagicMock(cookies={}),
+            RuntimeRunRequest.model_validate({"responses_create_params": {"input": "42"}, "task_id": "task-1"}),
+        )
+    assert calls == ["/seed_session", "/verify"]
+    assert result.reward == 1.0
+    assert result.custom_metric == 3
+
+
+def test_worker_receives_routes_not_verifier_secrets_or_task_answers(tmp_path):
+    host = make_host(tmp_path, server_urls={"resources": "https://reachable.example/gym"})
+    body = RuntimeRunRequest.model_validate({"responses_create_params": {"input": "solve"}, "answer": "GOLDEN"})
+    payload = host._worker_payload(body, {})
+    encoded = json.dumps(payload)
+    assert "SECRET" not in encoded
+    assert "GOLDEN" not in encoded
+    assert "reachable.example" in encoded
+    assert payload["config"]["runtime"] == {"type": "local"}
+
+
+@pytest.mark.parametrize("capture", [False, True])
+def test_worker_preserves_rollout_and_training_capture_routes(tmp_path, capture):
+    host = make_host(tmp_path)
+    host.server_client.global_config_dict.observability_enabled = True
+    host.server_client.global_config_dict.token_id_capture = {"enabled": capture, "all_agents": True}
+    body = RuntimeRunRequest.model_validate(
+        {
+            "responses_create_params": {"input": "solve"},
+            "_ng_task_index": 2,
+            "_ng_rollout_index": 3,
+        }
+    )
+    payload = host._worker_payload(body, {})
+    assert payload["path"] == "/ng-rollout/2-3/" + ("training-token-capture/" if capture else "") + "v1/responses"
+    assert payload["global_config"]["token_id_capture"]["enabled"] is capture
+    assert payload["config"]["token_id_capture"] is capture
+
+
+@pytest.mark.parametrize("failure", ["connect", "execute", "verify", "cancel"])
+async def test_borrowed_workspace_cleanup_on_failure(tmp_path, failure):
+    host = make_host(tmp_path, sandbox_source="environment", spec={})
+    sandbox = MagicMock(stop=AsyncMock())
+    provider = MagicMock(aclose=AsyncMock())
+    descriptor = {"sandbox_id": "task", "workdir": "/testbed", "opaque": {"lease": 1}}
+    calls = []
+
+    async def post(server_name, url_path, json, cookies):
+        calls.append(url_path)
+        if url_path == "/seed_session":
+            return Response({"workspace": {"provider": "sandbox", "descriptor": descriptor}})
+        assert cookies["resource_session"] == "task-cookie"
+        if url_path == "/verify":
+            raise ValueError("verify failed")
+        assert url_path == "/cleanup_session"
+        return Response({})
+
+    error = asyncio.CancelledError() if failure == "cancel" else ValueError("execute failed")
+    response = NeMoGymResponse(
+        id="response",
+        created_at=0,
+        model="file-agent",
+        object="response",
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+    with (
+        patch.object(ServerClient, "post", AsyncMock(side_effect=post)),
+        patch("nemo_gym.sandbox.agent_runtime.create_provider", return_value=provider),
+        patch(
+            "nemo_gym.sandbox.agent_runtime.AsyncSandbox.connect",
+            AsyncMock(
+                return_value=sandbox,
+                side_effect=ValueError("connect failed") if failure == "connect" else None,
+            ),
+        ) as connect,
+        patch.object(
+            SandboxedAgentHost,
+            "_execute",
+            AsyncMock(
+                return_value={"response": response.model_dump(mode="json")},
+                side_effect=error if failure in {"execute", "cancel"} else None,
+            ),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError if failure == "cancel" else ValueError):
+            await host.run(MagicMock(cookies={}), RuntimeRunRequest(responses_create_params={"input": "solve"}))
+        connect.assert_awaited_once_with(descriptor, provider=provider)
+    assert calls[-1] == "/cleanup_session"
+    sandbox.stop.assert_not_awaited()
+    provider.aclose.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"type": "typo"},
+        {"concurrency": 0},
+        {"agent_config": {"runtime": {"type": "sandbox"}}},
+        {"sandbox_source": "environment", "spec": {"image": "task"}},
+        {"sandbox_source": "typo"},
+        {"workspace": "environment"},
+    ],
+)
+def test_invalid_runtime_config(config):
+    with pytest.raises(ValidationError):
+        AgentRuntimeConfig.model_validate(config)


### PR DESCRIPTION
# Add shared sandbox runtime with automatic dependencies for OpenCode and SWE-bench

## Summary

Introduce a proof-of-concept runtime layer that runs an agent harness's Python process and its child processes inside a per-task sandbox. Demonstrate it with the ordinary `opencode_agent` and SWE-bench, without adding sandbox-specific branches to the OpenCode harness.

Local execution remains the default. The existing `opencode_sandboxed_agent` is retained for compatibility; this change adds an alternative configuration rather than deleting the legacy implementation.

## Motivation

Sandbox placement should be independent of harness behavior. Maintaining separate local and sandboxed agents couples each harness to sandbox provisioning, remote command execution, and environment-specific handle exchange.

Moving the harness process into the sandbox lets its normal filesystem operations and subprocesses act directly on the task repository. A shared host coordinates task preparation, execution, verification, and cleanup, while the harness continues to implement agent behavior.

## Design decisions

### Select placement before constructing the harness

Add a `BaseServer.create_server()` factory hook and use it in the server launcher. `SimpleResponsesAPIAgent` overrides the factory to select either the normal harness or a generic `SandboxedAgentHost`.

This selection happens before harness initialization, so OpenCode installation and other harness startup work happen inside the sandbox, not on the host. The inherited `runtime` configuration makes placement available to compatible harnesses without modifying each implementation.

The host remains outside the sandbox. This is per-task harness execution, not relocation of the complete long-lived Agent Server, Resources Server, or Model Server.

### Make sandbox ownership explicit

`runtime.sandbox_source` identifies who supplies the execution sandbox:

| Value | Creation and ownership | Cleanup |
| --- | --- | --- |
| `environment` (default) | Resources Server prepares the task sandbox; the host connects to its descriptor. | Resources Server owns destruction; the host requests session cleanup. |
| `runtime` | Agent runtime creates a sandbox from `runtime.provider` and `runtime.spec`. | Agent runtime stops it. |

SWE-bench uses `environment` because the benchmark selects the task image and prepares the repository. An agent-supplied `spec` is rejected in this mode. Conversely, `runtime` mode rejects an environment-provided workspace rather than silently executing in a different sandbox.

The name `sandbox_source` distinguishes ownership from a filesystem working directory. The prototype's earlier `runtime.workspace` key is not retained as an alias. The Resources Server's `workspace` response field remains unchanged.

### Keep the sandbox handle with the environment

Add a typed `SandboxWorkspace` descriptor and shared Resources Server helpers:

- `register_sandbox_workspace()` retains the live sandbox object under the session and returns a serializable provider reference and descriptor.
- `session_sandbox()` retrieves that original object during verification.
- `/cleanup_session` performs idempotent cleanup.

The host propagates session cookies through seed, execution, verification, and cleanup. The verifier therefore does not depend on the agent returning a sandbox ID. Providers used for environment handoff must support serialization and reconnection.

### Run the existing responses route in a worker

The host uploads a request payload and standalone worker, then starts the worker through the sandbox SDK. The worker imports and constructs the configured harness, initializes its ASGI application, and invokes its existing responses route with lifespan and capture behavior.

Request and result exchange uses JSON files outside the task repository. No inbound HTTP listener is required inside the sandbox, although referenced Gym servers must be reachable for outbound requests. `runtime.server_urls` supports endpoint overrides.

The inner harness uses local placement to avoid recursively launching another sandbox. Only harness settings, referenced server routes, response input, and session cookies are passed to it—not the complete global configuration or the run's verifier metadata. This is payload minimization, not a claim that the harness cannot access credentials explicitly provided in its own configuration or environment.

### Install dependencies without replacing the task environment

Automatic installation is enabled by default. The host snapshots Gym core and the selected harness from the current Git checkout, including eligible uncommitted files, and uploads the archive.

Inside a unique per-task directory, the installer:

1. Uses an existing `uv` executable or bootstraps the configured version.
2. Provisions the configured Python version and an isolated virtual environment.
3. Installs Gym and the harness's `requirements.txt` (with `overrides.txt` when present), or its `pyproject.toml`.
4. Launches the worker using that environment's interpreter.

The source bundle excludes host virtual environments, ignored files, symlinks, task datasets, and verifier directories. The task's existing Python environment is left intact. OpenCode's existing startup code handles its CLI installation; the shared installer does not contain an OpenCode-specific branch.

Prepared images can disable installation and select an existing interpreter. Uploads and a setup command remain available for additional provisioning.

## OpenCode + SWE-bench lifecycle

```text
/run
  -> SWE-bench /seed_session: create and register task sandbox
  -> shared agent host: connect, install dependencies, start worker
  -> OpenCode worker: edit /testbed and call the external Model Server
  -> SWE-bench /verify: retrieve original sandbox and extract git diff
  -> fresh grading sandbox: evaluate the patch and produce reward
  -> host: return verified response and request idempotent cleanup
```

SWE-bench retains its task preparation and anti-cheating logic. Verification still uses a fresh grading sandbox rather than trusting the agent-modified execution environment. The original task sandbox is cleaned up after patch extraction; host cleanup also runs in a `finally` block for success, failure, and cancellation paths.

The new `responses_api_agents/opencode_agent/configs/opencode_swebench.yaml` composes the ordinary harness with SWE-bench and a connect-capable provider:

```yaml
runtime:
  type: sandbox
  sandbox_source: environment
  dependencies:
    enabled: true
    python_version: 3.13.14
  timeout_s: 10800
  agent_config:
    repo_dir: /testbed
    workspace_root: /tmp/opencode-workspaces
```

## Implementation map

- `nemo_gym/server_utils.py`: server construction hook.
- `nemo_gym/base_responses_api_agent.py`: inherited runtime configuration and placement selection.
- `nemo_gym/sandbox/agent_runtime_config.py`: placement, provisioning, and worker configuration.
- `nemo_gym/sandbox/agent_runtime.py`: shared seed/execute/verify/cleanup coordinator.
- `nemo_gym/sandbox/agent_runtime_worker.py`: in-sandbox harness initialization and ASGI invocation.
- `nemo_gym/sandbox/agent_dependencies.py`: source packaging and sandbox-local dependency installation.
- `nemo_gym/sandbox/workspace.py` and `nemo_gym/base_resources_server.py`: typed handoff, session registry, and cleanup.
- `resources_servers/swebench/`: shared workspace integration and existing fresh-sandbox grading.
- `responses_api_agents/opencode_agent/configs/opencode_swebench.yaml`: configuration-only adoption by the ordinary OpenCode harness.
- `fern/versions/latest/pages/agent-server/runtime.mdx`: usage and compatibility documentation.

## Validation performed

- Shared runtime and dependency tests: **21 passed** after the `sandbox_source` rename. Coverage includes separate-process harness execution, host-versus-worker initialization, payload filtering, capture settings, failure/cancellation cleanup, source packaging, installation errors, and invalid configuration rejection.
- Earlier combined dependency/runtime/base/OpenCode/SWE-bench regression run: **65 passed** before the configuration-key rename. These counts overlap and are not additive.
- Real OpenCode smoke rollout in a clean Docker sandbox, without host source or virtual-environment mounts: automatic provisioning succeeded, the model used `read`, `edit`, and `bash`, and independent verification returned **reward 1.0**. The disposable container was cleaned up.
- Ruff and whitespace checks passed. Scoped pre-commit checks passed during implementation. Fern validation passed with zero errors and one warning.

The real rollout validates the shared runtime and automatic installation path; it is **not a full SWE-bench benchmark run**. Full-suite CI-equivalent checks and a full SWE-bench model evaluation remain outstanding.

## Prototype limitations and follow-up work

- Placement is integrated with `SimpleResponsesAPIAgent`; this does not provide arbitrary process placement for every server class.
- Harnesses must be importable and able to execute their responses route independently. Custom `/run` setup, postprocessing, and arbitrary harness-specific return fields are not automatically reproduced.
- Sandbox execution requires the outer `/run` endpoint; direct responses requests to the host are rejected.
- Programmatic callers must use `create_server()`; direct class construction bypasses placement.
- The Resources Server registry is process-local. Seed, verify, and cleanup must reach the same Resources Server process; distributed ownership or routing is not implemented.
- Runtime-owned sandbox handles are not automatically registered with the verifier. Environments needing task-filesystem verification should use environment-owned sandboxes.
- Automatic installation requires a host Git checkout and sandbox shell, `curl`, `tar`, and outbound distribution access. Extra local source dependencies and OS packages require explicit provisioning or prepared images.
- Installations are fresh per task and resolve manifests rather than `uv.lock`; cross-task caching and fully reproducible dependency resolution are follow-up work.
- Provider cancellation behavior varies; cleanup does not guarantee recovery of a cancelled worker's partial transcript.
- The legacy sandboxed OpenCode implementation remains available. Removing it should follow broader compatibility and SWE-bench rollout validation.
