### PR TITLE
docs(contributing): align PR, code, and CI guidance

### DIFF
--- a/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
+++ b/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: nemo-gym-pr-checks-and-labels
+description: Inspect and prepare NVIDIA-NeMo/Gym pull requests by selecting repository-specific local and CI checks, diagnosing missing or failed checks, and choosing current type, area, and state labels. Use for PR readiness, check selection, CI handoff, or PR labeling. Do not use for general code review or issue-triage sweeps.
+---
+
+# NeMo Gym PR Checks and Labels
+
+Use this workflow for a local branch or a GitHub pull request in
+`NVIDIA-NeMo/Gym`. Keep generic style rules in `AGENTS.md`, `pyproject.toml`,
+and `.pre-commit-config.yaml`; this skill covers the decisions that depend on
+Gym's change classifier, runtime contracts, and live PR taxonomy.
+
+## Establish Scope
+
+Read the artifact before choosing checks or labels:
+
+```bash
+git status --short
+git diff --stat <base>...HEAD
+git diff --name-only <base>...HEAD
+
+gh pr view <PR> --repo NVIDIA-NeMo/Gym \
+  --json number,title,body,isDraft,author,baseRefName,headRefName,headRefOid,labels,reviewDecision,mergeStateStatus
+gh api repos/NVIDIA-NeMo/Gym/pulls/<PR> --jq .author_association
+gh pr diff <PR> --repo NVIDIA-NeMo/Gym --name-only
+gh pr checks <PR> --repo NVIDIA-NeMo/Gym
+```
+
+For local validation and CI routing, treat these repository files as
+authoritative:
+
+- `AGENTS.md` for the quality bar and required rollout evidence.
+- `CONTRIBUTING.md` for contributor and environment requirements.
+- `.pre-commit-config.yaml` and `pyproject.toml` for enforced style.
+- `.github/actions/classify-changes/action.yml` for test-scope classification.
+- `.github/workflows/unit-tests.yml` and `.github/workflows/cicd-main.yml` for
+  actual CI behavior.
+- `scripts/ci/cov_fail_under.py` for the coverage threshold used by CI.
+
+When those files disagree with this skill, follow the repository files and
+report the drift.
+
+## Select Checks
+
+Run `pre-commit run --all-files` before handoff. Hooks can modify files; review
+the resulting diff, stage only intended changes, and rerun until clean.
+
+Then classify the complete PR diff using the same precedence as CI:
+
+| Diff classification | Paths | CI test scope | Local evidence |
+|---|---|---|---|
+| Docs-only | Only `**.md`, `fern/**`, `LICENSE`, or `benchmarks/**` | Unit tests are skipped | For Fern changes, follow `fern/README.md`; otherwise run relevant docs/link checks |
+| Server-only | One or more files in `resources_servers/**`, `responses_api_agents/**`, or `responses_api_models/**`, with no uncategorized files | Core and sandbox coverage tests plus tests for changed servers | Run `gym env test --resources-server <name>` for each changed server and targeted core tests when shared behavior is exercised |
+| Full | Any uncategorized file, including core code, CI, scripts, test infrastructure, or native skill-discovery links | Core and sandbox coverage tests plus the eight-shard server suite | Run targeted tests for the changed contract; use `gym dev test` and `gym env test --all` when the change warrants the full local cost |
+
+The precedence is full over server-only over docs-only. A Markdown file does
+not make a mixed PR docs-only. A canonical `SKILL.md`-only edit matches the
+Markdown rule, while adding a `.claude/skills` or `.codex/skills` symlink makes
+the diff full-scope under the current classifier.
+
+Additional evidence is required by behavior, not just path:
+
+- For behavior-changing environment or agent code, run a representative real
+  smoke rollout with a model and inspect both agent and verifier behavior.
+- For a new resources server, satisfy the fixtures and validation contract in
+  `CONTRIBUTING.md`, including server tests and example data/rollouts.
+- For an AI-generated test, confirm it fails for the broken behavior and
+  asserts an observable contract rather than generated wording or a
+  pass-through mock.
+- For docs, catalog, manifest, and other non-runtime changes, record model
+  rollouts as not applicable rather than spending model compute.
+
+Do not claim a check passed unless it ran against the final diff. If a check is
+too expensive or unavailable, name it and explain the residual risk.
+
+## Interpret GitHub Checks
+
+Distinguish three states:
+
+1. **Failed:** inspect the failing job and logs, reproduce the smallest relevant
+   command, and determine whether the failure belongs to the PR or
+   infrastructure.
+2. **Pending:** report the running or queued check; do not treat it as success.
+3. **Missing:** verify the path classification, draft state, head SHA, and trust
+   gate before assuming CI is broken.
+
+The main Gym pipeline runs from `pull-request/<number>`. An unverified or
+external head commit may need a maintainer to comment `/ok to test <full-sha>`.
+That comment authorizes repository CI to execute contributor code, so never post
+it merely because a check is missing; do so only when the user explicitly asks
+and has the needed maintainer authority.
+
+Check DCO separately. Every commit must contain a `Signed-off-by` trailer;
+cryptographic signing is optional.
+
+## Choose Labels
+
+Fetch the live labels and descriptions before making a decision:
+
+```bash
+gh label list --repo NVIDIA-NeMo/Gym --limit 200 \
+  --json name,description --jq '.[] | [.name, .description] | @tsv'
+```
+
+Live repository metadata takes precedence over the examples below. For a
+non-draft PR, prefer one label from each applicable family:
+
+- **Type:** `bug`, `feature`, `docs`, `ci`, or `support`. Use `docs` when the
+  deliverable is documentation or repository guidance even if CI classifies a
+  skill file as a full-suite path. Preserve legacy synonyms unless the user
+  explicitly asks for label hygiene.
+- **Area:** one dominant `area:*` label. Choose the user-facing domain, not
+  merely the file extension. For example, model-server docs are `area:model`,
+  while generic contributor docs are `area:docs`.
+- **State:** `needs-review` when a non-draft PR is ready for review;
+  `ready-to-merge` only after approval and required checks; or `blocked`,
+  `waiting-on-customer`, or `waiting-on-maintainers` when that state is
+  supported by current evidence. Draft PRs normally have no state label.
+
+Use the dominant changed behavior for area selection:
+
+| Dominant scope | Area label |
+|---|---|
+| Agent harnesses and Responses API agent behavior | `area:agent` |
+| Packaging, dependencies, containers, releases | `area:build` |
+| CI, test routing, repository automation | `area:ci` |
+| CLI commands and user-facing CLI behavior | `area:cli` |
+| Hydra config, schemas, composition, compatibility | `area:config` |
+| Shared APIs, servers, telemetry, registries | `area:core` |
+| Datasets, preparation, task formats, materialization | `area:data` |
+| Generic docs without a more specific domain | `area:docs` |
+| Environment framework, lifecycle, scaffolding, validation | `area:env-infra` |
+| Individual environments, benchmarks, verifiers | `area:environment` |
+| Evaluation, rollouts, reward profiling, exporters | `area:evaluation` |
+| Model servers, inference providers, adapters | `area:model` |
+| Submission, deployment, services, lifecycle orchestration | `area:orchestration` |
+| Sandbox providers and isolation/runtime contracts | `area:sandbox` |
+| Training integrations and training-data interfaces | `area:training` |
+
+Treat other labels as orthogonal and conservative:
+
+- Add `benchmark-onboarding` only for a self-contained benchmark-onboarding PR.
+- Add `community-request` only when external provenance is clear from GitHub
+  association/permissions or a linked original contribution. Do not infer
+  affiliation from a username or email address.
+- Preserve release, cherry-pick, QA, runner, and partner labels unless the user
+  asked for that workflow and the repository evidence supports the change.
+- Leave `sla:*` labels to `scripts/pr_sla_tracker.py` and its workflow.
+- Do not add `Run CICD` as a substitute for the `/ok to test` trust gate.
+
+## Mutation Boundary
+
+For requests to inspect checks, assess readiness, or recommend labels, remain
+read-only and return the proposed changes. A request to label a PR authorizes
+adding the supported labels to that PR, but not posting trust-gate comments,
+submitting reviews, merging, or changing unrelated issues.
+
+When applying labels, add only missing labels. Remove an existing label only
+when it directly conflicts with the selected family and the user requested
+normalization; otherwise report the conflict for maintainer judgment.
+
+## Handoff
+
+Report:
+
+- the diff classification and why;
+- checks passed, failed, pending, missing, or not run;
+- rollout evidence, or why it is not applicable;
+- current and proposed labels, including any ambiguity;
+- the exact remaining maintainer or author action.

--- a/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
+++ b/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
@@ -40,6 +40,21 @@ authoritative:
 When those files disagree with this skill, follow the repository files and
 report the drift.
 
+## Check PR Metadata
+
+Apply the title and body contract from `AGENTS.md` before declaring a PR ready:
+
+- Normal authored PR titles use `type(optional-scope): imperative summary`.
+  Do not add Megatron Bridge's `[area]` prefix; Gym expresses that information
+  with an `area:*` label. Preserve generated release and cherry-pick titles.
+- The body explains what changed and why, links the relevant issue or explains
+  why none is needed, lists exact validation, and provides rollout evidence or
+  an explicit justified `N/A`.
+- User-visible compatibility, migration, configuration, and benchmark-result
+  effects are stated when applicable.
+- Missing final validation is acceptable while the PR is a draft, but report it
+  before changing the PR to ready for review.
+
 ## Select Checks
 
 Run `pre-commit run --all-files` before handoff. Hooks can modify files; review

--- a/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
+++ b/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-gym-pr-checks-and-labels
-description: Inspect and prepare NVIDIA-NeMo/Gym pull requests by selecting repository-specific local and CI checks, diagnosing missing or failed checks, and choosing current type, area, and state labels. Use for PR readiness, check selection, CI handoff, or PR labeling. Do not use for general code review or issue-triage sweeps.
+description: Inspect and prepare NVIDIA-NeMo/Gym pull requests by reviewing relevant file history, selecting repository-specific local and CI checks, diagnosing missing or failed checks, and choosing current type, area, and state labels. Use for PR readiness, check selection, CI handoff, or PR labeling. Do not use for general code review or issue-triage sweeps.
 ---
 
 # NeMo Gym PR Checks and Labels
@@ -39,6 +39,46 @@ authoritative:
 
 When those files disagree with this skill, follow the repository files and
 report the drift.
+
+## Review Relevant History
+
+Before implementing or approving a non-trivial change to established behavior,
+do a bounded history pass over the affected code. Inspect behavior-owning source
+files even when the diff changes only tests; a new test can accidentally encode
+behavior that an earlier PR deliberately excluded or kept compatible.
+
+Start with recent commits and narrow blame where the behavior is not obvious:
+
+```bash
+git log --oneline -n 10 -- <path>
+git blame -L <start>,<end> -- <path>
+```
+
+For a relevant commit, follow a PR number in its subject or ask GitHub which PR
+contained it. Read both the PR-level discussion and inline review threads,
+because important constraints are often recorded only in review comments:
+
+```bash
+gh api repos/NVIDIA-NeMo/Gym/commits/<sha>/pulls \
+  -H 'Accept: application/vnd.github+json' \
+  --jq '.[] | [.number, .title, .html_url] | @tsv'
+gh pr view <PR> --repo NVIDIA-NeMo/Gym \
+  --json body,comments,reviews,files
+gh api --paginate repos/NVIDIA-NeMo/Gym/pulls/<PR>/comments \
+  --jq '.[] | [.user.login, .path, .body, .html_url] | @tsv'
+```
+
+Look specifically for intentional omissions or reversions, compatibility
+behavior, downstream consumers, unresolved dependency gates, and comments that
+explain counterintuitive code. Check whether the constraint still applies by
+inspecting the current callers and the state of linked issues; do not preserve a
+stale decision blindly. Deepen the search only when the recent history or code
+points to a material risk.
+
+If a historical corner case still applies, preserve it in a regression test,
+documentation, or a focused code comment, and cite the prior PR or issue in the
+current PR description. If it cannot be preserved within scope, report it as a
+review finding rather than silently changing the behavior.
 
 ## Check PR Metadata
 

--- a/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
+++ b/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
@@ -159,6 +159,15 @@ When applying labels, add only missing labels. Remove an existing label only
 when it directly conflicts with the selected family and the user requested
 normalization; otherwise report the conflict for maintainer judgment.
 
+If `gh pr edit --add-label` fails while querying deprecated Projects Classic
+fields, use the REST issue-label endpoint and then verify the PR:
+
+```bash
+gh api -X POST repos/NVIDIA-NeMo/Gym/issues/<PR>/labels \
+  -f 'labels[]=LABEL'
+gh pr view <PR> --repo NVIDIA-NeMo/Gym --json labels --jq '.labels[].name'
+```
+
 ## Handoff
 
 Report:

--- a/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
+++ b/.agents/skills/nemo-gym-pr-checks-and-labels/SKILL.md
@@ -57,21 +57,29 @@ Apply the title and body contract from `AGENTS.md` before declaring a PR ready:
 
 ## Select Checks
 
-Run `pre-commit run --all-files` before handoff. Hooks can modify files; review
-the resulting diff, stage only intended changes, and rerun until clean.
+For change or PR-preparation requests, run `pre-commit run --all-files` before
+handoff. Hooks can modify files; review the resulting diff, stage only intended
+changes, and rerun until clean. For read-only readiness assessments, inspect
+recorded validation and CI instead. If fresh execution is necessary, use an
+isolated temporary worktree or ask before running hooks in the user's worktree.
 
 Then classify the complete PR diff using the same precedence as CI:
 
 | Diff classification | Paths | CI test scope | Local evidence |
 |---|---|---|---|
-| Docs-only | Only `**.md`, `fern/**`, `LICENSE`, or `benchmarks/**` | Unit tests are skipped | For Fern changes, follow `fern/README.md`; otherwise run relevant docs/link checks |
-| Server-only | One or more files in `resources_servers/**`, `responses_api_agents/**`, or `responses_api_models/**`, with no uncategorized files | Core and sandbox coverage tests plus tests for changed servers | Run `gym env test --resources-server <name>` for each changed server and targeted core tests when shared behavior is exercised |
+| CI docs-classified | Only `**.md`, `fern/**`, `LICENSE`, or `benchmarks/**` | Unit tests are skipped | For Fern changes, follow `fern/README.md`; for non-doc files under `benchmarks/**`, run targeted preparation/tests; otherwise run relevant docs/link checks |
+| Server-only | One or more files in `resources_servers/**`, `responses_api_agents/**`, or `responses_api_models/**`, with no uncategorized files | Core and sandbox coverage tests plus tests for changed servers | Run `gym env test +entrypoint=<component>/<name>` for each changed component and targeted core tests when shared behavior is exercised |
 | Full | Any uncategorized file, including core code, CI, scripts, test infrastructure, or native skill-discovery links | Core and sandbox coverage tests plus the eight-shard server suite | Run targeted tests for the changed contract; use `gym dev test` and `gym env test --all` when the change warrants the full local cost |
 
-The precedence is full over server-only over docs-only. A Markdown file does
-not make a mixed PR docs-only. A canonical `SKILL.md`-only edit matches the
-Markdown rule, while adding a `.claude/skills` or `.codex/skills` symlink makes
-the diff full-scope under the current classifier.
+The precedence is full over server-only over CI docs-classified. A Markdown
+file does not make a mixed PR CI docs-classified. A canonical `SKILL.md`-only
+edit matches the Markdown rule, while adding a `.claude/skills` or
+`.codex/skills` symlink makes the diff full-scope under the current classifier.
+
+For server-only changes, replace `<component>` with `resources_servers`,
+`responses_api_agents`, or `responses_api_models`. The
+`gym env test --resources-server <name>` form is shorthand for resources
+servers only.
 
 Additional evidence is required by behavior, not just path:
 
@@ -128,9 +136,10 @@ non-draft PR, prefer one label from each applicable family:
   merely the file extension. For example, model-server docs are `area:model`,
   while generic contributor docs are `area:docs`.
 - **State:** `needs-review` when a non-draft PR is ready for review;
-  `ready-to-merge` only after approval and required checks; or `blocked`,
-  `waiting-on-customer`, or `waiting-on-maintainers` when that state is
-  supported by current evidence. Draft PRs normally have no state label.
+  `ready-to-merge` after approval once the branch is current, while waiting for
+  final CI or merge; or `blocked`, `waiting-on-customer`, or
+  `waiting-on-maintainers` when that state is supported by current evidence.
+  Draft PRs normally have no state label.
 
 Use the dominant changed behavior for area selection:
 

--- a/.claude/skills/nemo-gym-pr-checks-and-labels
+++ b/.claude/skills/nemo-gym-pr-checks-and-labels
@@ -1,0 +1,1 @@
+../../.agents/skills/nemo-gym-pr-checks-and-labels

--- a/.codex/skills/nemo-gym-pr-checks-and-labels
+++ b/.codex/skills/nemo-gym-pr-checks-and-labels
@@ -1,0 +1,1 @@
+../../.agents/skills/nemo-gym-pr-checks-and-labels

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,24 @@
 
 <!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->
 
+## Validation
+
+<!-- List the exact commands and checks run against the final diff. -->
+
+## Rollouts
+
+<!-- Include representative rollout evidence for behavior-changing environment or agent code, or a justified N/A. -->
+
+## Compatibility and benchmark impact
+
+<!-- Describe compatibility, migration, configuration, or benchmark-result effects, or state "None". -->
+
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
+- [ ] I have read the [contributing guidelines](https://github.com/NVIDIA-NeMo/Gym/blob/main/CONTRIBUTING.md).
 - [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
 - [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
-- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
+- [ ] Documentation added or updated, or N/A with justification.
+- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format checks pass).
+- [ ] New source files include the required Apache-2.0 SPDX header.
 - [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,19 @@ Humans: see [Development Setup → Use of AI and LLM Tools](https://docs.nvidia.
 - Docs live under `fern/versions/latest/pages/`. Bleeding-edge nav is `fern/versions/main.yml`. See `fern/README.md` and the `nemo-gym-docs` skill.
 - Do not introduce licenses incompatible with Apache-2.0. New source files need the standard NVIDIA SPDX header.
 
+## Pull Requests
+
+- For normal authored PRs, use a Conventional Commit-style title: `type(optional-scope): imperative summary`.
+  Common types are `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `build`, `ci`, and `chore`; use `design` for a
+  design-only proposal. The scope is optional but should name the affected component, such as `agent`, `eval`,
+  `sandbox`, or a specific environment. Automated release and cherry-pick PRs may keep their generated title format.
+- Do not copy Megatron Bridge's `[area]` title prefix into Gym. Use the repository's `area:*` label taxonomy instead.
+- The PR body must explain what changed and why, link the relevant issue or state why one is unnecessary, list the
+  exact validation performed, and include rollout evidence or an explicit `N/A` with justification. Call out user-facing
+  compatibility, migration, or benchmark-result impact when applicable.
+- Keep incomplete work as a draft. Mark it ready for review only after reviewing the final diff and recording the
+  applicable local checks. Use the `nemo-gym-pr-checks-and-labels` skill for CI routing and label selection.
+
 ## What This Is
 
 NeMo Gym is a library for evaluating and improving models and agents using environments. It provides infrastructure to develop environments, scalably run evaluation and training, and a collection of popular benchmarks and training environments. All components are composable and modular — bring your own agent, model, or environment and integrate with Gym where you need it.
@@ -139,6 +152,20 @@ gym env resolve --config ...
 - Line length: 119
 - Python 3.13.14+, async-first
 - Ruff for linting and formatting (double quotes, isort)
+- Add parameter and return annotations to new or changed public functions and methods, and explicit types to public
+  dataclass and Pydantic fields. Avoid `Any` at public boundaries when a concrete model, protocol, `TypedDict`, or
+  `object` plus narrowing expresses the contract. Match surrounding annotation style and do not perform unrelated
+  `Optional`/`List` syntax migrations.
+- Mypy is available as a development dependency but is not a repository-wide strict CI gate. Run it on a focused area
+  when that area is already type-checkable; do not claim repo-wide `mypy --strict` compliance.
+- Public APIs and objects included in generated reference docs need useful docstrings. Comments should explain intent,
+  invariants, or tradeoffs rather than narrating the code.
+- Use keyword-only arguments for new public parameters that are easy to swap or misread, especially repeated same-type
+  values and boolean controls.
+- Use module loggers for library and server diagnostics. Direct console output is acceptable in CLI/user-facing paths;
+  do not impose a blanket ban on `print()` copied from another repository.
+- Raise specific exceptions with actionable context. Broad exception handling is appropriate only at a deliberate
+  request, task, or process boundary where the error is logged, translated, or preserved for the caller.
 - CI reads the coverage threshold from `[tool.coverage.report].fail_under` via `scripts/ci/cov_fail_under.py`; do not
   hard-code a second threshold in contributor guidance.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ Humans: see [Development Setup → Use of AI and LLM Tools](https://docs.nvidia.
 - Prefer focused changes. Do not make unrelated "drive-by" edits. If a drive-by fix is worth keeping, open a separate issue or PR.
 - Intentional synthetic scaling of environments is fine when scoped via an issue or focused PR; do not dump unreviewed bulk diffs.
 - You (the human author) own every line submitted. Treat model output as untrusted until reviewed.
-- For environment or agent changes: run real rollouts with a model and inspect agent and verifier behavior. Green unit tests alone are not enough.
+- For behavior-changing environment or agent work: run representative real smoke rollouts with a model and inspect
+  agent and verifier behavior. Green unit tests alone are not enough. Metadata-only catalog or manifest changes and
+  docs-only changes do not require model compute.
 - Before opening a PR, run the local checks that mirror CI: tests (skip or N/A for docs-only), `pre-commit run --all-files`, and DCO sign-off (`git commit -s`). Cryptographic `-S` signing is optional and not required.
 - AI-generated tests must assert real behavior; avoid vacuous pass-through tests.
 - Prefer the vetted skills under `.agents/skills/` (see [Agent Skills](https://docs.nvidia.com/nemo/gym/latest/contribute/agent-skills)).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,11 +134,13 @@ gym env resolve --config ...
 
 ## Code Style
 
+- `pyproject.toml` is authoritative for Python, Ruff, formatter, and coverage settings;
+  `.pre-commit-config.yaml` is authoritative for the hooks that enforce them.
 - Line length: 119
 - Python 3.13.14+, async-first
 - Ruff for linting and formatting (double quotes, isort)
-- Test coverage must be >= 96%
-- All commits require DCO sign-off (`-s`). Cryptographic signing (`-S`) is optional and not enforced by CI.
+- CI reads the coverage threshold from `[tool.coverage.report].fail_under` via `scripts/ci/cov_fail_under.py`; do not
+  hard-code a second threshold in contributor guidance.
 
 ## Pre-commit Hooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,14 @@ If DCO checks fail after you have already pushed, see the [Development Setup Gui
 
 ## Code, Documentation, and Tests
 
+- Before changing established behavior, briefly review the relevant history of
+  the affected code. Start with `git log --oneline -n 10 -- <path>`; for a
+  non-obvious line or small range, use
+  `git blame -L <start>,<end> -- <path>`. When a relevant commit links a PR or
+  issue, read that discussion for compatibility constraints or corner cases
+  that may not yet be documented. If a constraint still applies, preserve it
+  in a regression test, documentation, or a focused code comment so future
+  contributors do not have to rediscover it.
 - Follow the code-style rules in [`AGENTS.md`](./AGENTS.md). Ruff, not Black,
   owns Python linting and formatting; `pyproject.toml` and
   `.pre-commit-config.yaml` are the enforced configuration. Annotate new or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,24 @@ Refer to the [RL Framework Integration Guide](https://docs.nvidia.com/nemo/gym/l
 
 **Not sure where to start?** Refer to our [open issues](https://github.com/NVIDIA-NeMo/Gym/issues) or create a new issue to discuss your idea.
 
+## Pull Requests
+
+- For normal authored PRs, use a Conventional Commit-style title:
+  `type(optional-scope): imperative summary`. Common types are `feat`, `fix`,
+  `docs`, `test`, `refactor`, `perf`, `build`, `ci`, and `chore`. Use `design`
+  for a design-only proposal, which normally carries the `docs` type label.
+  Generated release and cherry-pick PRs may keep their generated title format.
+- Explain what changed and why, link the relevant issue or explain why one is
+  unnecessary, list the exact validation performed, and include rollout
+  evidence or a justified `N/A`. State any compatibility, migration,
+  configuration, or benchmark-result impact.
+- Keep incomplete work as a draft. Mark it ready only after reviewing the final
+  diff and recording the applicable local checks.
+- Select one applicable type label and one dominant `area:*` label from the
+  [repository's live labels](https://github.com/NVIDIA-NeMo/Gym/labels). Drafts normally have no state label; add
+  `needs-review` when the PR is ready. If you cannot apply labels, list the
+  proposed labels in the PR body for a maintainer.
+
 ## Use of AI and LLM Tools
 
 We encourage contributors to use AI coding assistants (Cursor, Claude, Codex, OpenCode, and similar)
@@ -70,17 +88,33 @@ submitting a contribution, you agree that:
 
 For complete development setup, CI/CD requirements, DCO sign-off, and troubleshooting, refer to the [Development Setup Guide](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup.html).
 
+External contributors should fork Gym, clone their fork as `origin`, and add
+`NVIDIA-NeMo/Gym` as `upstream`. Contributors with repository write access may
+clone it directly as `origin`. In either case, create a focused branch from the
+current authoritative default branch (`upstream/main` for a fork or
+`origin/main` for a direct clone) rather than developing on `main`.
+
 **Quick Start:**
 
 ```bash
-git clone git@github.com:NVIDIA-NeMo/Gym.git
+# Install uv 0.11.21 or newer (required for the repository's Python version).
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
+
+# External contributors: clone your fork, then add the upstream repository.
+git clone git@github.com:YOUR-USERNAME/Gym.git
 cd Gym
+git remote add upstream git@github.com:NVIDIA-NeMo/Gym.git
+
+# With write access, use git@github.com:NVIDIA-NeMo/Gym.git as the clone URL
+# and omit the `git remote add upstream` step.
 uv venv --python 3.13.14 && source .venv/bin/activate
 uv sync --extra dev
 pre-commit install
 ```
 
-**Important:** All commits must be signed with DCO sign-off (`-s`):
+**Important:** All commits must be signed off under the DCO (`-s`).
+Cryptographic signing (`-S`) is optional:
 
 ```bash
 git commit -s -m "Your commit message"
@@ -88,29 +122,89 @@ git commit -s -m "Your commit message"
 
 If DCO checks fail after you have already pushed, see the [Development Setup Guide](https://docs.nvidia.com/nemo/gym/main/contribute/development-setup#dco-and-commit-signing). Force-pushing is disallowed on branches in the upstream repo; for fork branches, use `--force-with-lease` only if your fork allows it, otherwise push the signed history to a new branch.
 
+## Code, Documentation, and Tests
+
+- Follow the code-style rules in [`AGENTS.md`](./AGENTS.md). Ruff, not Black,
+  owns Python linting and formatting; `pyproject.toml` and
+  `.pre-commit-config.yaml` are the enforced configuration. Annotate new or
+  changed public boundaries and document generated public APIs; mypy is useful
+  for focused type-checkable areas but is not a repository-wide strict CI gate.
+- Every change must assess whether tests and documentation need updating. State
+  what was added or changed, or record a justified `N/A` in the PR body.
+  Significant user-facing features should document their motivation,
+  configuration or API, and an executable usage example.
+- Put deterministic shared-library behavior in `tests/unit_tests/` and
+  component behavior in that component's isolated test suite. Behavior-changing
+  environment or agent work also requires a representative model rollout and
+  inspection of agent and verifier behavior.
+- When renaming a public symbol, configuration key, CLI flag, file, or path,
+  search and update affected docs, docstrings, examples, scripts, configs, and
+  tests. Add compatibility aliases, migration notes, or documentation redirects
+  when users may still depend on the previous name.
+
+## Dependencies
+
+- Declare each new import in the narrowest appropriate dependency file. Keep
+  environment-, agent-, and model-specific packages in that component's
+  `pyproject.toml` or `requirements.txt`; add a root dependency only when shared
+  Gym runtime code requires it.
+- Root dependencies in `pyproject.toml` must record why they are needed, when
+  they were updated, and their license. Do not introduce a license incompatible
+  with Apache-2.0.
+- When root dependency resolution changes, run `uv lock` and commit both
+  `pyproject.toml` and `uv.lock`. Run the focused install and tests for the code
+  path that imports the dependency.
+- Guard or defer optional imports so the base package remains importable, and
+  raise an actionable error when the integration is selected without its
+  extra. Skip tests only when they genuinely require an unavailable optional
+  dependency or external tool.
+
 ## Continuous Integration (CI)
 
-CI runs in two clearly separated stages:
+Gym has three CI entry points:
 
-1. **Pre-merge checks** — run on every pull request. All must be green before a PR can merge.
-2. **Post-merge full test suite** — runs after merge on `main`, with no change detection. It always exercises everything.
+1. **PR-triggered checks** — lint, copyright, secrets, DCO, and the Fern preview build/comment workflows run from pull-request activity outside the mirrored main CICD pipeline.
+2. **Main Gym CICD** — `cicd-main.yml` runs on mirrored PR branches and pushes to `main`, and also on a four-hour schedule or manual dispatch. Its unit and component scope follows the change classifier; scheduled and manual runs add configured container and GPU E2E coverage.
+3. **Unconditional full suite** — `full-test-suite.yml` runs every four hours or by manual dispatch, without change detection.
 
-**Triggering CI (`/ok to test`):** GitHub CI workflows only run automatically for verified commits from NVIDIA-NeMo members. If your commits are unverified, or you're an external contributor, CI won't start until an NVIDIA-NeMo member comments `/ok to test <commit sha>` on the PR. This safeguards CI capacity and adds a review gate before external code can execute in CI.
+**Triggering trusted CI (`/ok to test`):** The mirrored Gym CICD and Fern
+workflows run automatically for verified commits from NVIDIA-NeMo members. If
+your commits are unverified, or you are an external contributor, these trusted
+workflows do not start until a qualified NVIDIA-NeMo vetter comments
+`/ok to test <full commit SHA>` on the PR. Approval applies to the current
+head; after an unverified head changes, a qualified vetter must approve the new
+full SHA.
+GitHub-hosted checks such as lint, copyright, secrets, DCO, and the Fern preview
+may still run directly. The trust gate prevents unreviewed contributor code
+from executing on NVIDIA runners.
 
-Reproduce the pre-merge checks locally before you push:
+Run the checks applicable to your diff before you push:
 
 ```bash
-pre-commit run --all-files                          # linting + custom hooks
-gym env test --resources-server your_server         # server tests + data validation
+pre-commit run --all-files                              # every change
+gym dev test                                           # shared core behavior
+gym env test +entrypoint=resources_servers/your_server # one component
+gym env test +entrypoint=resources_servers/your_server \
+  +should_validate_data=true                           # legacy resource-server data contract
+gym env test --all                                     # all server components; expensive
+python3 tests/unit_tests/test_fern_docs_links.py        # Fern internal links
+make docs-check                                        # Fern configuration
 ```
+
+The Fern commands require Node.js 22 or newer; see `fern/README.md` for setup
+and preview instructions.
+
+Use targeted tests for focused changes. The full local commands are appropriate
+when the diff or risk warrants their cost; they are not required for a docs-only
+change.
 
 ### Checks That Run on Every Pull Request
 
 | Check | Workflow | What it enforces |
 |-------|----------|------------------|
-| **Copyright** | `copyright-check.yml` | Every new file has the Apache 2.0 SPDX header (see below). |
-| **Code linting** | `code-linting.yml` | `pre-commit run --all-files` passes for all 8 hooks (see table below). |
-| **Fern docs** | `fern-docs-ci.yml` | `npm run check` in `fern/` validates the docs config. Runs only when a PR touches `fern/**`. |
+| **Copyright** | `copyright-check.yml` | New source files have the Apache 2.0 SPDX header (see below). |
+| **Code linting** | `code-linting.yml` | `pre-commit run --all-files` passes for all configured hooks (see table below). |
+| **Fern docs** | `fern-docs-ci.yml` | Checks internal links and runs `npm run check`; triggered by Fern content, its link test, or the workflow itself. |
 | **Unit tests** | `unit-tests.yml` | Smart change detection selects the test scope, then runs it (see below). |
 
 **Pre-commit hooks** (from `.pre-commit-config.yaml`):
@@ -128,10 +222,10 @@ gym env test --resources-server your_server         # server tests + data valida
 
 Hooks that auto-modify files (`ruff`, `ruff-format`, `add-verified-flag`, `update-readme-table`) may fail the first run while they rewrite files — stage the changes and commit again.
 
-**Every new file must include the Apache 2.0 header:**
+**Every new source file must include the Apache 2.0 header using the comment syntax for that file type:**
 
 ```python
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,39 +241,84 @@ Hooks that auto-modify files (`ruff`, `ruff-format`, `add-verified-flag`, `updat
 # limitations under the License.
 ```
 
-**Smart unit test selection** (`unit-tests.yml`) classifies your changed files and runs only the matching scope:
+The implementation in `.github/actions/classify-changes/action.yml` is
+authoritative. In summary, `unit-tests.yml` selects this scope:
 
 | Changed files | Test scope |
 |---------------|------------|
-| Only `**.md`, `docs/**`, `fern/**`, `LICENSE`, `benchmarks/**` | **Skip** — no tests run |
-| Only `resources_servers/**`, `responses_api_agents/**`, `responses_api_models/**` | **Server-only** — tests run for the changed servers only |
-| Anything else (core library, CI, scripts, and so on) | **Full suite** — all tests run |
+| Only `**.md`, `fern/**`, `LICENSE`, `benchmarks/**` | **CI docs-classified** — unit tests are skipped |
+| Only `resources_servers/**`, `responses_api_agents/**`, `responses_api_models/**` | **Server-only** — core and sandbox coverage plus changed-component tests |
+| Anything else (core library, CI, scripts, and so on) | **Full suite** — core and sandbox coverage plus all 8 server shards |
 
-Priority is `other > server > doc`: a PR touching both a server file and a core file triggers the full suite. When the full suite runs, the server tests are split across **8 parallel shards** with `fail_on_total_and_test_mismatch=true` — this means **every resources server must have at least one test**, or its shard fails.
+Priority is `other > server > doc`: a PR touching both a server file and a core
+file triggers the full suite. The full suite splits resources servers, agent
+servers, and model servers across **8 parallel shards**. Every discovered
+component needs an isolated test suite; missing or failed tests fail the shard.
+With `fail_on_total_and_test_mismatch=true`, CI also rejects modules that cannot
+enter the test set, such as a component missing its `README.md`.
 
-### Checks a New Environment Must Satisfy
+The CI docs-classified bucket includes executable files under `benchmarks/**`.
+When a benchmark preparation script or test changes, run its targeted
+preparation and tests locally even though the path classifier skips unit tests.
+For a server-only change, use
+`gym env test +entrypoint=<resources_servers|responses_api_agents|responses_api_models>/<name>`;
+`--resources-server <name>` is shorthand for resources servers only.
 
-If you are contributing a new resources server (environment), it must pass all of the following before it can merge. Most are enforced inside `gym env test --resources-server your_server` (see `nemo_gym/cli/env.py`):
+### Checks a New Environment or Benchmark Must Satisfy
 
-- **At least one test** — provide `tests/test_app.py`. A server with no tests fails the sharded suite (`fail_on_total_and_test_mismatch=true`).
-- **Copyright header** — on every new file (enforced by `copyright-check.yml`).
-- **`data/example.jsonl`** — must exist with **exactly 5 rows** (typically the first 5 rows of your train dataset).
-- **`data/example_metrics.json`** — must exist and report `"Number of examples": 5`. Generate it with `gym dataset collate "+config_paths=[...]" +output_dirpath=... +mode=example_validation`.
-- **`data/example_rollouts.jsonl`** — must exist with **exactly 5 rollouts** (run your example data through your agent to produce it).
-- **No merge-conflict artifacts** — the `data/` directory must contain no `*conflict*` files.
-- **Config `domain`** — every resources server YAML config must set `domain`.
-- **Dataset `license`** — train and validation datasets must include a `license` field.
-- **`verified: false`** — the `add-verified-flag` hook adds this to your config automatically. Leave it as-is; a maintainer flips it to `true` after baselining (see [Post-Merge](#post-merge-the-verified-flag)).
+New complete environments and benchmarks use the manifest-backed onboarding
+workflow documented in the
+[Environment Contribution Guide](https://docs.nvidia.com/nemo/gym/latest/contribute/environments):
 
-### Post-Merge: Full Test Suite
+```bash
+gym env validate --sync your_environment
+gym env test your_environment
+gym env publish your_environment
+```
 
-**Workflow:** `full-test-suite.yml` — runs on every push to `main` (no change detection; always runs everything):
+Before review, the manifest and its Gym configuration must agree, licensing
+metadata must be complete, the resources server must export a passing verifier
+fixture, and the workload must include at least one representative input. Each
+new component also needs tests for its behavior.
+
+For behavior-changing environment or agent code, run a representative real
+smoke rollout with a model and inspect the agent and verifier behavior. Record
+the evidence in the PR. Saving rollout artifacts in the repository is optional,
+and a full evaluation, reward profile, or training run is not a merge gate for
+training environments. Fixed evaluation benchmarks must follow the reward-
+profiling requirements in the linked Environment Contribution Guide.
+
+Standalone resources-server configs without a workload manifest remain on the
+legacy validation path. Run:
+
+```bash
+gym env test +entrypoint=resources_servers/your_server \
+  +should_validate_data=true
+```
+
+That legacy data validator requires exactly five rows in `data/example.jsonl`,
+`data/example_metrics.json` with `"Number of examples": 5`, and exactly five
+rows in `data/example_rollouts.jsonl`. It also rejects `*conflict*` artifacts
+and requires dataset license fields and a config `domain`. New source files
+need the SPDX header, and the server needs at least one test. New legacy configs
+start with `verified: false`; maintainers change that only after baselining.
+
+The manifest scaffold and the legacy five-row server validator currently use
+different layouts. Do not create duplicate legacy artifacts solely to make a
+manifest workload look like an unmigrated server; report a scaffold/CI mismatch
+on the PR so the underlying validator contract can be corrected.
+
+### Periodic and On-Demand Coverage
+
+`cicd-main.yml` runs periodically and on demand in addition to its mirrored-PR
+and `main` triggers. Its scheduled/manual path adds the configured container
+build and GPU E2E coverage.
+
+**Workflow:** `full-test-suite.yml` — runs every four hours and by manual
+dispatch, with no change detection:
 
 - **Core tests** — the same pytest markers as PR CI (`-m "not sandbox"` then `-m sandbox`).
 - **Server suite** — the same 8-shard run with `fail_on_total_and_test_mismatch=true`.
 - **Wheel install test** — builds the wheel, installs it in a fresh venv against a mock inference endpoint, and runs `ng_help`, `ng_dump_config`, `ng_init_resources_server`, `ng_run`, and `ng_collect_rollouts` end-to-end.
-- **Slack notification** — posts to the team channel if any job fails.
-
-### Post-Merge: The `verified` Flag
-
-New environments merge with `verified: false`. The environment is not surfaced as verified until a maintainer baselines the benchmark and flips `verified: true` in the YAML config. See the [Environment Contribution Guide](https://docs.nvidia.com/nemo/gym/latest/contribute/environments) for baselining requirements.
+- **Slack notification** — reports failures for eligible `main` or release refs;
+  a manually dispatched run may disable notification.

--- a/fern/versions/latest/pages/contribute/agent-skills.mdx
+++ b/fern/versions/latest/pages/contribute/agent-skills.mdx
@@ -32,6 +32,7 @@ Assistants discover skills automatically when they are pointed at a local Gym ch
 | [`nemo-gym-docs`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-docs) | Adding, moving, and removing pages on the Fern docs site |
 | [`nemo-gym-blade-analysis`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-blade-analysis) | BLADE-style benchmark reports from rollout evidence |
 | [`nemo-gym-pivot-datasets`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-pivot-datasets) | Creating and validating pivot datasets from rollout artifacts |
+| [`nemo-gym-pr-checks-and-labels`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-pr-checks-and-labels) | Selecting PR checks, diagnosing CI readiness, and applying Gym's live label taxonomy |
 | [`gh-stack`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/gh-stack) | Stacked pull request workflows with the `gh-stack` CLI extension |
 
 Compatible agents discover skills from the canonical tree directly. Native-path links provide compatibility for agents that require their own directory.

--- a/fern/versions/latest/pages/contribute/agent-skills.mdx
+++ b/fern/versions/latest/pages/contribute/agent-skills.mdx
@@ -32,7 +32,7 @@ Assistants discover skills automatically when they are pointed at a local Gym ch
 | [`nemo-gym-docs`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-docs) | Adding, moving, and removing pages on the Fern docs site |
 | [`nemo-gym-blade-analysis`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-blade-analysis) | BLADE-style benchmark reports from rollout evidence |
 | [`nemo-gym-pivot-datasets`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-pivot-datasets) | Creating and validating pivot datasets from rollout artifacts |
-| [`nemo-gym-pr-checks-and-labels`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-pr-checks-and-labels) | Selecting PR checks, diagnosing CI readiness, and applying Gym's live label taxonomy |
+| [`nemo-gym-pr-checks-and-labels`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/nemo-gym-pr-checks-and-labels) | Checking PR metadata, selecting required checks, diagnosing CI, and applying Gym's live label taxonomy |
 | [`gh-stack`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skills/gh-stack) | Stacked pull request workflows with the `gh-stack` CLI extension |
 
 Compatible agents discover skills from the canonical tree directly. Native-path links provide compatibility for agents that require their own directory.

--- a/fern/versions/latest/pages/contribute/environments/new-environment.mdx
+++ b/fern/versions/latest/pages/contribute/environments/new-environment.mdx
@@ -100,7 +100,7 @@ Fixture execution runs directly in the resources server's dependency environment
 
 ## Guiding Principles
 
-Adding a training environment has the same local correctness requirements as [Adding A Benchmark](/contribute/environments/adding-a-benchmark): its manifest must validate and its verifier fixture must pass. A full evaluation, reward profile, or training run can provide stronger evidence about measurement quality and training utility, but it is optional and is not a publication or merge compute gate.
+Adding a training environment has the same local correctness requirements as [Adding A Benchmark](/contribute/environments/adding-a-benchmark): its manifest must validate and its verifier fixture must pass. Behavior-changing environment or agent work must also run representative real smoke rollouts as required by `AGENTS.md`. A full evaluation, reward profile, or training run can provide stronger evidence about measurement quality and training utility, but it is optional and is not a publication or merge compute gate.
 
 When compute is available, a useful training experiment isolates the environment's effect on the targeted capability. GRPO with NeMo RL, 64 prompts per step, and 16 rollouts per prompt is one starting point; adjust it to the environment and available compute.
 
@@ -130,8 +130,8 @@ Contributing a resources server follows this sequence:
 | 1 | Curate Tasks | Collect or generate training tasks and create example data |
 | 2 | Implementation | Build resources server with verification logic |
 | 3 | Testing | Write and run unit tests |
-| 4 | Example Rollouts | Optionally capture runtime evidence |
-| 5 | Reward Profiling | Optionally inspect reward distribution |
+| 4 | Smoke Rollouts | For behavior changes, run a representative model rollout and inspect agent and verifier behavior |
+| 5 | Reward Profiling | Optionally inspect reward distribution for training environments; benchmarks require profiling |
 | 6 | Training Validation | Optionally test training utility |
 | 7 | Submit PR | Submit pull request with all required information |
 | 8 | Review | Address feedback on the required local checks and contribution metadata |
@@ -162,16 +162,27 @@ Write and run tests for your resources server:
 - At least one test per server is required for PR approval
 - You are responsible for ensuring your tests adequately cover your server's functionality
 
-### 4. Generate Example Rollouts (Optional)
+### 4. Generate Example Rollouts (Required for Behavior Changes)
 
-When a policy endpoint and compute are available, generate example rollouts as additional runtime evidence:
+When environment or agent work changes runtime behavior, configure a model endpoint, run a representative rollout, and inspect the agent and verifier results. For example:
 
-- Document the command used to start your server, for example, `gym env start --resources-server my_server`
-- If useful for review, save representative outputs to `data/example_rollouts.jsonl`
+```bash
+gym env start \
+  --resources-server my_server \
+  --model-type openai_model
 
-This evidence is not required to publish or merge the environment.
+gym eval run --no-serve \
+  --agent your_agent \
+  --input path/to/example.jsonl \
+  --output results/my_server_smoke.jsonl \
+  --limit 1
+```
 
-### 5. Reward Profiling (Optional)
+Document the commands and observed behavior in the PR. For a manifest-backed workload, saving the output under `data/example_rollouts.jsonl` is optional. A standalone legacy resources-server contribution must retain the five-row `data/example_rollouts.jsonl` artifact required by its data validator until that validator is migrated. Metadata-only catalog or manifest changes and docs-only changes do not require model compute.
+
+### 5. Reward Profiling (Optional for Training Environments)
+
+Fixed evaluation benchmarks must follow the reward-profiling requirements in [Adding A Benchmark](/contribute/environments/adding-a-benchmark). For training environments, profiling remains optional:
 
 Run inference to inspect reward distribution:
 
@@ -206,7 +217,7 @@ After submitting your PR:
 2. Address any feedback from reviewers
 3. After approval, maintainers merge the contribution
 
-Reviewers may inspect optional rollout or training evidence when provided, but do not need to reproduce a compute-heavy run for the contribution to merge.
+Reviewers inspect the required smoke-rollout evidence for behavior-changing work and may inspect optional full evaluation or training evidence when provided. They do not need to reproduce a compute-heavy run for the contribution to merge.
 
 ## Recommended Technical Design
 

--- a/tests/unit_tests/test_blade_toolkit.py
+++ b/tests/unit_tests/test_blade_toolkit.py
@@ -26,12 +26,14 @@ CLAUDE_SKILLS = (
     "nemo-gym-debugging",
     "nemo-gym-docs",
     "nemo-gym-pivot-datasets",
+    "nemo-gym-pr-checks-and-labels",
     "nemo-gym-reward-profiling",
 )
 CODEX_COMPATIBILITY_LINKS = (
     "nemo-gym-blade-analysis",
     "nemo-gym-debugging",
     "nemo-gym-pivot-datasets",
+    "nemo-gym-pr-checks-and-labels",
     "nemo-gym-reward-profiling",
 )
 TOOLKIT = REPO_ROOT / ".agents/skills/nemo-gym-blade-analysis/scripts/blade_toolkit.py"


### PR DESCRIPTION
## Summary

This PR establishes repo-wide contributor and AI-agent guidance for Gym:

- documents PR titles, focused changes, simplicity-first code guidance, typing and public-API expectations, logging/error-handling conventions, DCO, and validation handoff in `AGENTS.md` and `CONTRIBUTING.md`
- adds a `nemo-gym-pr-checks-and-labels` skill for affected-file history review, CI/check selection, missing-check diagnosis, and Gym's live label taxonomy
- updates the PR template and contributor docs to request exact validation, compatibility impact, and rollout evidence when applicable
- adds native Claude/Codex skill discovery links and regression coverage

The simplicity guidance distills the core idea from NVIDIA NeMo labs-molt's [`simplicity-first`](https://github.com/NVIDIA-NeMo/labs-molt/tree/main/.claude/skills/simplicity-first) skill directly into Gym's always-loaded code-style rules: prefer the smallest clear solution for current requirements, avoid speculative abstractions, and preserve required behavior.

The guidance adapts only conventions that Gym currently supports. In particular, Gym uses Ruff rather than Black, `area:*` labels rather than Megatron Bridge title prefixes, and does not claim a repository-wide strict mypy or Ruff-docstring CI gate.

Part of #3122.

## Relationship to #3123

This PR is independent of #3123 and can merge first.

- #3123 updates the technical contracts and skills for adding environments, benchmarks, and Fern documentation.
- #3194 defines the more general repository foundation: contribution, PR, code-style, validation, CI, and label guidance.

The PRs overlap in a few documentation and skill-discovery files, so whichever lands second will need a mechanical rebase/conflict resolution. There is no semantic dependency, and reviewing #3123 first is not required.

## What counts as a smoke rollout?

For behavior-changing environment or agent code, a representative real smoke rollout is the smallest model-backed end-to-end run that exercises the changed runtime path--normally one or a few representative tasks. The contributor should inspect the agent output or tool interactions and the verifier result, then record the command/configuration and observed outcome in the PR.

Unit tests, mocked requests, and health checks do not replace this evidence. A full evaluation, reward profile, or training run is not required. Docs-only and metadata-only catalog or manifest changes may record rollouts as N/A.

## Compatibility and benchmark impact

None. This PR changes contributor policy, documentation, repository skills, discovery links, and their tests; it does not change runtime behavior or benchmark results.

## Validation

- Agent Skills structural validation
- `pytest tests/unit_tests/test_skills.py tests/unit_tests/test_blade_toolkit.py -q` -- 26 passed
- `python tests/unit_tests/test_fern_docs_links.py` -- 14/14 passed
- `pre-commit run --all-files`
- `make docs-check` -- 0 errors; redirect validation skipped because Fern authentication was unavailable locally
- `git diff --check`
- exercised the documented PR inspection, check, label, and REST fallback commands against live Gym PRs
- forward-tested the affected-file history workflow against #3127, including the constraint recorded in #2113
- three independent review rounds found no remaining correctness blockers

## Rollouts

N/A. This PR does not change environment or agent runtime behavior.

## Checklist

- [x] Focused change
- [x] Targeted tests and pre-commit pass
- [x] Documentation updated
- [x] DCO sign-off present
