### PR TITLE
fix: expose accurate managed-server readiness

### DIFF
--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -494,8 +494,13 @@ class RunHelper:  # pragma: no cover
         if global_config_dict[DRY_RUN_KEY_NAME]:
             self.wait_for_dry_run_spinup()
         else:
-            self.wait_for_spinup()
-            self.wait_for_model_endpoints(global_config_dict)
+            self.wait_for_server_readiness(global_config_dict)
+
+    def wait_for_server_readiness(self, global_config_dict: DictConfig) -> None:
+        """Mark the head ready only after every managed server and model endpoint is reachable."""
+        self.wait_for_spinup()
+        self.wait_for_model_endpoints(global_config_dict)
+        self._head_server_instance.mark_ready()
 
     def display_server_instance_info(self) -> None:
         if not self._server_instance_display_configs:

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -626,6 +626,7 @@ class BaseServer(BaseModel):
         return server_config
 
     def setup_liveness(self, app: FastAPI) -> None:
+        @app.get("/health", include_in_schema=False)
         @app.get("/", include_in_schema=False)
         async def _liveness():
             return {"status": "ok"}

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -626,6 +626,9 @@ class BaseServer(BaseModel):
         return server_config
 
     def setup_liveness(self, app: FastAPI) -> None:
+        @app.get("/readyz", include_in_schema=False)
+        @app.get("/livez", include_in_schema=False)
+        @app.get("/healthz", include_in_schema=False)
         @app.get("/health", include_in_schema=False)
         @app.get("/", include_in_schema=False)
         async def _liveness():
@@ -1113,10 +1116,13 @@ class HeadServer(BaseServer):
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
 
+        @app.get("/livez", include_in_schema=False)
         @app.get("/", include_in_schema=False)
         async def _liveness():
             return {"status": "ok"}
 
+        @app.get("/readyz", include_in_schema=False)
+        @app.get("/healthz", include_in_schema=False)
         @app.get("/health", include_in_schema=False)
         async def _readiness(response: Response):
             if not self._ready:

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -1106,17 +1106,31 @@ Full body: {json.dumps(exc.body, indent=4)}
 class HeadServer(BaseServer):
     config: BaseServerConfig
     _server_instances: List[dict] = []
+    _ready: bool = PrivateAttr(default=False)
     # Serialized global config returned to clients.
     _cached_yaml: Optional[str] = None
 
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
 
-        self.setup_liveness(app)
+        @app.get("/", include_in_schema=False)
+        async def _liveness():
+            return {"status": "ok"}
+
+        @app.get("/health", include_in_schema=False)
+        async def _readiness(response: Response):
+            if not self._ready:
+                response.status_code = 503
+                return {"status": "starting"}
+            return {"status": "ok"}
+
         app.get("/global_config_dict_yaml")(self.global_config_dict_yaml)
         app.get("/server_instances")(self.get_server_instances)
 
         return app
+
+    def mark_ready(self) -> None:
+        self._ready = True
 
     def get_server_instances(self) -> List[dict]:
         return self._server_instances

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -311,6 +311,43 @@ class TestRunHelperDryRunSpinup:
             runner.wait_for_dry_run_spinup()
 
 
+class TestRunHelperServerReadiness:
+    def test_marks_head_ready_only_after_servers_and_model_endpoints(self) -> None:
+        runner = RunHelper()
+        runner._head_server_instance = MagicMock()
+        events = []
+        runner.wait_for_spinup = MagicMock(side_effect=lambda: events.append("servers"))
+        runner.wait_for_model_endpoints = MagicMock(side_effect=lambda _config: events.append("models"))
+        runner._head_server_instance.mark_ready.side_effect = lambda: events.append("head")
+        config = OmegaConf.create({})
+
+        runner.wait_for_server_readiness(config)
+
+        assert events == ["servers", "models", "head"]
+        runner.wait_for_model_endpoints.assert_called_once_with(config)
+
+    @pytest.mark.parametrize("failing_method", ["wait_for_spinup", "wait_for_model_endpoints"])
+    def test_readiness_failure_leaves_head_health_unready(self, failing_method: str) -> None:
+        from fastapi.testclient import TestClient
+
+        from nemo_gym.config_types import BaseServerConfig
+        from nemo_gym.server_utils import HeadServer
+
+        runner = RunHelper()
+        runner._head_server_instance = HeadServer(config=BaseServerConfig(host="", port=0))
+        runner.wait_for_spinup = MagicMock()
+        runner.wait_for_model_endpoints = MagicMock()
+        getattr(runner, failing_method).side_effect = RuntimeError("readiness failed")
+
+        with TestClient(runner._head_server_instance.setup_webserver()) as client:
+            with raises(RuntimeError, match="readiness failed"):
+                runner.wait_for_server_readiness(OmegaConf.create({}))
+
+            response = client.get("/health")
+            assert response.status_code == 503
+            assert response.json() == {"status": "starting"}
+
+
 class TestRunHelperShutdownReap:
     """RunHelper.shutdown must reap every server subprocess on every exit path."""
 

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -329,19 +329,22 @@ class TestServerUtils:
         head_server = HeadServer(config=BaseServerConfig(host="", port=0))
 
         with TestClient(head_server.setup_webserver()) as client:
-            response = client.get("/")
-            assert response.status_code == 200
-            assert response.json() == {"status": "ok"}
+            for path in ("/", "/livez"):
+                response = client.get(path)
+                assert response.status_code == 200
+                assert response.json() == {"status": "ok"}
 
-            response = client.get("/health")
-            assert response.status_code == 503
-            assert response.json() == {"status": "starting"}
+            for path in ("/health", "/healthz", "/readyz"):
+                response = client.get(path)
+                assert response.status_code == 503
+                assert response.json() == {"status": "starting"}
 
             head_server.mark_ready()
 
-            response = client.get("/health")
-            assert response.status_code == 200
-            assert response.json() == {"status": "ok"}
+            for path in ("/health", "/healthz", "/readyz"):
+                response = client.get(path)
+                assert response.status_code == 200
+                assert response.json() == {"status": "ok"}
 
     async def test_HeadServer_global_config_dict_yaml(self, monkeypatch: MonkeyPatch) -> None:
         global_config_dict = DictConfig({"a": 2})
@@ -562,7 +565,7 @@ class TestServerUtils:
 
         TestSimpleServer.run_webserver()
 
-    def test_setup_liveness_exposes_root_and_health(self) -> None:
+    def test_setup_liveness_exposes_conventional_probe_surface(self) -> None:
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
 
@@ -570,7 +573,7 @@ class TestServerUtils:
         BaseServer.setup_liveness(MagicMock(), app)
 
         with TestClient(app) as client:
-            for path in ("/", "/health"):
+            for path in ("/", "/health", "/healthz", "/livez", "/readyz"):
                 response = client.get(path)
                 assert response.status_code == 200
                 assert response.json() == {"status": "ok"}

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -542,6 +542,19 @@ class TestServerUtils:
 
         TestSimpleServer.run_webserver()
 
+    def test_setup_liveness_exposes_root_and_health(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        BaseServer.setup_liveness(MagicMock(), app)
+
+        with TestClient(app) as client:
+            for path in ("/", "/health"):
+                response = client.get(path)
+                assert response.status_code == 200
+                assert response.json() == {"status": "ok"}
+
     def test_setup_session_middleware_idempotent(self) -> None:
         from fastapi import FastAPI, Request
         from fastapi.testclient import TestClient

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -323,6 +323,26 @@ class TestServerUtils:
         head_server = HeadServer(config=BaseServerConfig(host="", port=0))
         head_server.setup_webserver()
 
+    def test_HeadServer_health_reports_readiness_without_changing_liveness(self) -> None:
+        from fastapi.testclient import TestClient
+
+        head_server = HeadServer(config=BaseServerConfig(host="", port=0))
+
+        with TestClient(head_server.setup_webserver()) as client:
+            response = client.get("/")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}
+
+            response = client.get("/health")
+            assert response.status_code == 503
+            assert response.json() == {"status": "starting"}
+
+            head_server.mark_ready()
+
+            response = client.get("/health")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}
+
     async def test_HeadServer_global_config_dict_yaml(self, monkeypatch: MonkeyPatch) -> None:
         global_config_dict = DictConfig({"a": 2})
         get_global_config_dict_mock = MagicMock()


### PR DESCRIPTION
## What does this PR do?

- Exposes a /health endpoint alongside the existing root liveness endpoint.
- Keeps the managed head server at HTTP 503 while child servers and model endpoints are starting.
- Marks the head server ready only after both readiness phases complete, after which /health returns HTTP 200.

NeMo Evaluator polls /health before creating its adapter proxy. Without this endpoint, the readiness check receives HTTP 404 and eventually times out. The readiness gate also prevents clients from sending work after child ports are published but before those services are actually ready.

## Testing

- 106 tests passed: tests/unit_tests/test_server_utils.py and tests/unit_tests/test_cli.py
- Ruff check and format check passed for all changed files
- pre-commit run --all-files passed

## Checklist

- [x] I have read the contributing guidelines.
- [x] The change is focused; no unrelated edits are included.
- [x] Tests were added and pass locally.
- [x] Pre-commit checks pass locally.
- [x] All commits have DCO sign-off.