### PR TITLE
feat(browsecomp): add Parallel search and extract support

### DIFF
--- a/benchmarks/browsecomp/config.yaml
+++ b/benchmarks/browsecomp/config.yaml
@@ -18,13 +18,15 @@ browsecomp_benchmark_resources_server:
       domain: agent
       debug: false
       # Search/browse backend. Override per-run with
-      # ++...browsecomp_advanced_harness.search_provider=tavily (+ tavily_api_key=[...]).
-      search_provider: exa
+      # search_provider=parallel (plus parallel_api_key=[...] and optional parallel_search_mode).
+      search_provider: ${oc.select:search_provider,exa}
       # Results per query. 10 is the Exa reference value; the Tavily path uses 5.
       max_results: 10
       # Supplied per-run as a sharded key list so concurrent runs do not collide
       # on provider rate limits. Null here; the launcher injects the real shard.
       exa_api_key: ${oc.select:exa_api_key,null}
+      parallel_api_key: ${oc.select:parallel_api_key,null}
+      parallel_search_mode: ${oc.select:parallel_search_mode,advanced}
       # terminal mode: search/browse write pages to a per-session disk workspace
       # and the read-only bash_command tool is exposed for the model to grep/read them.
       workspace: per_session
@@ -40,7 +42,8 @@ browsecomp_benchmark_agent:
   responses_api_agents:
     browsecomp_agent:
       entrypoint: app.py
-      max_steps: 400
+      # Leave tool-call turns uncapped; context resets bound prompt growth independently.
+      max_steps: null
       nudge_steps: true
       max_context_tokens: 196608
       # token-based reset (50k standard)

--- a/resources_servers/browsecomp_advanced_harness/app.py
+++ b/resources_servers/browsecomp_advanced_harness/app.py
@@ -57,11 +57,13 @@ from resources_servers.browsecomp_advanced_harness.judge_prompt import JUDGE_PRO
 
 
 class TavilySearchResourcesServerConfig(BaseResourcesServerConfig):
-    # Search/browse backend. "tavily" (default) or "exa". The chosen provider's
-    # key must be present (validated below). exclude_domains are honored by both.
+    # Search/browse backend. The chosen provider's key must be present (validated below).
+    # exclude_domains are honored by all providers.
     search_provider: str = "tavily"
     tavily_api_key: str | List[str] | None = None
     exa_api_key: str | List[str] | None = None
+    parallel_api_key: str | List[str] | None = None
+    parallel_search_mode: str = "advanced"
     exclude_domains_file_path: str
     use_judge: bool = True  # If False, use regex matching instead of LLM judge
     judge_model_server: Optional[ModelServerRef] = None
@@ -76,7 +78,7 @@ class TavilySearchResourcesServerConfig(BaseResourcesServerConfig):
     bash_timeout_s: float = 60.0  # match the reference harness's _BASH_MAX_DURATION_S
     bash_max_concurrency: int = 64
     max_page_bytes: int = 2_000_000  # cap per-page bytes written to disk
-    # Results returned per search query (both providers). The reference Exa
+    # Results returned per search query (all providers). The reference Exa
     # reference uses 10; its Tavily path (and this harness historically) uses 5.
     max_results: int = 5
 
@@ -86,8 +88,20 @@ class TavilySearchResourcesServerConfig(BaseResourcesServerConfig):
             raise ValueError("tavily_api_key is required when search_provider='tavily'")
         if self.search_provider == "exa" and not self.exa_api_key:
             raise ValueError("exa_api_key is required when search_provider='exa'")
-        if self.search_provider not in ("tavily", "exa"):
-            raise ValueError(f"search_provider must be 'tavily' or 'exa', got {self.search_provider!r}")
+        if self.search_provider == "parallel" and not self.parallel_api_key:
+            raise ValueError("parallel_api_key is required when search_provider='parallel'")
+        if self.search_provider not in ("tavily", "exa", "parallel"):
+            raise ValueError(f"search_provider must be 'tavily', 'exa', or 'parallel', got {self.search_provider!r}")
+        if self.search_provider == "parallel" and self.parallel_search_mode not in (
+            "turbo",
+            "fast",
+            "basic",
+            "advanced",
+        ):
+            raise ValueError(
+                "parallel_search_mode must be 'turbo', 'fast', 'basic', or 'advanced', "
+                f"got {self.parallel_search_mode!r}"
+            )
         return self
 
 
@@ -186,7 +200,7 @@ class JudgeEvaluation(BaseModel):
 
 class TavilySearchSingleAsyncTavilyMetrics(BaseModel):
     function: str  # "search" | "browse"
-    provider: str = "tavily"  # "tavily" | "exa"
+    provider: str = "tavily"  # "tavily" | "exa" | "parallel"
     status: str
     start_time: float
     end_time: float
@@ -396,6 +410,92 @@ class ExaAIOHTTPClient(BaseModel):
     async def get_contents(self, urls: List[str], max_characters: int) -> Dict[str, Any]:
         body = {"urls": list(urls), "text": {"maxCharacters": max_characters}}
         return await self._post("/contents", body)
+
+
+_PARALLEL_SEARCH_MAX_CHARS_PER_RESULT = 2000
+
+
+class ParallelAIOHTTPClient(BaseModel):
+    """Async Parallel Search and Extract client using NeMo Gym's global aiohttp client."""
+
+    headers: Dict[str, str]
+    base_url: str = "https://api.parallel.ai"
+    debug: bool = False
+
+    async def _post(self, endpoint: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        request_kwargs = {
+            "method": "POST",
+            "headers": self.headers,
+            "url": f"{self.base_url}{endpoint}",
+            "data": json.dumps(body),
+        }
+
+        MAX_NUM_TRIES = 3  # mirror the Tavily and Exa clients
+        max_num_tries = MAX_NUM_TRIES
+        tries = 0
+        while tries < max_num_tries:
+            tries += 1
+            response = await request(**request_kwargs)
+
+            if response.status in (401, 403):
+                _abort_on_invalid_api_key("parallel", response.status, (await response.content.read()).decode())
+
+            if response.status in RETRY_ERROR_CODES:
+                rate_limited = response.status in RATE_LIMIT_ERROR_CODES
+                if rate_limited:
+                    max_num_tries += 1
+                _count_provider_retry(response.status)
+                content = (await response.content.read()).decode()
+                tag = "parallel_rate_limit" if rate_limited else "parallel_retry"
+                print(
+                    f"[browsecomp][tool_fail][{tag}] endpoint={endpoint} status={response.status} "
+                    f"try={tries} body={content[:300]}",
+                    flush=True,
+                )
+                await sleep(0.5)
+                continue
+
+            data = await response.json()
+            if self.debug:
+                print(f"Received the following Parallel response: status={response.status}")
+            return data
+
+        await raise_for_status(response)
+
+    async def search(
+        self,
+        query: str,
+        num_results: int,
+        mode: str = "advanced",
+        max_chars_per_result: int = _PARALLEL_SEARCH_MAX_CHARS_PER_RESULT,
+        exclude_domains: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        advanced_settings: Dict[str, Any] = {
+            "max_results": num_results,
+            "excerpt_settings": {"max_chars_per_result": max_chars_per_result},
+        }
+        if exclude_domains:
+            advanced_settings["source_policy"] = {"exclude_domains": list(exclude_domains)}
+        body = {
+            "search_queries": [query],
+            "mode": mode,
+            "advanced_settings": advanced_settings,
+        }
+        return await self._post("/v1/search", body)
+
+    async def extract(
+        self,
+        urls: List[str],
+        max_characters: int,
+        objective: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "urls": list(urls),
+            "advanced_settings": {"full_content": {"max_chars_per_result": max_characters}},
+        }
+        if objective:
+            body["objective"] = objective
+        return await self._post("/v1/extract", body)
 
 
 # ---------------------------------------------------------------------------
@@ -748,6 +848,7 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
 
     _async_tavily_clients: Optional[List[AsyncTavilyClient]] = PrivateAttr(default=None)
     _exa_clients: Optional[List[ExaAIOHTTPClient]] = PrivateAttr(default=None)
+    _parallel_clients: Optional[List[ParallelAIOHTTPClient]] = PrivateAttr(default=None)
     _num_requests: int = 0
     _session_id_to_metrics: Optional[Dict[str, TavilySearchMetrics]] = PrivateAttr(default=None)
     _session_workspaces: Dict[str, "_PageWriter"] = PrivateAttr(default_factory=dict)
@@ -790,6 +891,24 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                 for k in exa_api_keys
             ]
             print(f"Search provider: exa ({len(self._exa_clients)} key(s))")
+
+        # Parallel clients (built only when a Parallel key is configured). One client
+        # per key; round-robined like Tavily and Exa. Native aiohttp REST, no SDK dependency.
+        parallel_api_keys = self.config.parallel_api_key
+        if isinstance(parallel_api_keys, str):
+            parallel_api_keys = [parallel_api_keys]
+        if parallel_api_keys:
+            self._parallel_clients = [
+                ParallelAIOHTTPClient(
+                    headers={"x-api-key": k, "Content-Type": "application/json"},
+                    debug=self.config.debug,
+                )
+                for k in parallel_api_keys
+            ]
+            print(
+                f"Search provider: parallel (mode={self.config.parallel_search_mode}, "
+                f"{len(self._parallel_clients)} key(s))"
+            )
 
         self._session_id_to_metrics = defaultdict(TavilySearchMetrics)
 
@@ -927,6 +1046,11 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
         self._num_requests += 1
         return client
 
+    def _select_parallel_client(self) -> ParallelAIOHTTPClient:
+        client = self._parallel_clients[self._num_requests % len(self._parallel_clients)]
+        self._num_requests += 1
+        return client
+
     def _record_call(
         self, metrics: "TavilySearchMetrics", function: str, provider: str, status: str, start: float
     ) -> None:
@@ -971,6 +1095,40 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
             url = result.get("url", "") or ""
             highlights = result.get("highlights") or []
             snippet = " ... ".join(h for h in highlights if h)
+            entry = f"[Title]: {title}\n[URL]: {url}\n[Snippet]: {snippet}\n"
+            if running_len + len(entry) > max_length:
+                break
+            blocks.append(entry)
+            running_len += len(entry)
+        return "\n".join(blocks)
+
+    async def _parallel_search_one(self, query: str, max_length: int, metrics: "TavilySearchMetrics") -> str:
+        """Parallel search: return result excerpts inline using the Exa-compatible format."""
+        if len(query) > 400:
+            return "Query is too long"
+
+        client = self._select_parallel_client()
+        call_start = time()
+        try:
+            results = await client.search(
+                query,
+                num_results=self.config.max_results,
+                mode=self.config.parallel_search_mode,
+                exclude_domains=self._exclude_domains,
+            )
+        except Exception as e:
+            self._record_call(metrics, "search", "parallel", "error", call_start)
+            print(f"[browsecomp][tool_fail][parallel_search] query={query[:200]!r} error={e}", flush=True)
+            return f"Search failed: {e}"
+        self._record_call(metrics, "search", "parallel", "success", call_start)
+
+        blocks = [f"[Search Query]: {query}"]
+        running_len = len(blocks[0])
+        for result in results.get("results", []):
+            title = result.get("title", "") or ""
+            url = result.get("url", "") or ""
+            excerpts = result.get("excerpts") or []
+            snippet = " ... ".join(excerpt for excerpt in excerpts if excerpt)
             entry = f"[Title]: {title}\n[URL]: {url}\n[Snippet]: {snippet}\n"
             if running_len + len(entry) > max_length:
                 break
@@ -1067,7 +1225,12 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
             return TavilySearchResponse(results_string="Query is none or empty")
 
         max_per_query_length = body.max_total_length // len(body.queries)
-        if self.config.search_provider == "exa":
+        if self.config.search_provider == "parallel":
+            # Parallel returns excerpts inline, including when terminal mode is enabled.
+            results = await asyncio.gather(
+                *[self._parallel_search_one(q, max_per_query_length, metrics) for q in body.queries]
+            )
+        elif self.config.search_provider == "exa":
             # Exa: highlights-only, always inline (no disk pages, even in terminal mode).
             results = await asyncio.gather(
                 *[self._exa_search_one(q, max_per_query_length, metrics) for q in body.queries]
@@ -1105,7 +1268,31 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
         # fetch full page content (provider-specific); normalize to a list of
         # {url, raw_content} so the shared disk/inline formatting below is provider-agnostic.
         start_time = time()
-        if self.config.search_provider == "exa":
+        if self.config.search_provider == "parallel":
+            parallel_client = self._select_parallel_client()
+            print(
+                f"[parallel_call_begin function=extract n_urls={len(urls)} goal={(body.goal or '')[:80]!r}]",
+                flush=True,
+            )
+            try:
+                raw = await parallel_client.extract(
+                    urls=urls,
+                    max_characters=max_per_url_length,
+                    objective=body.goal,
+                )
+            except Exception as e:
+                self._record_call(metrics, "browse", "parallel", "error", start_time)
+                print(f"[browsecomp][tool_fail][parallel_extract] urls={urls} error={e}", flush=True)
+                return BrowseResponse(results_string=f"Failed to extract content: {e}")
+            self._record_call(metrics, "browse", "parallel", "success", start_time)
+            result_list = [
+                {
+                    "url": result.get("url", "") or "",
+                    "raw_content": result.get("full_content") or " ... ".join(result.get("excerpts") or []) or "",
+                }
+                for result in raw.get("results", [])
+            ]
+        elif self.config.search_provider == "exa":
             exa_client = self._select_exa_client()
             print(f"[exa_call_begin function=browse n_urls={len(urls)} goal={(body.goal or '')[:80]!r}]", flush=True)
             try:

--- a/resources_servers/browsecomp_advanced_harness/configs/browsecomp_advanced_harness.yaml
+++ b/resources_servers/browsecomp_advanced_harness/configs/browsecomp_advanced_harness.yaml
@@ -5,7 +5,12 @@ browsecomp_advanced_harness_resources_server:
       entrypoint: app.py
       domain: agent
       debug: false
-      tavily_api_key: ${tavily_api_key}
+      search_provider: ${oc.select:search_provider,tavily}
+      tavily_api_key: ${oc.select:tavily_api_key,null}
+      exa_api_key: ${oc.select:exa_api_key,null}
+      parallel_api_key: ${oc.select:parallel_api_key,null}
+      parallel_search_mode: ${oc.select:parallel_search_mode,advanced}
+      max_results: ${oc.select:max_results,5}
       exclude_domains_file_path: ${exclude_domains_file_path}
       use_judge: true
       judge_model_server:

--- a/resources_servers/browsecomp_advanced_harness/tests/test_parallel_provider.py
+++ b/resources_servers/browsecomp_advanced_harness/tests/test_parallel_provider.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Parallel Search and Extract provider."""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest import fixture
+
+import resources_servers.browsecomp_advanced_harness.app as app_module
+from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
+from resources_servers.browsecomp_advanced_harness.app import (
+    BrowseRequest,
+    ParallelAIOHTTPClient,
+    TavilySearchRequest,
+    TavilySearchResourcesServer,
+    TavilySearchResourcesServerConfig,
+)
+
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_DUMMY_EXCLUDE_DOMAINS_FILE = os.path.join(_TEST_DIR, "dummy_exclude_domains_file.json")
+
+
+def _http_response(status: int, body: dict):
+    response = MagicMock()
+    response.status = status
+    response.content.read = AsyncMock(return_value=json.dumps(body).encode())
+    response.json = AsyncMock(return_value=body)
+    return response
+
+
+@fixture(autouse=True)
+def _clear_retry_counts():
+    app_module._PROVIDER_RETRY_COUNTS.set(None)
+    yield
+    app_module._PROVIDER_RETRY_COUNTS.set(None)
+
+
+class TestParallelProvider:
+    @fixture
+    def config(self) -> TavilySearchResourcesServerConfig:
+        return TavilySearchResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            search_provider="parallel",
+            parallel_api_key="test_parallel_key",  # pragma: allowlist secret
+            parallel_search_mode="fast",
+            exclude_domains_file_path=_DUMMY_EXCLUDE_DOMAINS_FILE,
+        )
+
+    @fixture
+    def server(self, config: TavilySearchResourcesServerConfig) -> TavilySearchResourcesServer:
+        return TavilySearchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def _req(self) -> MagicMock:
+        request = MagicMock()
+        request.session = {SESSION_ID_KEY: "test_session_id"}
+        return request
+
+    def test_config_requires_parallel_key(self) -> None:
+        with pytest.raises(ValueError, match="parallel_api_key"):
+            TavilySearchResourcesServerConfig(
+                host="0.0.0.0",
+                port=8080,
+                entrypoint="",
+                name="",
+                search_provider="parallel",
+                exclude_domains_file_path=_DUMMY_EXCLUDE_DOMAINS_FILE,
+            )
+
+    def test_config_rejects_unknown_parallel_mode(self) -> None:
+        with pytest.raises(ValueError, match="parallel_search_mode"):
+            TavilySearchResourcesServerConfig(
+                host="0.0.0.0",
+                port=8080,
+                entrypoint="",
+                name="",
+                search_provider="parallel",
+                parallel_api_key="test_parallel_key",  # pragma: allowlist secret
+                parallel_search_mode="unknown",
+                exclude_domains_file_path=_DUMMY_EXCLUDE_DOMAINS_FILE,
+            )
+
+    def test_parallel_keys_round_robin(self, config: TavilySearchResourcesServerConfig) -> None:
+        config.parallel_api_key = ["key_one", "key_two"]  # pragma: allowlist secret
+        server = TavilySearchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+        assert server._select_parallel_client().headers["x-api-key"] == "key_one"
+        assert server._select_parallel_client().headers["x-api-key"] == "key_two"
+        assert server._select_parallel_client().headers["x-api-key"] == "key_one"
+
+    async def test_search_request_sets_excerpt_cap(self, monkeypatch) -> None:
+        client = ParallelAIOHTTPClient(headers={"x-api-key": "test"})  # pragma: allowlist secret
+        fake_request = AsyncMock(return_value=_http_response(200, {"results": []}))
+        monkeypatch.setattr(app_module, "request", fake_request)
+
+        await client.search("who won", num_results=10, mode="fast", exclude_domains=["example.com"])
+
+        request_body = json.loads(fake_request.await_args.kwargs["data"])
+        assert fake_request.await_args.kwargs["url"] == "https://api.parallel.ai/v1/search"
+        assert request_body == {
+            "search_queries": ["who won"],
+            "mode": "fast",
+            "advanced_settings": {
+                "max_results": 10,
+                "excerpt_settings": {"max_chars_per_result": 2000},
+                "source_policy": {"exclude_domains": ["example.com"]},
+            },
+        }
+
+    async def test_extract_request_sets_full_content_cap(self, monkeypatch) -> None:
+        client = ParallelAIOHTTPClient(headers={"x-api-key": "test"})  # pragma: allowlist secret
+        fake_request = AsyncMock(return_value=_http_response(200, {"results": []}))
+        monkeypatch.setattr(app_module, "request", fake_request)
+
+        await client.extract(
+            ["https://example.com"],
+            max_characters=10000,
+            objective="find the answer",
+        )
+
+        request_body = json.loads(fake_request.await_args.kwargs["data"])
+        assert fake_request.await_args.kwargs["url"] == "https://api.parallel.ai/v1/extract"
+        assert request_body == {
+            "urls": ["https://example.com"],
+            "advanced_settings": {"full_content": {"max_chars_per_result": 10000}},
+            "objective": "find the answer",
+        }
+
+    async def test_search_formats_parallel_excerpts(self, server: TavilySearchResourcesServer) -> None:
+        parallel = MagicMock()
+        parallel.search = AsyncMock(
+            return_value={
+                "results": [
+                    {
+                        "title": "Result title",
+                        "url": "https://example.com/result",
+                        "excerpts": ["first", "second"],
+                    }
+                ]
+            }
+        )
+        server._parallel_clients = [parallel]
+
+        response = await server.search(self._req(), TavilySearchRequest(queries=["who won"]))
+
+        parallel.search.assert_awaited_once_with(
+            "who won",
+            num_results=5,
+            mode="fast",
+            exclude_domains=["blacklisteddomain.com"],
+        )
+        assert "[Search Query]: who won" in response.results_string
+        assert "[Title]: Result title" in response.results_string
+        assert "[URL]: https://example.com/result" in response.results_string
+        assert "[Snippet]: first ... second" in response.results_string
+
+    async def test_search_failure_is_returned_to_model(self, server: TavilySearchResourcesServer) -> None:
+        parallel = MagicMock()
+        parallel.search = AsyncMock(side_effect=RuntimeError("search failed"))
+        server._parallel_clients = [parallel]
+
+        response = await server.search(self._req(), TavilySearchRequest(queries=["who won"]))
+
+        assert response.results_string == "Search failed: search failed"
+        [record] = server._session_id_to_metrics["test_session_id"].async_tavily_calls
+        assert record.function == "search"
+        assert record.provider == "parallel"
+        assert record.status == "error"
+
+    async def test_browse_uses_parallel_full_content(self, server: TavilySearchResourcesServer) -> None:
+        parallel = MagicMock()
+        parallel.extract = AsyncMock(
+            return_value={"results": [{"url": "https://example.com", "full_content": "FULL PAGE"}]}
+        )
+        server._parallel_clients = [parallel]
+
+        response = await server.browse(
+            self._req(), BrowseRequest(urls=["https://example.com"], goal="find the answer")
+        )
+
+        parallel.extract.assert_awaited_once_with(
+            urls=["https://example.com"],
+            max_characters=30000,
+            objective="find the answer",
+        )
+        assert "[URL]: https://example.com" in response.results_string
+        assert "FULL PAGE" in response.results_string
+        records = server._session_id_to_metrics["test_session_id"].async_tavily_calls
+        assert len(records) == 1
+        assert records[0].function == "browse"
+        assert records[0].provider == "parallel"
+
+    async def test_browse_failure_is_returned_to_model(self, server: TavilySearchResourcesServer) -> None:
+        parallel = MagicMock()
+        parallel.extract = AsyncMock(side_effect=RuntimeError("extract failed"))
+        server._parallel_clients = [parallel]
+
+        response = await server.browse(self._req(), BrowseRequest(urls=["https://example.com"]))
+
+        assert response.results_string == "Failed to extract content: extract failed"
+        [record] = server._session_id_to_metrics["test_session_id"].async_tavily_calls
+        assert record.function == "browse"
+        assert record.provider == "parallel"
+        assert record.status == "error"
+
+    async def test_parallel_429_is_counted(self, monkeypatch) -> None:
+        client = ParallelAIOHTTPClient(headers={})
+        fake_request = AsyncMock(side_effect=[_http_response(429, {}), _http_response(200, {"results": []})])
+        monkeypatch.setattr(app_module, "request", fake_request)
+
+        await client.search("q", num_results=5)
+
+        assert app_module._PROVIDER_RETRY_COUNTS.get() == {
+            "num_429_retries": 1,
+            "num_other_retries": 0,
+        }

--- a/responses_api_agents/browsecomp_agent/app.py
+++ b/responses_api_agents/browsecomp_agent/app.py
@@ -140,7 +140,8 @@ _ANSWER_COMMIT_RE = re.compile(
 class BrowsecompAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
-    max_steps: int = 400
+    # Optional safety limit on model turns. None leaves the number of tool-call turns uncapped.
+    max_steps: Optional[int] = None
     keep_rounds: int = 9999
     nudge_steps: bool = True
     max_context_tokens: int = 196608
@@ -570,7 +571,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
                             f"status={api_response.status} body={tool_output[:300]}",
                             flush=True,
                         )
-                if self.config.nudge_steps:
+                if self.config.nudge_steps and self.config.max_steps is not None:
                     turns_left = self.config.max_steps - step
                     tool_output += "\n\n[%d turns remaining out of %d]" % (turns_left, self.config.max_steps)
 
@@ -593,7 +594,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
                     full_trajectory[-1] = new_outputs[-1]
 
             # --- Nudge the model at milestone steps ---
-            if self.config.nudge_steps and all_fn_calls:
+            if self.config.nudge_steps and self.config.max_steps is not None and all_fn_calls:
                 quarter = self.config.max_steps // 4
                 half = self.config.max_steps // 2
                 near_end = int(self.config.max_steps * 0.875)

--- a/responses_api_agents/browsecomp_agent/tests/test_app.py
+++ b/responses_api_agents/browsecomp_agent/tests/test_app.py
@@ -120,7 +120,7 @@ class TestApp:
 
     def test_config_defaults(self) -> None:
         config = _make_config()
-        assert config.max_steps == 400
+        assert config.max_steps is None
         assert config.keep_rounds == 9999
         assert config.nudge_steps is True
         assert config.max_context_tokens == 196608
@@ -277,6 +277,8 @@ class TestApp:
 
         assert agent.server_client.post.call_count == 3  # model + tool + model
         assert result.output[-1].content[0].text == "Final Answer: Paris"
+        second_model_body = agent.server_client.post.call_args_list[-1].kwargs["json"]
+        assert "turns remaining" not in second_model_body.input[-1].output
 
     async def test_responses_respects_max_steps(self) -> None:
         """Agent should stop after max_steps even if no final answer is given."""


### PR DESCRIPTION
## What does this PR do?

Adds Parallel Search and Extract as an optional provider for the existing BrowseComp advanced harness.

### Scope

- Adds a native aiohttp-based Parallel client using NeMo Gym's shared `nemo_gym.server_utils.request()` path.
- Maps BrowseComp `search` calls to Parallel Search (`/v1/search`) and `browse` calls to Parallel Extract (`/v1/extract`).
- Supports Parallel API-key configuration, search modes, provider selection, retry/error metrics, and round-robin rotation across multiple keys.
- Keeps the existing Exa benchmark default while allowing Parallel to be selected through Hydra overrides.
- Removes the agent's total tool-call/step cap by making `max_steps` optional and setting the BrowseComp benchmark value to `null`. Explicit finite `max_steps` overrides remain supported.
- Retains the existing character and response-size limits, including the per-search-result excerpt cap and per-request total-length budget.
- Adds focused unit coverage for request mapping, response formatting, retries, failures, metrics, key rotation, and uncapped agent behavior.

The provider mapping follows the general approach in [shapleyai/small-language-model#15](https://github.com/shapleyai/small-language-model/pull/15), scoped to the existing NeMo Gym harness.

### Validation

- `pytest resources_servers/browsecomp_advanced_harness/tests responses_api_agents/browsecomp_agent/tests -x` — 158 passed
- `pre-commit run --all-files` — passed
- YAML configuration parsing — passed
- Live Parallel smoke test — Search returned results and Extract returned full content through the new client

This is a draft because a model-driven BrowseComp rollout is still pending; no model endpoint credentials are configured in the current environment.

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
