### PR TITLE
feat(benchmarks): remove the dataset-level agent pin

### DIFF
--- a/nemo_gym/benchmarks.py
+++ b/nemo_gym/benchmarks.py
@@ -108,7 +108,7 @@ class BenchmarkConfig(BaseModel):
         dataset = datasets[0]
 
         try:
-            agent_name = resolve_dataset_agent(global_config_dict, declaring_instance_names[0], pin=dataset.agent)
+            agent_name = resolve_dataset_agent(global_config_dict, declaring_instance_names[0])
         except ConfigError as e:
             raise ConfigError(f"Benchmark config {path}: dataset {dataset.name!r}: {e}") from e
 

--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -258,7 +258,7 @@ def prepare_benchmark() -> None:
         dataset = datasets[0]
 
         try:
-            agent_name = resolve_dataset_agent(global_config_dict, str(server_instance_name), pin=dataset.agent)
+            agent_name = resolve_dataset_agent(global_config_dict, str(server_instance_name))
         except ConfigError as e:
             raise ConfigError(f"Benchmark dataset {dataset.name!r}: {e}") from e
 

--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -440,6 +440,19 @@ class HuggingFaceDatasetSource(BaseModel):
 DatasetSource = Annotated[Union[GitlabDatasetSource, HuggingFaceDatasetSource], Field(discriminator="type")]
 
 
+def _reject_dataset_agent_pin(data: Any) -> Any:
+    """A dataset entry names no agent. Rows route to the agent bound to the declaring resources server
+    (or to the declaring agent); a config where several agents share one resources server picks the
+    harness with `fan_out`, `+agent_map={<rs>: <agent>}`, or by declaring the dataset on the agent."""
+    if isinstance(data, dict) and "agent" in data:
+        raise ValueError(
+            "dataset entries do not take an `agent:` key. Rows are dispatched to the agent that references the "
+            "declaring resources server; when several do, use `fan_out`, pass `+agent_map={<rs>: <agent>}`, or "
+            "declare the dataset on the agent."
+        )
+    return data
+
+
 class DatasetConfig(BaseModel):
     name: str
     type: DatasetType
@@ -465,6 +478,8 @@ class DatasetConfig(BaseModel):
             Literal["GNU General Public License v3.0"],
         ]
     ] = None
+
+    _reject_agent_pin = model_validator(mode="before")(_reject_dataset_agent_pin)
 
     @model_validator(mode="after")
     def check_train_validation_sets(self) -> "DatasetConfig":
@@ -537,16 +552,8 @@ class BenchmarkDatasetConfig(BaseModel):
     prepare_script: Path
     prompt_config: Optional[Path] = None
     num_repeats: int = Field(default=1, ge=1)
-    agent: Optional[str] = Field(
-        default=None,
-        description=(
-            "Agent instance that runs this benchmark (a top-level key of the merged config). "
-            "Only needed when the config is ambiguous: the dataset is declared on a resources "
-            "server that several agents reference. The pin must name one of those agents — rows "
-            "are dispatched along the agent -> resources server edge, so any other value is a "
-            "config error. Unambiguous configs resolve without it."
-        ),
-    )
+
+    _reject_agent_pin = model_validator(mode="before")(_reject_dataset_agent_pin)
 
 
 ########################################

--- a/nemo_gym/environment/scaffold.py
+++ b/nemo_gym/environment/scaffold.py
@@ -279,9 +279,8 @@ def _manifest(composition: _Composition) -> EnvironmentManifest:
 def _asset_config(composition: _Composition) -> str:
     # Datasets are declared on the resources server (which defines what the rows mean and how
     # they are scored), never on the agent — the agent is a run-time choice. The scaffolded
-    # config has exactly one agent referencing the resources server, so benchmark datasets
-    # resolve their harness from that edge; the dataset-level `agent:` key stays reserved for
-    # genuinely ambiguous configs.
+    # config has exactly one agent referencing the resources server, so datasets resolve their
+    # harness from that edge.
     dataset_dict = composition.dataset.model_dump(mode="json", exclude_none=True)
     agent_config: dict[str, Any] = {
         "resources_server": {"type": "resources_servers", "name": composition.resource_instance},

--- a/nemo_gym/environment/validation.py
+++ b/nemo_gym/environment/validation.py
@@ -33,7 +33,6 @@ from nemo_gym.environment.manifest import (
 from nemo_gym.global_config import (
     GlobalConfigDictParser,
     GlobalConfigDictParserConfig,
-    dataset_agent_pins,
     resolve_dataset_agent,
 )
 from nemo_gym.prompt import apply_prompt_to_row, load_prompt_config, validate_prompt_compatibility
@@ -151,14 +150,8 @@ def _select_dataset_agent(agents: list[Any]) -> Any:
 
 def _resolve_dataset_owner_agent(resolved: DictConfig, owner_instance_name: str) -> str:
     """The agent rollout dispatch routes ``owner_instance_name``'s datasets to (validation-time check)."""
-    pins = dataset_agent_pins(resolved, owner_instance_name)
-    if len(pins) > 1:
-        raise EnvironmentValidationError(
-            f"Datasets on {owner_instance_name!r} pin conflicting agents ({sorted(pins)}); rows route by the "
-            "declaring instance alone, so all pins on one instance must agree."
-        )
     try:
-        return resolve_dataset_agent(resolved, owner_instance_name, pin=pins[0] if pins else None)
+        return resolve_dataset_agent(resolved, owner_instance_name)
     except ConfigError as e:
         raise EnvironmentValidationError(f"Datasets on {owner_instance_name!r}: {e}") from e
 
@@ -203,8 +196,6 @@ def _resolve_manifest_composition(config_path: Path) -> ResolvedComposition:
             )
     else:
         selected_agent = _select_dataset_agent(agents)
-        # Rejects an `agent:` pin naming anyone but the declaring agent (dispatch would ignore it).
-        _resolve_dataset_owner_agent(resolved, selected_agent.name)
 
     agent_server = _implementation_name(selected_agent)
     agent_config = selected_agent.get_inner_run_server_config_dict()

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -1633,58 +1633,24 @@ def agents_by_resources_server(global_config_dict: DictConfig) -> Dict[str, List
     return result
 
 
-def dataset_agent_pins(global_config_dict: DictConfig, instance_name: str) -> List[str]:
-    """Distinct dataset-level ``agent:`` pins declared by one server instance, in declaration order."""
-    try:
-        inner = get_first_server_config_dict(global_config_dict, instance_name)
-    except Exception:
-        return []
-    pins: List[str] = []
-    for dataset in inner.get("datasets") or []:
-        if not isinstance(dataset, (dict, DictConfig)):
-            continue
-        pin = dataset.get("agent")
-        if isinstance(pin, str) and pin not in pins:
-            pins.append(pin)
-    return pins
-
-
-def resolve_dataset_agent(
-    global_config_dict: DictConfig, declaring_instance_name: str, pin: Optional[str] = None
-) -> str:
+def resolve_dataset_agent(global_config_dict: DictConfig, declaring_instance_name: str) -> str:
     """Resolve the agent that runs a dataset declared by ``declaring_instance_name``.
 
     Single source of truth for dataset -> agent routing, shared by benchmark discovery,
     preparation, manifest validation, and rollout dispatch, so they can never disagree.
-    First hit wins:
 
-    1. ``pin`` (the dataset's ``agent:`` key) — validated: it must name the declaring agent
-       itself, or an agent referencing the declaring resources server. Anything else is a hard
-       error, never a silent re-route (rows carry only the declaring instance name).
-    2. The declaring agent block itself.
-    3. The unique agent referencing the declaring resources server; zero or 2+ is a hard error.
+    1. A dataset declared on an agent block runs on that agent.
+    2. A dataset declared on a resources server runs on the unique agent referencing it.
+       Zero or 2+ referencing agents is a hard error: the config has to say which harness
+       runs the rows (``fan_out`` to run all of them, ``agent_map`` for a one-off, or declare
+       the dataset on the agent). Rows carry only the declaring instance name, so nothing
+       downstream can disambiguate silently.
     """
     block = global_config_dict.get(declaring_instance_name)
-    is_agent = isinstance(block, DictConfig) and "responses_api_agents" in block
-
-    if is_agent:
-        if pin is not None and pin != declaring_instance_name:
-            raise ConfigError(
-                f"dataset declared by agent {declaring_instance_name!r} pins agent {pin!r}, but rows are "
-                f"dispatched to the declaring agent, so the pin would silently not apply. Drop the `agent:` "
-                "key, or declare the dataset on the resources server and pin there."
-            )
+    if isinstance(block, DictConfig) and "responses_api_agents" in block:
         return str(declaring_instance_name)
 
     candidates = agents_by_resources_server(global_config_dict).get(str(declaring_instance_name), [])
-    if pin is not None:
-        if pin not in candidates:
-            raise ConfigError(
-                f"the dataset pins agent {pin!r}, but no agent of that name references resources server "
-                f"{declaring_instance_name!r} (rows are dispatched along the agent -> resources server edge). "
-                f"Agents referencing it: {sorted(candidates) if candidates else 'none'}."
-            )
-        return pin
     if not candidates:
         raise ConfigError(
             f"no agent in the running config references resources server {declaring_instance_name!r}. "
@@ -1692,9 +1658,9 @@ def resolve_dataset_agent(
         )
     if len(candidates) > 1:
         raise ConfigError(
-            f"{len(candidates)} agents reference this resources server ({sorted(candidates)}). "
-            "Pin the harness with an `agent:` key on the dataset declaration, or pass "
-            f"+agent_map={{{declaring_instance_name}: <agent>}} to pick one at run time."
+            f"{len(candidates)} agents reference this resources server ({sorted(candidates)}), so the rows "
+            f"have no single harness. Pass +agent_map={{{declaring_instance_name}: <agent>}} to pick one at "
+            f"run time, add a `fan_out` entry to run all of them, or declare the dataset on the agent."
         )
     return candidates[0]
 

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -64,7 +64,6 @@ from nemo_gym.global_config import (
     TASK_INDEX_KEY_NAME,
     TASK_SOURCE_KEY_NAME,
     allowed_agents_for,
-    dataset_agent_pins,
     get_global_config_dict,
     pairing_override_enabled,
     resolve_dataset_agent,
@@ -1756,9 +1755,9 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
 
         task_source names the config instance that declared the row's dataset. Resolution is
         :func:`~nemo_gym.global_config.resolve_dataset_agent` — the same rules benchmark
-        discovery uses, so dispatch can never disagree with the listing. Conflicting `agent:`
-        pins across one instance's datasets are a hard error (rows carry only the instance
-        name), as are unknown/non-routable instances; +agent_map is the disambiguator.
+        discovery uses, so dispatch can never disagree with the listing. Unknown or
+        non-routable instances are a hard error, as is a resources server shared by several
+        agents (rows carry only the instance name); +agent_map is the run-time disambiguator.
 
         Rows that already have an agent_ref are left untouched, so this is a no-op on legacy
         datasets and on already-resolved (materialized) rows. Runs before any dispatch.
@@ -1798,15 +1797,8 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
             elif not isinstance(block, DictConfig):
                 errors.append(f"{ts!r}: not a server instance")
             elif "responses_api_agents" in block or "resources_servers" in block:
-                pins = dataset_agent_pins(global_config_dict, ts)
-                if len(pins) > 1:
-                    errors.append(
-                        f"{ts!r}: its datasets pin conflicting agents ({sorted(pins)}), which task_source "
-                        f"alone cannot tell apart; pass +agent_map={{{ts}: <agent>}} to pick one"
-                    )
-                    continue
                 try:
-                    resolution[ts] = resolve_dataset_agent(global_config_dict, ts, pin=pins[0] if pins else None)
+                    resolution[ts] = resolve_dataset_agent(global_config_dict, ts)
                 except ConfigError as e:
                     errors.append(f"{ts!r}: {e}")
             else:

--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -702,9 +702,7 @@ class TrainDataProcessor(BaseModel):
                 aggregate_metrics = state.metrics.aggregate()
 
                 aggregate_metrics_dict = aggregate_metrics.model_dump(mode="json", by_alias=True)
-                # The agent: pin is routing config, not dataset identity; excluding it keeps
-                # pre-pin metrics sidecars valid (no conflict churn from the decoupling).
-                aggregate_metrics_dict = d.model_dump(mode="json", exclude={"agent"}) | aggregate_metrics_dict
+                aggregate_metrics_dict = d.model_dump(mode="json") | aggregate_metrics_dict
 
                 data_fpath = Path(d.jsonl_fpath)
                 metrics_fpath = data_fpath.with_name(f"{data_fpath.stem}_metrics.json")
@@ -917,9 +915,7 @@ This could be due to a change in how metrics are calculated, leading to outdated
                 None,
             )
             if d is not None:
-                # The agent: pin is routing config, not dataset identity; excluding it keeps
-                # pre-pin metrics sidecars valid (no conflict churn from the decoupling).
-                aggregate_metrics_dict = d.model_dump(mode="json", exclude={"agent"}) | aggregate_metrics_dict
+                aggregate_metrics_dict = d.model_dump(mode="json") | aggregate_metrics_dict
 
             parent = Path(config.output_dirpath)
             parent.mkdir(exist_ok=True, parents=True)

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -598,8 +598,8 @@ class TestPrepareBenchmark:
 
 
 class TestBenchmarkAgentResolution:
-    """Pins how a benchmark finds its agent (dataset-decoupling): explicit `agent:` pin >
-    declaring agent block > unique agent referencing the declaring resources server."""
+    """Pins how a benchmark finds its agent (dataset-decoupling): the declaring agent block, else
+    the unique agent referencing the declaring resources server. There is no per-dataset override."""
 
     def _benchmark_dataset(self, **extra):
         return {
@@ -624,34 +624,10 @@ class TestBenchmarkAgentResolution:
             path=Path("bench/config.yaml"), initial_config_dict=OmegaConf.create(top_level), strict=False
         )
 
-    def test_declaring_agent_block_still_wins_without_pin(self) -> None:
+    def test_declaring_agent_block_wins(self) -> None:
         cfg = self._config(
             my_agent={
                 "responses_api_agents": {"impl": {"entrypoint": "app.py", "datasets": [self._benchmark_dataset()]}}
-            }
-        )
-        assert cfg.agent_name == "my_agent"
-
-    def test_agent_pin_on_agent_declared_dataset_must_name_the_declarer(self) -> None:
-        """Dispatch routes rows to the declaring agent, so a pin elsewhere would silently not apply."""
-        from nemo_gym.config_types import ConfigError
-
-        with pytest.raises(ConfigError, match="the pin would silently not apply"):
-            self._config(
-                my_agent={
-                    "responses_api_agents": {
-                        "impl": {"entrypoint": "app.py", "datasets": [self._benchmark_dataset(agent="other_agent")]}
-                    }
-                },
-                other_agent={"responses_api_agents": {"impl": {"entrypoint": "app.py"}}},
-            )
-
-    def test_redundant_agent_pin_naming_the_declarer_is_allowed(self) -> None:
-        cfg = self._config(
-            my_agent={
-                "responses_api_agents": {
-                    "impl": {"entrypoint": "app.py", "datasets": [self._benchmark_dataset(agent="my_agent")]}
-                }
             }
         )
         assert cfg.agent_name == "my_agent"
@@ -667,10 +643,12 @@ class TestBenchmarkAgentResolution:
         )
         assert cfg.agent_name == "my_agent"
 
-    def test_rs_declared_dataset_with_two_agents_requires_pin(self) -> None:
+    def test_rs_declared_dataset_with_two_agents_is_an_error(self) -> None:
+        """Two harnesses on one verifier: the config must choose (agent_map / fan_out / declare on the
+        agent). Nothing on the dataset entry can pick one."""
         from nemo_gym.config_types import ConfigError
 
-        with pytest.raises(ConfigError, match="Pin the harness with an `agent:` key"):
+        with pytest.raises(ConfigError, match=r"2 agents reference this resources server.*no single harness"):
             self._config(
                 my_rs={
                     "resources_servers": {
@@ -681,65 +659,12 @@ class TestBenchmarkAgentResolution:
                 agent_b=self._agent("my_rs"),
             )
 
-    def test_rs_declared_dataset_with_pin_needs_no_inversion(self) -> None:
-        cfg = self._config(
-            my_rs={
-                "resources_servers": {
-                    "impl": {
-                        "entrypoint": "app.py",
-                        "domain": "other",
-                        "datasets": [self._benchmark_dataset(agent="agent_b")],
-                    }
-                }
-            },
-            agent_a=self._agent("my_rs"),
-            agent_b=self._agent("my_rs"),
-        )
-        assert cfg.agent_name == "agent_b"
 
-    def test_rs_declared_pin_must_reference_the_declaring_rs(self) -> None:
-        """A pin naming an agent wired to a different RS would list one agent and run another."""
-        from nemo_gym.config_types import ConfigError
+class TestDiscoveryCollateRolloutAgree:
+    """The agent discovery resolves for a benchmark is the agent rollout dispatch routes its
+    collated rows to — one resolver, so the listing and the run can never disagree."""
 
-        with pytest.raises(ConfigError, match="no agent of that name references resources server 'my_rs'"):
-            self._config(
-                my_rs={
-                    "resources_servers": {
-                        "impl": {
-                            "entrypoint": "app.py",
-                            "domain": "other",
-                            "datasets": [self._benchmark_dataset(agent="agent_b")],
-                        }
-                    }
-                },
-                some_other_rs={"resources_servers": {"impl": {"entrypoint": "app.py", "domain": "other"}}},
-                agent_a=self._agent("my_rs"),
-                agent_b=self._agent("some_other_rs"),
-            )
-
-    def test_rs_declared_pin_naming_unknown_agent_errors(self) -> None:
-        from nemo_gym.config_types import ConfigError
-
-        with pytest.raises(ConfigError, match="pins agent 'ghost'"):
-            self._config(
-                my_rs={
-                    "resources_servers": {
-                        "impl": {
-                            "entrypoint": "app.py",
-                            "domain": "other",
-                            "datasets": [self._benchmark_dataset(agent="ghost")],
-                        }
-                    }
-                },
-                agent_a=self._agent("my_rs"),
-            )
-
-
-class TestAgentPinDiscoveryCollateRollout:
-    """The agent discovery resolves for a pinned benchmark is the agent rollout dispatch routes
-    its collated rows to (previously the pin was honored at discovery only)."""
-
-    def test_pin_survives_discovery_collate_and_rollout(self, tmp_path: Path, monkeypatch) -> None:
+    def test_resolution_survives_discovery_collate_and_rollout(self, tmp_path: Path, monkeypatch) -> None:
         import json
 
         from nemo_gym.benchmarks import BenchmarkConfig
@@ -750,7 +675,7 @@ class TestAgentPinDiscoveryCollateRollout:
         data_fpath = tmp_path / "bench.jsonl"
         data_fpath.write_text(json.dumps({"responses_create_params": {"input": []}}) + "\n")
         config = {
-            "shared_rs": {
+            "my_rs": {
                 "resources_servers": {
                     "impl": {
                         "entrypoint": "app.py",
@@ -761,48 +686,104 @@ class TestAgentPinDiscoveryCollateRollout:
                                 "type": "benchmark",
                                 "jsonl_fpath": str(data_fpath),
                                 "prepare_script": "prepare.py",
-                                "agent": "agent_b",
                             }
                         ],
                     }
                 }
             },
-            "agent_a": {
+            "my_agent": {
                 "responses_api_agents": {
                     "impl": {
                         "entrypoint": "app.py",
-                        "resources_server": {"type": "resources_servers", "name": "shared_rs"},
-                    }
-                }
-            },
-            "agent_b": {
-                "responses_api_agents": {
-                    "impl": {
-                        "entrypoint": "app.py",
-                        "resources_server": {"type": "resources_servers", "name": "shared_rs"},
+                        "resources_server": {"type": "resources_servers", "name": "my_rs"},
                     }
                 }
             },
         }
         config_dict = OmegaConf.create(config)
 
-        # 1. Discovery: two agents reference shared_rs; the pin picks agent_b.
+        # 1. Discovery: the unique agent referencing my_rs.
         bc = BenchmarkConfig.from_initial_config_dict(
             path=Path("bench/config.yaml"), initial_config_dict=config_dict, strict=False
         )
-        assert bc.agent_name == "agent_b"
+        assert bc.agent_name == "my_agent"
 
-        # 2. Collate (real stamping): rows carry only task_source, never the pin or an agent_ref.
-        rs_instance, err = maybe_get_server_instance_config("shared_rs", config_dict["shared_rs"])
+        # 2. Collate (real stamping): rows carry only task_source, never an agent name.
+        rs_instance, err = maybe_get_server_instance_config("my_rs", config_dict["my_rs"])
         assert err is None, err
         monkeypatch.chdir(tmp_path)
         paths = TrainDataProcessor()._collate_samples_single_type(
             type="benchmark", server_instance_configs=[rs_instance]
         )
         rows = [json.loads(line) for line in open(paths[0])]
-        assert rows[0]["task_source"] == "shared_rs"
+        assert rows[0]["task_source"] == "my_rs"
         assert "agent_ref" not in rows[0]
 
-        # 3. Rollout dispatch: resolution reads the pin back off the declaring instance.
+        # 3. Rollout dispatch resolves the same agent from the declaring instance.
         RolloutCollectionHelper.resolve_task_sources(rows, config_dict)
         assert rows[0]["agent_ref"] == {"name": bc.agent_name}
+
+
+class TestDatasetEntriesTakeNoAgentKey:
+    """The dataset-level `agent:` key was removed (review on #2724): a leftover one fails config load
+    with a pointer to the supported ways of choosing a harness, instead of being silently ignored."""
+
+    def test_benchmark_dataset_rejects_agent_key(self) -> None:
+        from pydantic import ValidationError
+
+        from nemo_gym.config_types import BenchmarkDatasetConfig
+
+        with pytest.raises(ValidationError, match=r"do not take an `agent:` key.*fan_out.*agent_map"):
+            BenchmarkDatasetConfig(
+                name="bench", type="benchmark", jsonl_fpath="d.jsonl", prepare_script="p.py", agent="agent_b"
+            )
+
+    def test_dataset_rejects_agent_key(self) -> None:
+        from pydantic import ValidationError
+
+        from nemo_gym.config_types import DatasetConfig
+
+        with pytest.raises(ValidationError, match=r"do not take an `agent:` key"):
+            DatasetConfig(name="example", type="example", jsonl_fpath="d.jsonl", agent="agent_b")
+
+    def test_agent_key_fails_benchmark_discovery(self, capsys) -> None:
+        """Through the real path: the config loader flags the declaring server as malformed and stops,
+        with the reason on stderr, so `gym eval` never starts with a key it would not honor."""
+        from nemo_gym.benchmarks import BenchmarkConfig
+        from nemo_gym.config_types import AlmostServerError
+
+        with pytest.raises(AlmostServerError):
+            BenchmarkConfig.from_initial_config_dict(
+                path=Path("bench/config.yaml"),
+                initial_config_dict=OmegaConf.create(
+                    {
+                        "my_rs": {
+                            "resources_servers": {
+                                "impl": {
+                                    "entrypoint": "app.py",
+                                    "domain": "other",
+                                    "datasets": [
+                                        {
+                                            "name": "bench",
+                                            "type": "benchmark",
+                                            "jsonl_fpath": "d.jsonl",
+                                            "prepare_script": "p.py",
+                                            "agent": "my_agent",
+                                        }
+                                    ],
+                                }
+                            }
+                        },
+                        "my_agent": {
+                            "responses_api_agents": {
+                                "impl": {
+                                    "entrypoint": "app.py",
+                                    "resources_server": {"type": "resources_servers", "name": "my_rs"},
+                                }
+                            }
+                        },
+                    }
+                ),
+                strict=False,
+            )
+        assert "do not take an `agent:` key" in capsys.readouterr().err

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -3636,15 +3636,6 @@ _RESOLVER_CONFIG = {
     "shared_agent_a": {"responses_api_agents": {"a": {"resources_server": {"name": "shared_rs"}}}},
     "shared_agent_b": {"responses_api_agents": {"b": {"resources_server": {"name": "shared_rs"}}}},
     "orphan_rs": {"resources_servers": {"impl": {}}},
-    # Dataset-level `agent:` pins (the escape hatch for ambiguous configs).
-    "pinned_rs": {"resources_servers": {"impl": {"datasets": [{"agent": "pinned_agent_b"}]}}},
-    "pinned_agent_a": {"responses_api_agents": {"a": {"resources_server": {"name": "pinned_rs"}}}},
-    "pinned_agent_b": {"responses_api_agents": {"b": {"resources_server": {"name": "pinned_rs"}}}},
-    "mispinned_rs": {"resources_servers": {"impl": {"datasets": [{"agent": "math_agent"}]}}},
-    "conflict_rs": {
-        "resources_servers": {"impl": {"datasets": [{"agent": "shared_agent_a"}, {"agent": "shared_agent_b"}]}}
-    },
-    "mispinned_agent": {"responses_api_agents": {"a": {"datasets": [{"agent": "math_agent"}]}}},
 }
 
 
@@ -3683,25 +3674,6 @@ class TestResolveTaskSources:
     def test_rs_with_no_agent_raises(self) -> None:
         with pytest.raises(ValueError, match="no agent in the running config references"):
             self._resolve([{"task_source": "orphan_rs"}])
-
-    def test_agent_pin_disambiguates_shared_rs(self) -> None:
-        """The dataset-level `agent:` pin reaches dispatch: an RS referenced by two agents routes
-        to the pinned one instead of erroring as ambiguous."""
-        rows = [{"task_source": "pinned_rs"}]
-        assert self._resolve(rows)[0]["agent_ref"] == {"name": "pinned_agent_b"}
-
-    def test_agent_pin_not_referencing_the_rs_raises(self) -> None:
-        """A pin naming an agent wired to a different RS must not silently re-route."""
-        with pytest.raises(ValueError, match="no agent of that name references resources server 'mispinned_rs'"):
-            self._resolve([{"task_source": "mispinned_rs"}])
-
-    def test_conflicting_agent_pins_raise_naming_agent_map(self) -> None:
-        with pytest.raises(ValueError, match=r"conflicting agents.*agent_map"):
-            self._resolve([{"task_source": "conflict_rs"}])
-
-    def test_agent_pin_on_agent_declared_dataset_must_name_the_declarer(self) -> None:
-        with pytest.raises(ValueError, match="the pin would silently not apply"):
-            self._resolve([{"task_source": "mispinned_agent"}])
 
     def test_task_source_survives_resolution(self) -> None:
         """The stamp stays on the row (provenance); only agent_ref is added."""


### PR DESCRIPTION
## Problem

#2724 added an optional `agent:` key on dataset entries — a "pin" naming which agent runs a dataset when several agents reference the same resources server. Marta's review on #2724 (https://github.com/NVIDIA-NeMo/Gym/pull/2724#issuecomment-5421716111) argued the key should not exist: the only motivating case (bigcodebench) is a composition artifact, and an ambiguous config should be an error to fix, not something to paper over per dataset.

She was right, and the migration bore it out: after #2724 and #2732 there is not a single `agent:` pin in the repo, and the scaffold never emits one. The key is dead weight with a real cost — a second place, besides the config's own agent → resources-server wiring, where the harness can be chosen.

## Change

The `agent:` key on dataset entries is removed. Routing has exactly two rules, both derived from the config's structure:

1. A dataset declared on an agent block runs on that agent.
2. A dataset declared on a resources server runs on the unique agent referencing it.

Zero or several referencing agents is a config error at load time. The error names the three supported ways to choose a harness, none of them per-dataset:

```text
2 agents reference this resources server (['agent_a', 'agent_b']), so the rows have no single
harness. Pass +agent_map={my_rs: <agent>} to pick one at run time, add a `fan_out` entry to
run all of them, or declare the dataset on the agent.
```

A leftover `agent:` key in a dataset entry is rejected when the config loads (not silently ignored), with the same pointers:

```text
dataset entries do not take an `agent:` key. Rows are dispatched to the agent that references the
declaring resources server; when several do, use `fan_out`, pass `+agent_map={<rs>: <agent>}`, or
declare the dataset on the agent.
```

What goes away:

- `BenchmarkDatasetConfig.agent` and `dataset_agent_pins()`; `resolve_dataset_agent()` loses its `pin` parameter and the two pin-specific errors.
- The pin plumbing in its four callers (benchmark discovery, `gym eval` prepare, rollout dispatch, environment validation), including validation's "conflicting pins on one instance" check.
- The metrics-sidecar carve-out that excluded the pin from dataset dumps.

## Behavior

Identical for every config on `main` and on #2732 — none uses the key. The only capability lost is a static, per-dataset default harness for a resources server shared by several agents; that case now fails fast and points at `agent_map`, `fan_out`, or agent-side declaration. genrm_compare, the one shared-RS config with RS-declared data, already uses `fan_out`.

## Verification

- Full core unit suite green locally.
- Pin tests replaced: the discovery == collate == dispatch agreement test is kept without the pin; three new tests cover the rejection on `DatasetConfig`, `BenchmarkDatasetConfig`, and through real benchmark discovery.
- `grep` for `agent:` in dataset entries across `benchmarks/`, `resources_servers/`, `environments/`, `responses_api_agents/` on `main` and on #2732: zero hits.

## Relationship to other PRs

Follows up on #2724 (merged). Independent of #2732 (configs and data only); whichever lands second rebases trivially. Closes the loop on Marta's #2724 review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
