### PR TITLE
feat(capture): expose complete rollout training traces

### DIFF
--- a/fern/versions/latest/pages/model-server/model-call-capture.mdx
+++ b/fern/versions/latest/pages/model-server/model-call-capture.mdx
@@ -292,3 +292,89 @@ The model-server boundary observes model HTTP requests and responses. It can rec
 reasoning, and tool results present in those payloads, but it does not observe tool execution,
 environment events, context compaction, semantic turns, or subagent structure. Those require
 instrumentation at the agent, tool, environment, or rollout layer.
+
+## Deliver multiple training traces
+
+Training-token capture is separate from the evaluation evidence described above. A trainer that
+supports multiple sequences per logical rollout can opt into complete trace delivery:
+
+```yaml
+token_id_capture:
+  enabled: true
+  all_agents: true
+  dir: /absolute/shared/path/training-captures
+  rebuild_response: true
+  delivery: all_traces
+  builder: prefix_merging  # Or per_request.
+```
+
+NeMo RL passes this block under `env.nemo_gym`. The model server and finalizer must share the capture
+directory and preserve `/ng-rollout/<rollout_id>/training-token-capture` on every model call.
+`delivery: main_chain` with `builder: prefix_merging` remains the default and preserves the existing
+single-response behavior. `per_request` requires `delivery: all_traces`.
+
+- `prefix_merging` extends Gym's existing verified-parent builder. It delivers each retained chain,
+  including independent roots and branches. It does not infer a parent across an unresolved boundary.
+- `per_request` uses the same captured-call admission and retry selection, then emits each retained
+  call with its exact full prompt and sampled generation.
+
+The plural mode leaves the scored `response` and scalar `reward` unchanged and adds a top-level
+`training_traces` envelope. Native inline token fields are also preserved. A trainer must explicitly
+consume the envelope; reading only `response.output` does not consume plural training data.
+
+```json
+{
+  "training_traces": {
+    "schema_version": 1,
+    "rollout_id": "0-0",
+    "builder": "per_request",
+    "traces": [{
+      "trace_id": "0-0:call-a",
+      "model_call_ids": ["call-a"],
+      "token_ids": [1, 2, 10, 11],
+      "generation_logprobs": [0.0, 0.0, -0.1, -0.2],
+      "loss_mask": [0, 0, 1, 1],
+      "sampled_spans": [{"model_call_id": "call-a", "start": 2, "end": 4}]
+    }]
+  }
+}
+```
+
+This is a synthetic schema example. All three arrays have the same length. Prompt and interstitial
+context positions carry loss mask zero and synthetic logprob zero. Each `sampled_spans` entry is a
+half-open range into the complete row and preserves the captured generated tokens and behavior
+logprobs. The first token is always conditioning context. A call's sampled span has exactly one
+loss-bearing owner across the envelope. A shared ancestor can appear as context in another branch,
+with mask zero. Deterministic call identities choose ownership; transport completion order does not.
+`model_call_ids` includes both owned calls and repeated ancestor context.
+
+Callers of `RunHelper.run_examples` finalize returned records explicitly. Gym's rollout-to-file
+collector already performs this step. Preserve the caller's `ROLLOUT_ID_KEY_NAME` field on the result:
+
+```python
+from nemo_gym.token_id_capture.delivery import finalize_rollout_token_capture
+from nemo_gym.token_id_capture.store import TokenCaptureStore
+
+source = TokenCaptureStore("/absolute/shared/path/training-captures")
+built = await finalize_rollout_token_capture(
+    result, source, delivery="all_traces", builder="per_request"
+)
+```
+
+The finalizer freezes its `TokenSource`; it never deletes captured evidence. Retire with
+`retire_rollout_token_capture` only after durable trainer acceptance or durable file handoff.
+An incomplete snapshot, conflicting duplicate, unresolved parent, ambiguous retained retry, invalid
+terminal, mixed model, or invalid token/logprob arrays masks the rollout and emits no usable envelope.
+Same-prompt independent invocations without retention evidence cannot be distinguished safely from
+retries; they remain unsupported rather than being silently counted as successful calls.
+
+This initial envelope supports text-only training without router replay. `routed_experts` is rejected.
+Framework-owned `external_staging` receipts still rebuild one selected chain, so configuring that path
+with `delivery: all_traces` raises an error before collection. A framework may use the generic
+`TokenSource` finalizer for plural delivery; the existing staged receipt API is unchanged.
+
+Trace reconstruction does not define rewards, advantages, or loss normalization. The trainer groups
+independently sampled logical rollouts by their input task, computes the chosen logical advantages,
+and then expands trace rows with their parent rollout identity. Repeated context must not become
+additional sampled tokens. Shared outcome rewards and token ownership alone do not solve process
+credit assignment or reward hacking; normalization choices require separate validation.

--- a/fern/versions/latest/pages/model-server/model-call-capture.mdx
+++ b/fern/versions/latest/pages/model-server/model-call-capture.mdx
@@ -318,6 +318,13 @@ single-response behavior. `per_request` requires `delivery: all_traces`.
 - `per_request` uses the same captured-call admission and retry selection, then emits each retained
   call with its exact full prompt and sampled generation.
 
+In plural delivery, a complete captured prompt can remain an independent root when its resolved
+parent's sampled tokens are no longer a prefix of the canonical next prompt, for example after
+removing an empty thinking template. This fallback requires a valid cumulative token length and
+digest for the complete captured call. It preserves the exact conditioning tokens without joining
+across the rewrite. Delta records, missing or unresolved parents, and ambiguous retries still fail
+closed. The default `main_chain` behavior is unchanged.
+
 The plural mode leaves the scored `response` and scalar `reward` unchanged and adds a top-level
 `training_traces` envelope. Native inline token fields are also preserved. A trainer must explicitly
 consume the envelope; reading only `response.output` does not consume plural training data.

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -1432,7 +1432,10 @@ class RolloutCollectionHelper(BaseModel):
                 global_config,
                 (row.get(AGENT_REF_KEY_NAME) or {}).get("name"),
             ):
-                token_capture_build = await finalize_rollout_token_capture(result, token_source)
+                settings = token_capture_config.token_id_capture
+                token_capture_build = await finalize_rollout_token_capture(
+                    result, token_source, builder=settings.builder, delivery=settings.delivery
+                )
                 if token_capture_build is not None:
                     finalized_count += 1
                     if token_capture_build.get(MASK_SAMPLE_KEY):

--- a/nemo_gym/token_id_capture/__init__.py
+++ b/nemo_gym/token_id_capture/__init__.py
@@ -38,6 +38,7 @@ Failed or masked builds retain their capture evidence.
 from nemo_gym.token_id_capture.builder import (
     Chain,
     assert_prefix_contiguity,
+    per_request,
     prefix_merging,
     project_chain_to_output_items,
     project_main_chain_response,
@@ -160,6 +161,7 @@ __all__ = [
     "assistant_fingerprint",
     "stamp_continuation",
     "prefix_merging",
+    "per_request",
     "project_chain_to_output_items",
     "project_main_chain_response",
     "run_builder",

--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -83,9 +83,9 @@ class BuildNotes:
     chains: int = 0
     generated_tokens_captured: int = 0
     generated_tokens_delivered: int = 0
-    # Only one chain is delivered per rollout.
-    # Sub-agent branches and post-compaction chains are dropped.
-    # The delivered fraction exposes this limitation.
+    # Legacy main-chain delivery drops sub-agent and post-compaction chains.
+    # Opt-in all_traces counts each retained generated span once.
+    # The delivered fraction exposes drops in either mode.
     delivered_fraction: float = 0.0
     # These calls have a retry sibling that the harness may not have kept.
     # A final-call retry is unresolved because no later call identifies the survivor.
@@ -275,7 +275,9 @@ class _NullPrefixIndex:
         return None, False
 
 
-def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = None) -> BuildOutput:
+def prefix_merging(
+    entries: list[TokenEntry], terminal_call_id: str | None = None, *, all_traces: bool = False
+) -> BuildOutput:
     # An at-least-once transport can deliver one entry twice.
     # Conflicting payloads for one id are corrupt.
     deduped: dict[str, TokenEntry] = {}
@@ -284,6 +286,10 @@ def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = Non
         previous = deduped.get(candidate.model_call_id)
         if previous is None:
             deduped[candidate.model_call_id] = candidate
+        elif all_traces and previous.model_dump(exclude={"created_at"}) != candidate.model_dump(
+            exclude={"created_at"}
+        ):
+            duplicate_conflicts.append(candidate.model_call_id)
         elif (list(previous.prompt_token_ids), list(previous.generation_token_ids)) != (
             list(candidate.prompt_token_ids),
             list(candidate.generation_token_ids),
@@ -295,6 +301,13 @@ def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = Non
     # Materialize delta records before sorting or checking parent digests.
     # Exclude a record when its parent chain cannot be reconstructed exactly.
     entries, unreconstructable = _materialize_delta_prompts(entries)
+    if all_traces:
+        for entry in entries:
+            cumulative = list(entry.prompt_token_ids) + list(entry.generation_token_ids)
+            if (entry.cum_len is not None and entry.cum_len != len(cumulative)) or (
+                entry.digest is not None and entry.digest != compute_digest(cumulative)
+            ):
+                raise ValueError(f"captured cumulative proof mismatch for {entry.model_call_id}")
 
     # A call without generated tokens has no training signal.
     # Its cumulative sequence equals its prompt.
@@ -408,18 +421,20 @@ def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = Non
             if len(retry_group) < 2:
                 continue
             on_terminal_path = [n for n in retry_group if id(n) in terminal_ancestry]
+            extended = [n for n in retry_group if any(not child.quarantined for child in n.children)]
             if on_terminal_path:
-                # The verified terminal identifies the sibling the harness kept.
-                keep = set(on_terminal_path)
+                # In plural delivery, a verified child proves another sibling was
+                # also consumed. Do not discard a real fork just because one
+                # sibling produced the final answer.
+                keep = set(on_terminal_path) | (set(extended) if all_traces else set())
             else:
-                extended = [n for n in retry_group if any(not child.quarantined for child in n.children)]
                 if extended:
                     keep = set(extended)
                 else:
                     keep = {min(retry_group, key=lambda n: n.entry.model_call_id)}
                     # With an attributed terminal, a group off the terminal path
                     # cannot reach the delivered chain, so it never masks.
-                    if terminal_node is None:
+                    if terminal_node is None or all_traces:
                         unresolved_retries.extend(n.entry.model_call_id for n in retry_group)
             for node in retry_group:
                 if node not in keep and not node.quarantined:
@@ -464,6 +479,11 @@ def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = Non
             else:
                 terminal_chain = chain_from(terminal_path)
                 terminal_chain_status = "delivered"
+
+    if all_traces:
+        # Terminal attribution resolves retries, but does not select which
+        # independent calls belong to an opt-in complete rollout delivery.
+        terminal_chain = None
 
     # Materialize root-to-leaf chains.
     # A leaf chain through the terminal is represented by the truncated main chain.
@@ -534,11 +554,29 @@ def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = Non
         parent_link_failures=parent_link_failures,
         unresolved_parent_calls=unresolved_parent_calls,
     )
+    if all_traces:
+        kept = {link.entry.model_call_id: link.entry for chain in chains for link in chain.links}
+        notes.generated_tokens_delivered = sum(len(entry.generation_token_ids) for entry in kept.values())
+        notes.delivered_fraction = round(notes.generated_tokens_delivered / captured, 4) if captured else 0.0
     return BuildOutput(chains=chains, quarantined=quarantined, notes=notes)
+
+
+def per_request(entries: list[TokenEntry], terminal_call_id: str | None = None) -> BuildOutput:
+    """Emit one full-prompt chain per admitted call using the same retry evidence."""
+    out = prefix_merging(entries, terminal_call_id=terminal_call_id, all_traces=True)
+    kept = {link.entry.model_call_id: link.entry for chain in out.chains for link in chain.links}
+    out.chains = [
+        Chain(chain_id=call_id, root_prompt=list(entry.prompt_token_ids), links=[ChainLink(entry, [])])
+        for call_id, entry in sorted(kept.items())
+    ]
+    out.notes.builder = "per_request"
+    out.notes.chains = len(out.chains)
+    return out
 
 
 _BUILDERS: dict[str, Callable[..., BuildOutput]] = {
     "prefix_merging": prefix_merging,
+    "per_request": per_request,
 }
 
 
@@ -546,6 +584,8 @@ def run_builder(
     entries: list[TokenEntry],
     builder: str = "prefix_merging",
     terminal_call_id: str | None = None,
+    *,
+    all_traces: bool = False,
 ) -> BuildOutput:
     """Chain frozen snapshot entries with the named strategy.
 
@@ -554,8 +594,8 @@ def run_builder(
     if builder not in _BUILDERS:
         raise ValueError(f"unknown builder {builder!r}; known: {sorted(_BUILDERS)}")
     if builder == "prefix_merging":
-        return prefix_merging(entries, terminal_call_id=terminal_call_id)
-    return _BUILDERS[builder](entries)
+        return prefix_merging(entries, terminal_call_id=terminal_call_id, all_traces=all_traces)
+    return _BUILDERS[builder](entries, terminal_call_id=terminal_call_id)
 
 
 # --- Projection to a contiguous, token-bearing response ---

--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -296,6 +296,7 @@ def prefix_merging(
         ):
             duplicate_conflicts.append(candidate.model_call_id)
     entries = list(deduped.values())
+    captured_full_prompts = {entry.model_call_id for entry in entries if not entry.prompt_is_delta}
 
     # Chain construction assumes full prompts.
     # Materialize delta records before sorting or checking parent digests.
@@ -365,8 +366,20 @@ def prefix_merging(
         parent, ambiguous, note = _resolve_parent(node, nodes_by_call_id, prefix_index)
         if note:
             parent_link_failures[note] = parent_link_failures.get(note, 0) + 1
-            # A recovered fallback found a safe parent.
-            if not note.endswith("_recovered"):
+            # A canonical next prompt can rewrite a consumed response or its
+            # template (for example, remove an empty thinking prefix). A complete,
+            # independently verified capture can still train as its own root.
+            # Do not invent a token-prefix join or use this for delta/missing/
+            # unresolved parents. Retry admission below remains unchanged.
+            rewritten_full_prompt = (
+                all_traces
+                and note == "parent_digest_mismatch"
+                and entry.parent_resolution == ParentResolutionStatus.RESOLVED
+                and entry.model_call_id in captured_full_prompts
+                and entry.cum_len is not None
+                and entry.digest is not None
+            )
+            if not note.endswith("_recovered") and not rewritten_full_prompt:
                 node.unresolved_boundary = True
                 unresolved_parent_calls.append(entry.model_call_id)
         if parent is not None:

--- a/nemo_gym/token_id_capture/config.py
+++ b/nemo_gym/token_id_capture/config.py
@@ -71,7 +71,7 @@ import os
 from collections.abc import Mapping
 from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -114,6 +114,10 @@ class TokenIdCaptureSettings(BaseModel):
     # Finalization does not retire the frozen snapshot.
     # Durable delivery permits retirement by snapshot id and version.
     rebuild_response: bool = True
+    # Plural delivery preserves the scored response and adds training_traces.
+    # The legacy default continues projecting a single main response.
+    delivery: Literal["main_chain", "all_traces"] = "main_chain"
+    builder: Literal["prefix_merging", "per_request"] = "prefix_merging"
     # A custom sink normally needs a resolver over the same backend namespace.
     # Without one, every multi-call continuation is unresolved and masked.
     # This flag permits that degraded behavior explicitly.
@@ -163,6 +167,10 @@ class TokenIdCaptureConfig(BaseModel):
     @model_validator(mode="after")
     def _validate(self) -> "TokenIdCaptureConfig":
         block = self.token_id_capture
+        if block.builder == "per_request" and block.delivery != "all_traces":
+            raise ValueError("per_request requires token_id_capture.delivery=all_traces")
+        if block.external_staging and block.delivery == "all_traces":
+            raise ValueError("all_traces delivery is not supported by external_staging; use a TokenSource finalizer")
         if block.external_staging and not block.enabled:
             raise ValueError("token_id_capture.external_staging requires token_id_capture.enabled")
         if block.external_staging and block.rebuild_response:

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -41,6 +41,7 @@ from nemo_gym.token_id_capture.protocols import TokenSource
 from nemo_gym.token_id_capture.records import TokenEntry
 from nemo_gym.token_id_capture.store import TokenCaptureStore
 from nemo_gym.token_id_capture.terminal import TerminalAttribution, resolve_terminal
+from nemo_gym.token_id_capture.training_traces import project_training_traces
 
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,7 @@ def _assemble(
     verified_response: dict | None = None,
     explicit_terminal_call_id: str | None = None,
     declared_response_id: str | None = None,
+    delivery: str = "main_chain",
 ) -> dict:
     # Attribute the verified terminal before building.
     # ``verified_response`` is the scored response from the /run result.
@@ -125,7 +127,20 @@ def _assemble(
         }
 
     try:
-        out = run_builder(entries, builder, terminal_call_id=attribution.model_call_id)
+        if delivery not in ("main_chain", "all_traces"):
+            raise ValueError(f"unknown delivery mode {delivery!r}")
+        if builder == "per_request" and delivery != "all_traces":
+            raise ValueError("per_request requires all_traces delivery")
+        if delivery == "all_traces":
+            if (explicit_terminal_call_id or declared_response_id) and not attribution.attributed:
+                raise ValueError("declared terminal could not be attributed to captured tokens")
+            if any(entry.rollout_id != rollout_id for entry in entries):
+                raise ValueError("capture contains entries from a different rollout")
+            if len({entry.model for entry in entries}) != 1:
+                raise ValueError("all_traces requires a single policy model per rollout")
+        out = run_builder(
+            entries, builder, terminal_call_id=attribution.model_call_id, all_traces=delivery == "all_traces"
+        )
     except (AssertionError, ValueError, KeyError, IndexError, TypeError) as error:
         logger.warning(
             "Could not build a trajectory for rollout %s from %d captured call(s): %s",
@@ -139,8 +154,13 @@ def _assemble(
     try:
         for chain in out.chains:
             chain.validate()
-        response = project_main_chain_response(rollout_id, out, model=model)
-        assert_prefix_contiguity(response)
+        training_traces = None
+        if delivery == "all_traces":
+            training_traces = project_training_traces(rollout_id, out).model_dump()
+            response = None
+        else:
+            response = project_main_chain_response(rollout_id, out, model=model)
+            assert_prefix_contiguity(response)
     except (AssertionError, ValueError, KeyError, IndexError, TypeError) as error:
         logger.warning(
             "Could not build a trajectory for rollout %s from %d captured call(s): %s",
@@ -176,7 +196,11 @@ def _assemble(
         "empty_generation_calls": len(notes.empty_generation_calls),
     }
     unresolved = notes.unresolved_retries
-    if notes.terminal_chain == "delivered":
+    if delivery == "all_traces":
+        # project_training_traces validated every retained chain, including
+        # off-terminal roots and repeated-ancestor ownership.
+        mask = False
+    elif notes.terminal_chain == "delivered":
         # The verified chain is attributed and intact.
         # Off-path calls (auxiliary calls, sub-agent forks, abandoned retries)
         # are excluded from delivery instead of masking the rollout.
@@ -191,8 +215,9 @@ def _assemble(
         # Mask the rollout when the client-selected generation is unknown.
         mask = bool(unresolved) or bool(notes.unresolved_parent_calls) or notes.roots != 1 or notes.chains != 1
     # An empty delivery must never be trainable, whatever produced it.
-    mask = mask or not any(item.get("generation_token_ids") for item in response.get("output", []))
-    return {
+    if delivery != "all_traces":
+        mask = mask or not any(item.get("generation_token_ids") for item in response.get("output", []))
+    result = {
         "rollout_id": rollout_id,
         "builder": builder,
         "rebuilt_response": response,
@@ -201,6 +226,9 @@ def _assemble(
         "unresolved_retries": list(unresolved),
         "unresolved_parent_calls": list(notes.unresolved_parent_calls),
     }
+    if training_traces is not None:
+        result["training_traces"] = training_traces
+    return result
 
 
 def trajectories_for_rollout(
@@ -208,6 +236,7 @@ def trajectories_for_rollout(
     token_capture_dirs: list[Path],
     *,
     builder: str = "prefix_merging",
+    delivery: str = "main_chain",
     model: str = "",
     verified_response: dict | None = None,
     explicit_terminal_call_id: str | None = None,
@@ -235,9 +264,11 @@ def trajectories_for_rollout(
                 model,
                 verified_response=verified_response,
                 explicit_terminal_call_id=explicit_terminal_call_id,
+                delivery=delivery,
             )
         if snapshot.incomplete:
             built["mask_sample"] = True
+            built.pop("training_traces", None)
             built.setdefault("metrics", {})["capture_incomplete"] = True
         built["_capture_snapshot"] = {
             "snapshot_id": snapshot.snapshot_id,
@@ -252,6 +283,7 @@ async def trajectories_from_source(
     source: TokenSource,
     *,
     builder: str = "prefix_merging",
+    delivery: str = "main_chain",
     model: str = "",
     verified_response: dict | None = None,
     explicit_terminal_call_id: str | None = None,
@@ -282,11 +314,13 @@ async def trajectories_from_source(
                 model,
                 verified_response=verified_response,
                 explicit_terminal_call_id=explicit_terminal_call_id,
+                delivery=delivery,
                 declared_response_id=declared_response_id,
             )
         )
     if snapshot.incomplete:
         built["mask_sample"] = True
+        built.pop("training_traces", None)
         built.setdefault("metrics", {})["capture_incomplete"] = True
     built["_capture_snapshot"] = {
         "snapshot_id": snapshot.snapshot_id,

--- a/nemo_gym/token_id_capture/delivery.py
+++ b/nemo_gym/token_id_capture/delivery.py
@@ -84,12 +84,21 @@ def _unusable(result: dict, error: str, message: str) -> dict:
     return {"rebuilt_response": None, MASK_SAMPLE_KEY: True, "error": error, "metrics": metrics}
 
 
-async def finalize_rollout_token_capture(result: dict, source: TokenSource | None) -> dict | None:
+async def finalize_rollout_token_capture(
+    result: dict,
+    source: TokenSource | None,
+    *,
+    builder: str = "prefix_merging",
+    delivery: str = "main_chain",
+) -> dict | None:
     """Rebuild one finished rollout record's ``response.output`` from its recorded token ids.
 
     Call this after the harness and verifier finish the record.
     The function mutates ``result`` in place.
-    It replaces only ``response.output``.
+    By default it replaces only ``response.output``.
+    With ``delivery="all_traces"`` it preserves the scored response, including
+    native inline tokens, and attaches a versioned ``training_traces`` envelope.
+    That mode requires a trainer which consumes the envelope explicitly.
     It preserves the reward and all other harness and verifier output.
 
     The function freezes capture records through ``source``.
@@ -121,7 +130,10 @@ async def finalize_rollout_token_capture(result: dict, source: TokenSource | Non
             f"a rollout result carries a malformed id ({error}), so its recorded token ids could "
             "not be looked up and it will be token-less.",
         )
-    if rollout_carries_token_ids(result):
+    if delivery == "all_traces":
+        # Never accept stale or harness-supplied training rows as captured proof.
+        result.pop("training_traces", None)
+    if delivery == "main_chain" and rollout_carries_token_ids(result):
         # Re-finalization must return the frozen snapshot.
         # The caller must be able to retire on every path.
         if rollout_id is None:
@@ -159,6 +171,8 @@ async def finalize_rollout_token_capture(result: dict, source: TokenSource | Non
         built = await trajectories_from_source(
             rollout_id,
             source,
+            builder=builder,
+            delivery=delivery,
             model=str(response.get("model") or ""),
             verified_response=response or None,
             explicit_terminal_call_id=str(explicit_terminal) if explicit_terminal else None,
@@ -184,6 +198,8 @@ async def finalize_rollout_token_capture(result: dict, source: TokenSource | Non
             "middleware correlated.",
         )
 
+    if "training_traces" in built:
+        result["training_traces"] = built["training_traces"]
     projected = built["rebuilt_response"]
     if projected is not None:
         if isinstance(result.get("response"), dict):
@@ -242,4 +258,8 @@ def capture_build_can_retire(built: dict | None) -> bool:
     """Whether a successful build consumed a frozen snapshot."""
     if built is None or built.get(MASK_SAMPLE_KEY):
         return False
-    return built.get("rebuilt_response") is not None or bool(built.get(_REDUNDANT_CAPTURE_KEY))
+    return (
+        built.get("rebuilt_response") is not None
+        or bool(built.get("training_traces"))
+        or bool(built.get(_REDUNDANT_CAPTURE_KEY))
+    )

--- a/nemo_gym/token_id_capture/training_traces.py
+++ b/nemo_gym/token_id_capture/training_traces.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned, text-only training rows owned by one logical rollout.
+
+Context tokens may appear in several rows. A sampled call's generated span
+has exactly one loss-bearing owner, independent of the reconstruction mode.
+This module does not assign rewards, advantages, or trainer loss weights.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from nemo_gym.token_id_capture.builder import BuildOutput
+
+
+class SampledSpan(BaseModel):
+    """Half-open row positions for one call's owned sampled generation."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+    model_call_id: str = Field(min_length=1)
+    start: int = Field(ge=1)
+    end: int = Field(ge=2)
+
+
+class TrainingTrace(BaseModel):
+    """One complete conditioning sequence with aligned behavior evidence."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+    trace_id: str = Field(min_length=1)
+    model_call_ids: list[str]
+    token_ids: list[int]
+    generation_logprobs: list[float]
+    loss_mask: list[int]
+    sampled_spans: list[SampledSpan]
+
+    @model_validator(mode="after")
+    def _validate_tokens(self) -> "TrainingTrace":
+        size = len(self.token_ids)
+        if not size or len(self.generation_logprobs) != size or len(self.loss_mask) != size:
+            raise ValueError("training trace token, logprob, and mask lengths must match and be nonempty")
+        if self.loss_mask[0] != 0 or any(mask not in (0, 1) for mask in self.loss_mask):
+            raise ValueError("training trace requires a masked conditioning token and binary loss masks")
+        if any(token < 0 for token in self.token_ids) or any(not math.isfinite(lp) for lp in self.generation_logprobs):
+            raise ValueError("training trace requires nonnegative tokens and finite logprobs")
+        if len(set(self.model_call_ids)) != len(self.model_call_ids):
+            raise ValueError("model_call_ids must be unique within a trace")
+        owned = [0] * size
+        for span in self.sampled_spans:
+            if span.model_call_id not in self.model_call_ids or not span.start < span.end <= size:
+                raise ValueError("sampled span must reference a captured call and lie within its trace")
+            for index in range(span.start, span.end):
+                if owned[index]:
+                    raise ValueError("sampled spans must not overlap")
+                owned[index] = 1
+        if owned != self.loss_mask or not any(owned):
+            raise ValueError("sampled spans must exactly cover all trainable tokens")
+        return self
+
+
+class TrainingTraceBatch(BaseModel):
+    """Wire contract for all retained calls of one logical rollout."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+    schema_version: Literal[1] = 1
+    rollout_id: str = Field(min_length=1)
+    builder: Literal["prefix_merging", "per_request"]
+    traces: list[TrainingTrace] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_ownership(self) -> "TrainingTraceBatch":
+        if len({trace.trace_id for trace in self.traces}) != len(self.traces):
+            raise ValueError("trace ids must be unique within a rollout")
+        owners = [span.model_call_id for trace in self.traces for span in trace.sampled_spans]
+        if len(owners) != len(set(owners)):
+            raise ValueError("each captured sampled span must have exactly one training owner")
+        if set(owners) != {call_id for trace in self.traces for call_id in trace.model_call_ids}:
+            raise ValueError("every referenced captured call must have a training owner")
+        return self
+
+
+def project_training_traces(rollout_id: str, out: BuildOutput) -> TrainingTraceBatch:
+    """Project safe chains, masking repeated ancestors rather than sampling them twice.
+
+    Chain order depends on call identities, not transport completion order.
+    A repeated ancestor remains exact context in another branch, with loss 0.
+    Unsupported router-replay evidence is rejected rather than discarded.
+    """
+    if out.notes.unresolved_retries or out.notes.unresolved_parent_calls:
+        raise ValueError("all_traces requires resolved retry selection and parent custody")
+    if out.notes.terminal_chain in ("broken", "not_captured"):
+        raise ValueError("the declared terminal call is not safely captured")
+    owned_calls: set[str] = set()
+    traces: list[TrainingTrace] = []
+    for chain in sorted(out.chains, key=lambda item: tuple(link.entry.model_call_id for link in item.links)):
+        chain.validate()
+        token_ids = list(chain.root_prompt)
+        logprobs = [0.0] * len(token_ids)
+        masks = [0] * len(token_ids)
+        spans: list[SampledSpan] = []
+        call_ids: list[str] = []
+        for link in chain.links:
+            entry = link.entry
+            if entry.rollout_id != rollout_id:
+                raise ValueError("captured call belongs to a different rollout")
+            if entry.routed_experts is not None:
+                raise ValueError("all_traces does not yet support routed_experts")
+            call_ids.append(entry.model_call_id)
+            token_ids.extend(link.interstitial)
+            logprobs.extend([0.0] * len(link.interstitial))
+            masks.extend([0] * len(link.interstitial))
+            start = len(token_ids)
+            if not start:
+                raise ValueError("sampled tokens require a nonempty conditioning prompt")
+            token_ids.extend(entry.generation_token_ids)
+            owns = entry.model_call_id not in owned_calls
+            logprobs.extend(entry.generation_log_probs if owns else [0.0] * len(entry.generation_token_ids))
+            masks.extend([int(owns)] * len(entry.generation_token_ids))
+            if owns:
+                spans.append(SampledSpan(model_call_id=entry.model_call_id, start=start, end=len(token_ids)))
+                owned_calls.add(entry.model_call_id)
+        if spans:
+            traces.append(
+                TrainingTrace(
+                    trace_id=f"{rollout_id}:{call_ids[-1]}",
+                    model_call_ids=call_ids,
+                    token_ids=token_ids,
+                    generation_logprobs=logprobs,
+                    loss_mask=masks,
+                    sampled_spans=spans,
+                )
+            )
+    return TrainingTraceBatch(rollout_id=rollout_id, builder=out.notes.builder, traces=traces)

--- a/tests/unit_tests/test_training_traces.py
+++ b/tests/unit_tests/test_training_traces.py
@@ -283,3 +283,52 @@ def test_direct_projection_rejects_wrong_rollout_and_unavailable_terminal():
         project_training_traces("wrong", run_builder(entries, all_traces=True))
     with pytest.raises(ValueError, match="terminal"):
         project_training_traces("r1", run_builder(entries, terminal_call_id="absent", all_traces=True))
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_rewritten_empty_thinking_template_keeps_complete_calls_as_separate_roots(builder):
+    # The sampled request has an empty thinking prefix; the canonical next
+    # request removes it while retaining the sampled tool-call text.
+    first = _entry("a", [1, 2, 151667, 271, 151668, 271], [151657, 10, 151658, 151645])
+    second = _entry("b", [1, 2, 151657, 10, 151658, 151645, 3], [11, 12], "a")
+    for entries in ([first, second], [second, first]):
+        result = _build(entries, builder, explicit_terminal_call_id="b")
+        assert not result["mask_sample"]
+        envelope = result["training_traces"]
+        assert len(envelope["traces"]) == 2
+        assert _owned(envelope) == {
+            entry.model_call_id: (entry.generation_token_ids, entry.generation_log_probs) for entry in entries
+        }
+        for trace in envelope["traces"]:
+            entry = first if trace["model_call_ids"] == ["a"] else second
+            assert trace["token_ids"] == entry.prompt_token_ids + entry.generation_token_ids
+            assert trace["loss_mask"] == [0] * len(entry.prompt_token_ids) + [1] * len(entry.generation_token_ids)
+        assert result["metrics"]["parent_link_failures"] == {"parent_digest_mismatch": 1}
+    legacy = _assemble("r1", [first, second], "prefix_merging", "policy", explicit_terminal_call_id="b")
+    assert legacy["mask_sample"]
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+@pytest.mark.parametrize(
+    "damage",
+    [
+        {"prompt_is_delta": True},
+        {"parent_resolution": ParentResolutionStatus.UNRESOLVED},
+        {"parent_call_id": "absent"},
+        {"digest": None},
+    ],
+)
+def test_rewritten_prompt_fallback_requires_self_contained_verified_capture(builder, damage):
+    first = _entry("a", [1, 2], [10])
+    second = _entry("b", [1, 3, 4], [11], "a").model_copy(update=damage)
+    result = _build([first, second], builder, explicit_terminal_call_id="b")
+    assert result["mask_sample"] and "training_traces" not in result
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_rewritten_prompt_does_not_disambiguate_retry_siblings(builder):
+    first = _entry("a", [1, 2], [10])
+    retry = _entry("retry", [1, 2], [12])
+    second = _entry("b", [1, 3, 4], [11], "a")
+    result = _build([first, retry, second], builder, explicit_terminal_call_id="b")
+    assert result["mask_sample"] and "training_traces" not in result

--- a/tests/unit_tests/test_training_traces.py
+++ b/tests/unit_tests/test_training_traces.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check complete rollout delivery, custody, and reconstruction-independent ownership."""
+
+import copy
+from itertools import permutations
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from nemo_gym.global_config import ROLLOUT_ID_KEY_NAME
+from nemo_gym.token_id_capture.builder import run_builder
+from nemo_gym.token_id_capture.config import TokenIdCaptureConfig
+from nemo_gym.token_id_capture.consumer import _assemble, trajectories_for_rollout, trajectories_from_source
+from nemo_gym.token_id_capture.delivery import (
+    capture_build_can_retire,
+    finalize_rollout_token_capture,
+    retire_rollout_token_capture,
+)
+from nemo_gym.token_id_capture.protocols import TokenCaptureSnapshot
+from nemo_gym.token_id_capture.records import ParentResolutionStatus, TokenEntry, stamp_lineage
+from nemo_gym.token_id_capture.store import TokenCaptureStore
+from nemo_gym.token_id_capture.training_traces import TrainingTraceBatch, project_training_traces
+
+
+def _entry(call_id, prompt, generated, parent=None):
+    entry = TokenEntry(
+        rollout_id="r1",
+        model_call_id=call_id,
+        model="policy",
+        prompt_token_ids=prompt,
+        generation_token_ids=generated,
+        generation_log_probs=[-token / 100 for token in generated],
+        response_id=f"response-{call_id}",
+    )
+    return stamp_lineage(
+        entry,
+        parent,
+        parent_resolution=ParentResolutionStatus.RESOLVED if parent else ParentResolutionStatus.ROOT,
+    )
+
+
+def _branching_calls():
+    return [
+        _entry("a", [1, 2], [10, 11]),
+        _entry("b", [1, 2, 10, 11, 3], [12], "a"),
+        _entry("c", [1, 2, 10, 11, 4], [13, 14], "a"),
+        _entry("d", [5, 6], [15]),
+    ]
+
+
+def _build(entries, builder="prefix_merging", **kwargs):
+    return _assemble("r1", entries, builder, "policy", delivery="all_traces", **kwargs)
+
+
+def _owned(envelope):
+    return {
+        span["model_call_id"]: (
+            trace["token_ids"][span["start"] : span["end"]],
+            trace["generation_logprobs"][span["start"] : span["end"]],
+        )
+        for trace in envelope["traces"]
+        for span in trace["sampled_spans"]
+    }
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_interleaved_forks_and_independent_roots_preserve_every_sample_once(builder):
+    entries = _branching_calls()
+    expected = {entry.model_call_id: (entry.generation_token_ids, entry.generation_log_probs) for entry in entries}
+    results = []
+    for shuffled in permutations(entries):
+        result = _build(list(shuffled), builder, explicit_terminal_call_id="c")
+        assert not result["mask_sample"]
+        envelope = result["training_traces"]
+        assert _owned(envelope) == expected
+        assert sum(sum(trace["loss_mask"]) for trace in envelope["traces"]) == 6
+        assert result["metrics"]["delivered_fraction"] == 1.0
+        results.append(envelope)
+    assert all(result == results[0] for result in results)
+    assert len(results[0]["traces"]) == (4 if builder == "per_request" else 3)
+
+
+def test_prefix_projection_masks_ancestor_copy_but_retains_exact_context():
+    envelope = _build(_branching_calls())["training_traces"]
+    second_branch = next(trace for trace in envelope["traces"] if trace["model_call_ids"] == ["a", "c"])
+    assert second_branch["token_ids"] == [1, 2, 10, 11, 4, 13, 14]
+    assert second_branch["loss_mask"] == [0, 0, 0, 0, 0, 1, 1]
+    assert second_branch["generation_logprobs"][-2:] == [-0.13, -0.14]
+
+
+def test_representation_modes_own_identical_sampled_data():
+    entries = _branching_calls()
+    assert _owned(_build(entries, "per_request")["training_traces"]) == _owned(
+        _build(entries, "prefix_merging")["training_traces"]
+    )
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_compaction_root_preserved_and_legacy_delivery_unchanged(builder):
+    entries = [_entry("a", [1], [10]), _entry("b", [1, 10, 2], [11], "a"), _entry("c", [3], [12])]
+    result = _build(entries, builder, explicit_terminal_call_id="c")
+    assert set(_owned(result["training_traces"])) == {"a", "b", "c"}
+    legacy = _assemble("r1", entries, "prefix_merging", "policy", explicit_terminal_call_id="c")
+    assert not legacy["mask_sample"]
+    assert "training_traces" not in legacy
+    assert legacy["rebuilt_response"]["output"][0]["generation_token_ids"] == [12]
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_duplicate_delivery_deduplicated_and_differing_logprobs_rejected(builder):
+    entry = _entry("a", [1], [10])
+    result = _build([entry, entry.model_copy(deep=True)], builder)
+    assert not result["mask_sample"]
+    assert len(_owned(result["training_traces"])) == 1
+    conflict = entry.model_copy(update={"generation_log_probs": [-0.9]})
+    bad = _build([entry, conflict], builder)
+    assert bad["mask_sample"] and "training_traces" not in bad
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_ambiguous_off_terminal_retry_masks_complete_rollout(builder):
+    entries = [_entry("a", [1], [10]), _entry("b", [1], [11]), _entry("terminal", [2], [12])]
+    result = _build(entries, builder, explicit_terminal_call_id="terminal")
+    assert result["mask_sample"] and "training_traces" not in result
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_terminal_and_extended_sibling_both_have_retention_evidence(builder):
+    entries = [_entry("a", [1], [10]), _entry("b", [1], [11]), _entry("c", [1, 11, 2], [12], "b")]
+    result = _build(entries, builder, explicit_terminal_call_id="a")
+    assert set(_owned(result["training_traces"])) == {"a", "b", "c"}
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_retry_selected_by_terminal_or_child_excludes_abandoned_generation(builder):
+    entries = [_entry("a", [1], [10]), _entry("b", [1], [11])]
+    result = _build(entries, builder, explicit_terminal_call_id="b")
+    assert set(_owned(result["training_traces"])) == {"b"}
+    entries.append(_entry("c", [1, 11, 2], [12], "b"))
+    result = _build(entries, builder)
+    assert set(_owned(result["training_traces"])) == {"b", "c"}
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+def test_delta_prompts_equal_full_prompt_reconstruction(builder):
+    first = _entry("a", [1], [10])
+    full = _entry("b", [1, 10, 2], [11], "a")
+    delta = full.model_copy(update={"prompt_token_ids": [2], "prompt_is_delta": True})
+    assert _build([first, delta], builder)["training_traces"] == _build([first, full], builder)["training_traces"]
+    bad = _build([delta], builder)
+    assert bad["mask_sample"] and "training_traces" not in bad
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"rollout_id": "different"},
+        {"parent_resolution": ParentResolutionStatus.UNRESOLVED},
+        {"digest": "bad-proof"},
+        {"cum_len": 999},
+        {"generation_log_probs": [float("nan")]},
+        {"routed_experts": [[0]]},
+    ],
+)
+def test_unsupported_or_unproven_evidence_is_not_delivered(update):
+    result = _build([_entry("a", [1], [10]).model_copy(update=update)])
+    assert result["mask_sample"] and "training_traces" not in result
+
+
+def test_unknown_terminal_and_mixed_policy_models_fail_closed():
+    assert _build([_entry("a", [1], [10])], declared_response_id="missing")["mask_sample"]
+    result = _build([_entry("a", [1], [10]), _entry("b", [2], [11]).model_copy(update={"model": "other"})])
+    assert result["mask_sample"]
+
+
+def test_empty_prompt_and_empty_generation_cannot_create_unconditioned_loss():
+    assert _build([_entry("a", [], [10])])["mask_sample"]
+    assert _build([_entry("a", [1], [])])["mask_sample"]
+
+
+@pytest.mark.parametrize("builder", ["prefix_merging", "per_request"])
+async def test_source_file_and_finalizer_share_envelope_and_retirement_boundary(tmp_path, builder):
+    store = TokenCaptureStore(tmp_path)
+    for entry in _branching_calls():
+        store.append(entry)
+    file_result = trajectories_for_rollout("r1", [tmp_path], builder=builder, delivery="all_traces")
+    source_result = await trajectories_from_source("r1", store, builder=builder, delivery="all_traces")
+    assert file_result["training_traces"] == source_result["training_traces"]
+    response = {"output": [{"generation_token_ids": [99], "content": "scored answer"}]}
+    record = {ROLLOUT_ID_KEY_NAME: "r1", "response": copy.deepcopy(response), "reward": 0.75}
+    built = await finalize_rollout_token_capture(record, store, builder=builder, delivery="all_traces")
+    assert record["response"] == response and record["reward"] == 0.75
+    assert record["training_traces"] == file_result["training_traces"]
+    assert capture_build_can_retire(built)
+    assert len(store.read_entries("r1")) == 4
+    assert await retire_rollout_token_capture("r1", store, built)
+    assert store.read_entries("r1") == []
+    await store.close()
+
+
+async def test_incomplete_source_masks_and_removes_stale_envelope():
+    source = AsyncMock()
+    source.freeze.return_value = TokenCaptureSnapshot("r1", tuple(_branching_calls()), True, "frozen", 1)
+    result = {ROLLOUT_ID_KEY_NAME: "r1", "response": {}, "training_traces": {"stale": True}}
+    with pytest.warns(UserWarning, match="incompletely"):
+        built = await finalize_rollout_token_capture(result, source, delivery="all_traces")
+    assert result["mask_sample"] and "training_traces" not in result
+    assert not capture_build_can_retire(built)
+
+
+@pytest.mark.parametrize(
+    "block,match",
+    [
+        ({"builder": "per_request"}, "per_request requires"),
+        (
+            {"enabled": True, "delivery": "all_traces", "external_staging": True, "rebuild_response": False},
+            "external_staging",
+        ),
+        ({"delivery": "unknown"}, "Input should be"),
+    ],
+)
+def test_unsupported_config_rejected_before_training(block, match):
+    with pytest.raises(ValidationError, match=match):
+        TokenIdCaptureConfig.model_validate({"token_id_capture": block})
+
+
+def test_default_configuration_is_legacy_and_per_request_is_registered():
+    settings = TokenIdCaptureConfig().token_id_capture
+    assert settings.delivery == "main_chain" and settings.builder == "prefix_merging"
+    assert run_builder(_branching_calls(), "per_request").notes.builder == "per_request"
+
+
+@pytest.mark.parametrize(
+    "damage",
+    [
+        "double-owner",
+        "span-outside",
+        "unowned-mask",
+        "first-token",
+        "nan",
+        "length",
+        "call-ids",
+        "overlap",
+        "trace-ids",
+        "unowned-call",
+    ],
+)
+def test_wire_contract_rejects_invalid_ownership_and_alignment(damage):
+    envelope = _build(_branching_calls())["training_traces"]
+    first = envelope["traces"][0]
+    if damage == "double-owner":
+        duplicate = copy.deepcopy(first)
+        duplicate["trace_id"] = "duplicate"
+        envelope["traces"].append(duplicate)
+    elif damage == "span-outside":
+        first["sampled_spans"][0]["end"] = 1000
+    elif damage == "unowned-mask":
+        first["loss_mask"][1] = 1
+    elif damage == "first-token":
+        first["loss_mask"][0] = 1
+    elif damage == "nan":
+        first["generation_logprobs"][0] = float("nan")
+    elif damage == "length":
+        first["generation_logprobs"].pop()
+    elif damage == "call-ids":
+        first["model_call_ids"].append(first["model_call_ids"][0])
+    elif damage == "overlap":
+        first["sampled_spans"].append(copy.deepcopy(first["sampled_spans"][0]))
+    elif damage == "trace-ids":
+        envelope["traces"][1]["trace_id"] = first["trace_id"]
+    else:
+        first["model_call_ids"].append("missing-owner")
+    with pytest.raises(ValidationError):
+        TrainingTraceBatch.model_validate(envelope)
+
+
+def test_direct_projection_rejects_wrong_rollout_and_unavailable_terminal():
+    entries = _branching_calls()
+    with pytest.raises(ValueError, match="different rollout"):
+        project_training_traces("wrong", run_builder(entries, all_traces=True))
+    with pytest.raises(ValueError, match="terminal"):
+        project_training_traces("r1", run_builder(entries, terminal_call_id="absent", all_traces=True))


### PR DESCRIPTION
## What does this PR do?

Captured rollouts can contain several valid call chains, but token-capture finalization currently delivers only the selected main chain. Add opt-in `token_id_capture.delivery=all_traces` to deliver retained branches and independent roots in a versioned `training_traces` envelope, while preserving the scored response and reward.

Reuse the existing verified-parent prefix builder and retry admission for both `prefix_merging` and the new `per_request` mode. Each sampled generation has exactly one loss-bearing owner; repeated ancestor context is masked. The envelope carries aligned tokens, behavior logprobs, loss masks, and sampled-span ownership. Logical rewards, advantages, and trainer normalization remain the consuming framework's responsibility.

A complete, independently validated full prompt whose resolved declared parent fails only byte-prefix matching is retained as a separate root. This handles canonical template rewrites without asserting continuity across them. Unverifiable delta prompts or parent custody, incomplete captures, conflicting duplicates, and ambiguous retries still fail closed.

Defaults retain the current main-chain API. This initial scope supports one text policy model through local capture or a generic `TokenSource`; plural `external_staging` and router-replay extras are explicitly unsupported. Same-prompt independent invocations still need sufficient retention evidence to distinguish them from retries.

Validation:

- 469 capture, rollout, and transport regression tests passed; coverage checked separately.
- 42 contract/reconstruction tests passed with 100% coverage of the new schema/projection module.
- The template-rewrite follow-up passed 125 contract, builder, and terminal-attribution tests, including full-prompt fallback and unchanged retry/delta safeguards.
- `pre-commit run --all-files` passed at the current head.
- Fern check: zero errors, one warning.

Live integration with Pi + Reasoning Gym (`knights_knaves`), `Qwen/Qwen3-1.7B`, and the [companion NeMo RL consumer](https://github.com/NVIDIA-NeMo/RL/pull/4078) completed two optimization steps and saved changed model weights in each mode:

| Training mode | Logical rollouts | Captured calls / training traces | Sampled tokens |
|---|---:|---:|---:|
| `per_request` | 16 | 32 / 32 | 9,232 |
| `prefix_merging` | 16 | 32 / 32 | 9,801 |

Every sampled token and behavior logprob matched from raw capture through trace ownership to the active training mask, with no missing, duplicate, incomplete, or overlong exclusions. Both tool-call and reasoning/final-response generations entered training; 4,665 tokens had nonzero advantage across the two runs. Tool outputs and prompt context remained masked. Rebuilding each saved capture with both builders preserved identical sampled ownership. Pi's canonical template rewrites produced separate roots; chain joining and fork ownership are covered by deterministic tests.

Upstream [full PR CI](https://github.com/NVIDIA-NeMo/Gym/actions/runs/34477973243) and [wheel validation](https://github.com/NVIDIA-NeMo/Gym/actions/runs/34477974035) passed at `407fcf9`. [Automated review](https://github.com/NVIDIA-NeMo/Gym/pull/3212#issuecomment-5619050646) completed with **SHIP — no reliability concerns** and no requested changes.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated edits are excluded.
- [x] Tests added or updated and pass in the HSG development environment.
- [x] Pre-commit checks pass (`pre-commit run --all-files`).
- [x] All commits have DCO sign-off (`git commit -s`).
