### PR TITLE
feat(core): define the shared failure-kind vocabulary

### DIFF
--- a/nemo_gym/failure_kinds.py
+++ b/nemo_gym/failure_kinds.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared names for why a rollout failed.
+
+Gym describes failures with free text and component-local labels, so the same failure
+arrives at a collector, a log line and a metric under three different names and cannot be
+grouped. This module holds the one vocabulary those producers share.
+
+A name says *what kind of thing went wrong* and nothing else. Whether to retry, whether
+the request may be replayed, whether a completed result should be masked, and what to tell
+a person are all properties of the occurrence, not of the name — they live on the failure
+record, on the verify response, and in ``failure_reason`` respectively. Keeping them out is
+deliberate: metadata attached to a name goes stale the moment one caller wants to retry
+what another caller does not.
+
+Names are low cardinality on purpose. They are safe as a metric label or a span dimension;
+``failure_reason`` never is, because it carries occurrence detail and can be unbounded.
+
+This module imports only the standard library so that data tooling can read the vocabulary
+without installing any server's requirements.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+# ``<domain>_<condition>``. The domain says which layer observed the failure, so a reader
+# can tell an unreachable model server from an unreachable sandbox without a second field.
+_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# An environment may use ``<server>:<kind>`` for something the shared vocabulary should not
+# grow a name for. The prefix keeps it groupable without making it look registered.
+_NAMESPACED_PATTERN = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+
+
+# --- transport: reaching another process at all ------------------------------------- #
+TRANSPORT_UNREACHABLE = "transport_unreachable"
+TRANSPORT_PEER_DROP = "transport_peer_drop"
+TRANSPORT_TIMEOUT = "transport_timeout"
+TRANSPORT_LOCAL_RESOURCE = "transport_local_resource"
+
+# --- agent: the /run call and the harness behind it ---------------------------------- #
+# Both are produced today by rollout collection: the agent answered and broke, versus
+# something in front of it answered and the rollout never ran.
+AGENT_RUN_ERROR = "agent_run_error"
+AGENT_REQUEST_FAILED = "agent_request_failed"
+AGENT_TIMEOUT = "agent_timeout"
+AGENT_COMMAND_NOT_ALLOWED = "agent_command_not_allowed"
+
+# --- verifier and judge --------------------------------------------------------------- #
+# ``judge_failed`` is produced today by judge_failsafe and by reverification.
+JUDGE_FAILED = "judge_failed"
+JUDGE_UNPARSEABLE = "judge_unparseable"
+VERIFIER_ERROR = "verifier_error"
+
+# --- provider: sandboxes, browsers, containers ----------------------------------------- #
+PROVIDER_UNAVAILABLE = "provider_unavailable"
+PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+PROVIDER_OOM_KILLED = "provider_oom_killed"
+
+# --- resources session ------------------------------------------------------------------ #
+SESSION_LOST = "session_lost"
+SESSION_EXPIRED = "session_expired"
+SESSION_RELEASE_FAILED = "session_release_failed"
+
+# --- cancellation and process lifecycle -------------------------------------------------- #
+# ``kill_shaped`` names what rollout collection already treats as unstorable: a SIGTERM, a
+# dead Ray actor, an OOM outside the rollout's own process.
+CANCELLED = "cancelled"
+KILL_SHAPED = "kill_shaped"
+SHUTDOWN = "shutdown"
+
+# --- persistence and cohorts --------------------------------------------------------------- #
+PERSISTENCE_FAILED = "persistence_failed"
+COHORT_INCOMPLETE = "cohort_incomplete"
+
+
+FAILURE_KINDS: frozenset[str] = frozenset(
+    {
+        TRANSPORT_UNREACHABLE,
+        TRANSPORT_PEER_DROP,
+        TRANSPORT_TIMEOUT,
+        TRANSPORT_LOCAL_RESOURCE,
+        AGENT_RUN_ERROR,
+        AGENT_REQUEST_FAILED,
+        AGENT_TIMEOUT,
+        AGENT_COMMAND_NOT_ALLOWED,
+        JUDGE_FAILED,
+        JUDGE_UNPARSEABLE,
+        VERIFIER_ERROR,
+        PROVIDER_UNAVAILABLE,
+        PROVIDER_QUOTA_EXHAUSTED,
+        PROVIDER_OOM_KILLED,
+        SESSION_LOST,
+        SESSION_EXPIRED,
+        SESSION_RELEASE_FAILED,
+        CANCELLED,
+        KILL_SHAPED,
+        SHUTDOWN,
+        PERSISTENCE_FAILED,
+        COHORT_INCOMPLETE,
+    }
+)
+
+
+def is_registered(name: str) -> bool:
+    """Whether ``name`` is part of the shared vocabulary."""
+    return name in FAILURE_KINDS
+
+
+def is_namespaced(name: str) -> bool:
+    """Whether ``name`` is an environment's own ``<server>:<kind>`` extension."""
+    return bool(_NAMESPACED_PATTERN.match(name))
+
+
+def validate_failure_kind(name: str | None) -> str | None:
+    """Return ``name`` unchanged, warning once about anything unregistered.
+
+    Producers call this at their boundary. It warns rather than raises so a component that
+    still emits an old label stays visible during migration — rejecting it outright would
+    replace an observable wrong name with an invisible dropped failure, which is worse than
+    the problem this vocabulary exists to fix.
+    """
+    if name is None or is_registered(name) or is_namespaced(name):
+        return name
+    logger.warning(
+        "unregistered failure_kind %r; register it in nemo_gym/failure_kinds.py or namespace it as '<server>:%s'",
+        name,
+        name,
+    )
+    return name

--- a/nemo_gym/failure_kinds.py
+++ b/nemo_gym/failure_kinds.py
@@ -43,11 +43,13 @@ logger = logging.getLogger(__name__)
 
 # ``<domain>_<condition>``. The domain says which layer observed the failure, so a reader
 # can tell an unreachable model server from an unreachable sandbox without a second field.
-_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+# ``fullmatch`` below, not ``match``: ``$`` also matches before a final newline, which
+# would admit "judge_failed\n" as a second, silently different label for one failure.
+_NAME_PATTERN = re.compile(r"[a-z][a-z0-9_]*")
 
 # An environment may use ``<server>:<kind>`` for something the shared vocabulary should not
 # grow a name for. The prefix keeps it groupable without making it look registered.
-_NAMESPACED_PATTERN = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+_NAMESPACED_PATTERN = re.compile(r"[a-z][a-z0-9_]*:[a-z][a-z0-9_]*")
 
 
 # --- transport: reaching another process at all ------------------------------------- #
@@ -127,11 +129,16 @@ def is_registered(name: str) -> bool:
 
 def is_namespaced(name: str) -> bool:
     """Whether ``name`` is an environment's own ``<server>:<kind>`` extension."""
-    return bool(_NAMESPACED_PATTERN.match(name))
+    return bool(_NAMESPACED_PATTERN.fullmatch(name))
+
+
+# Names already reported. A failing component emits the same label on every rollout, so
+# warning per call would bury the one line that matters under thousands of copies.
+_WARNED_UNKNOWN: set[str] = set()
 
 
 def validate_failure_kind(name: str | None) -> str | None:
-    """Return ``name`` unchanged, warning once about anything unregistered.
+    """Return ``name`` unchanged, warning once per unregistered value.
 
     Producers call this at their boundary. It warns rather than raises so a component that
     still emits an old label stays visible during migration — rejecting it outright would
@@ -140,9 +147,11 @@ def validate_failure_kind(name: str | None) -> str | None:
     """
     if name is None or is_registered(name) or is_namespaced(name):
         return name
-    logger.warning(
-        "unregistered failure_kind %r; register it in nemo_gym/failure_kinds.py or namespace it as '<server>:%s'",
-        name,
-        name,
-    )
+    if name not in _WARNED_UNKNOWN:
+        _WARNED_UNKNOWN.add(name)
+        logger.warning(
+            "unregistered failure_kind %r; register it in nemo_gym/failure_kinds.py or namespace it as "
+            "'<server>:<kind>'. Reported once per name.",
+            name,
+        )
     return name

--- a/tests/unit_tests/test_failure_kinds.py
+++ b/tests/unit_tests/test_failure_kinds.py
@@ -59,6 +59,12 @@ class TestRegistryLookup:
     def test_a_bare_name_is_not_namespaced(self) -> None:
         assert not is_namespaced("judge_failed")
 
+    def test_a_trailing_newline_is_not_a_legal_name(self) -> None:
+        """`$` also matches before a final newline, so `match` would admit a second,
+        silently different label for the same failure."""
+        assert not is_namespaced("my_server:odd_case\n")
+        assert not is_registered("judge_failed\n")
+
 
 class TestValidation:
     def test_a_registered_name_passes_silently(self, caplog) -> None:
@@ -75,11 +81,39 @@ class TestValidation:
 
     def test_an_unknown_name_warns_but_survives(self, caplog) -> None:
         """Rejecting it would trade a visible wrong name for an invisible dropped failure."""
+        failure_kinds._WARNED_UNKNOWN.discard("legacy_label")
         with caplog.at_level(logging.WARNING):
             result = validate_failure_kind("legacy_label")
 
         assert result == "legacy_label"
         assert any("legacy_label" in record.getMessage() for record in caplog.records)
+
+    def test_a_malformed_namespaced_value_takes_the_unknown_path(self, caplog) -> None:
+        """It stays observable instead of passing silently as a namespaced name."""
+        with caplog.at_level(logging.WARNING):
+            result = validate_failure_kind("my_server:odd_case\n")
+
+        assert result == "my_server:odd_case\n"
+        assert len(caplog.records) == 1
+
+    def test_the_same_unknown_name_is_reported_once(self, caplog) -> None:
+        """A failing component emits the same label on every rollout; warning per call
+        buries the one line that matters."""
+        failure_kinds._WARNED_UNKNOWN.discard("repeated_legacy")
+        with caplog.at_level(logging.WARNING):
+            for _ in range(1000):
+                assert validate_failure_kind("repeated_legacy") == "repeated_legacy"
+
+        assert len(caplog.records) == 1
+
+    def test_each_distinct_unknown_name_is_still_reported(self, caplog) -> None:
+        for name in ("legacy_one", "legacy_two"):
+            failure_kinds._WARNED_UNKNOWN.discard(name)
+        with caplog.at_level(logging.WARNING):
+            validate_failure_kind("legacy_one")
+            validate_failure_kind("legacy_two")
+
+        assert len(caplog.records) == 2
 
     def test_absent_is_not_a_failure(self, caplog) -> None:
         with caplog.at_level(logging.WARNING):

--- a/tests/unit_tests/test_failure_kinds.py
+++ b/tests/unit_tests/test_failure_kinds.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The shared failure vocabulary has to stay small, stable and label-safe."""
+
+import logging
+import re
+
+from nemo_gym import failure_kinds
+from nemo_gym.failure_kinds import (
+    FAILURE_KINDS,
+    is_namespaced,
+    is_registered,
+    validate_failure_kind,
+)
+
+
+class TestNamingConvention:
+    def test_every_name_matches_one_convention(self) -> None:
+        assert all(re.fullmatch(r"[a-z][a-z0-9_]*", name) for name in FAILURE_KINDS)
+
+    def test_no_name_differs_from_another_only_by_case_or_separator(self) -> None:
+        """Two spellings of one failure defeat the grouping this vocabulary exists for."""
+        normalized = [name.lower().replace("_", "") for name in FAILURE_KINDS]
+
+        assert len(set(normalized)) == len(normalized)
+
+    def test_every_name_states_the_layer_that_observed_the_failure(self) -> None:
+        """`transport_timeout` and `agent_timeout` are different failures, not one."""
+        domains = ("transport_", "agent_", "judge_", "verifier_", "provider_", "session_", "cohort_", "persistence_")
+        lifecycle = {"cancelled", "kill_shaped", "shutdown"}
+
+        undomained = {n for n in FAILURE_KINDS if not n.startswith(domains)} - lifecycle
+
+        assert undomained == set()
+
+
+class TestRegistryLookup:
+    def test_a_registered_name_is_recognized(self) -> None:
+        assert is_registered("judge_failed")
+
+    def test_an_unregistered_name_is_not(self) -> None:
+        assert not is_registered("something_invented")
+
+    def test_an_environment_can_namespace_its_own(self) -> None:
+        assert is_namespaced("lexmount_browser:quota_exhausted")
+
+    def test_a_bare_name_is_not_namespaced(self) -> None:
+        assert not is_namespaced("judge_failed")
+
+
+class TestValidation:
+    def test_a_registered_name_passes_silently(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert validate_failure_kind("judge_failed") == "judge_failed"
+
+        assert caplog.records == []
+
+    def test_a_namespaced_name_passes_silently(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert validate_failure_kind("my_server:odd_case") == "my_server:odd_case"
+
+        assert caplog.records == []
+
+    def test_an_unknown_name_warns_but_survives(self, caplog) -> None:
+        """Rejecting it would trade a visible wrong name for an invisible dropped failure."""
+        with caplog.at_level(logging.WARNING):
+            result = validate_failure_kind("legacy_label")
+
+        assert result == "legacy_label"
+        assert any("legacy_label" in record.getMessage() for record in caplog.records)
+
+    def test_absent_is_not_a_failure(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert validate_failure_kind(None) is None
+
+        assert caplog.records == []
+
+
+class TestLabelSafety:
+    def test_the_vocabulary_stays_small_enough_to_be_a_metric_label(self) -> None:
+        """A name is a metric dimension. Free text belongs in `failure_reason` instead."""
+        assert len(FAILURE_KINDS) < 64
+
+    def test_no_name_carries_occurrence_detail(self) -> None:
+        assert all(len(name) < 40 and " " not in name for name in FAILURE_KINDS)
+
+
+class TestNamesTheRepoAlreadyProduces:
+    """Labels main emits today must be in the vocabulary, or it describes nothing."""
+
+    def test_rollout_collection_row_routing_classes(self) -> None:
+        from nemo_gym.rollout_collection import AGENT_REQUEST_FAILED_FAILURE_CLASS, AGENT_RUN_ERROR_FAILURE_CLASS
+
+        assert is_registered(AGENT_RUN_ERROR_FAILURE_CLASS)
+        assert is_registered(AGENT_REQUEST_FAILED_FAILURE_CLASS)
+
+    def test_the_judge_failsafe_class(self) -> None:
+        from nemo_gym.rollout_reverification import JUDGE_FAILED_FAILURE_CLASS
+
+        assert is_registered(JUDGE_FAILED_FAILURE_CLASS)
+
+
+class TestDependencyWeight:
+    def test_the_module_imports_nothing_from_the_server_stack(self) -> None:
+        """Data tooling reads the vocabulary without installing any server's requirements."""
+        source = open(failure_kinds.__file__).read()
+
+        assert "import fastapi" not in source
+        assert "from nemo_gym" not in source


### PR DESCRIPTION
Closes #3179

Gym describes failures with free text and component-local labels, so the same failure reaches a collector, a log line and a metric under three different names and cannot be grouped.

## What a name is, and what it is not

A name says what kind of thing went wrong and nothing else. Retryability, replay safety, whether a completed result should be masked, and what to tell a person are properties of the occurrence rather than of the name — they belong to the failure record, the verify response, and `failure_reason`.

Keeping them out is the reason the registry carries no per-entry metadata: anything attached to a name goes stale the moment one caller wants to retry what another does not. That is also what the acceptance criterion "no retry-policy metadata that can become stale" asks for.

Names are `<domain>_<condition>`, so a reader can tell an unreachable model server from an unreachable sandbox without a second field, and they are low cardinality, so they are safe as a metric label or a span dimension. `failure_reason` never is.

## Unknown names warn rather than raise

`validate_failure_kind` returns the name unchanged and logs once. Rejecting an unregistered value would trade a visible wrong label for an invisible dropped failure, which is worse than the problem the vocabulary exists to fix, and it would break components mid-migration. An environment that needs something the shared set should not grow can use `<server>:<kind>`.

## The vocabulary describes the repo, not an intention

`agent_run_error`, `agent_request_failed` and `judge_failed` are labels `main` emits today. Tests import those constants from `rollout_collection` and `rollout_reverification` and assert they are registered, so the set cannot drift from the code that produces it.

## Scope

This adds the vocabulary only. `failure_kind` reaching `BaseVerifyResponse` is #2608's follow-on and lands with #2611, which rebases onto whatever merges here. Typed rollout outcomes referencing the same names are #2135.

## Relationship to #2728

This replaces rather than rebases #2728. That PR is on a fork branch we cannot push to, and #3179's last acceptance criterion is "PR #2728 is rebased or replaced under this issue". The vocabulary here is drawn from what `main` produces now, which has moved since #2728 was drafted — #2017 and #2883 introduced the `agent_request_failed` / `agent_run_error` split. The `status`/`source` fields are dropped for the reason above.

## Tests

16 cases: every name matches one convention and no two differ only by case or separator; every name states the layer that observed the failure; registered, unregistered and namespaced lookup; validation staying silent on known names and warning without raising on unknown ones; the set staying small enough to be a metric label and carrying no occurrence detail; the labels `main` already produces staying registered; and the module importing nothing from the server stack so data tooling can read it without installing a server's requirements.

`uv run --extra dev pytest tests/unit_tests -q` → 4348 passed. `test_e2b_provider` and `test_enroot_provider` fail on a clean `upstream/main` too.
