### PR TITLE
GDPVal: Read nested task reference inputs when enabled

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -269,6 +269,8 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_pdf_include_text: bool = True
     # Exact request-wide image cap for raster and PDF-overflow transports.
     judge_max_images_per_request: int = 450
+    # Read nested reference inputs while leaving submission directories shallow.
+    judge_reference_files_recursive: bool = False
     # Whether the (single) local judge natively reads audio / video, tracked
     # SEPARATELY because MiniMax-M3 — the reference self-hosted judge — reads video
     # but NOT audio (its config has an image + video tower but no audio config). So
@@ -911,6 +913,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     include_text=self.config.judge_pdf_include_text,
                     audio_capable=audio_capable,
                     video_capable=video_capable,
+                    recursive=bool(
+                        self.config.judge_reference_files_recursive and path and path.name == "reference_files"
+                    ),
                 )
             return section_cache[key]
 

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -750,6 +750,7 @@ def build_file_section(
     include_text: bool = True,
     audio_capable: bool = False,
     video_capable: bool = False,
+    recursive: bool = False,
 ) -> list[dict]:
     """Build OpenAI content blocks from all files in a directory.
 
@@ -766,6 +767,8 @@ def build_file_section(
     *video_capable* keep audio / video files (respectively) as native media
     blocks (vs stubbing them) when the judge reads that modality — they are
     independent so a video-only judge (MiniMax-M3) keeps video but stubs audio.
+    *recursive* includes nested files and ZIPs, retaining relative input labels
+    and resolving Office PDF sidecars in each file's own directory.
     """
     if clean_up_list is None:
         clean_up_list = []
@@ -819,14 +822,22 @@ def build_file_section(
         for block in blocks:
             _append_block(block)
 
-    extracted_dirs: list[Path] = []
+    file_names: list[str] = []
     if file_dir is not None and os.path.exists(file_dir):
-        for file_name in os.listdir(file_dir):
-            if file_name.lower().endswith(".zip"):
-                extract_dir, _ = _maybe_unzip(os.path.join(file_dir, file_name))
-                if extract_dir is not None:
-                    clean_up_list.append(extract_dir)
-                    extracted_dirs.append(extract_dir)
+        file_names = os.listdir(file_dir)
+        if recursive:
+            file_names.extend(
+                path.relative_to(file_dir).as_posix()
+                for path in sorted(Path(file_dir).rglob("*"))
+                if path.is_file() and path.parent != Path(file_dir)
+            )
+    extracted_dirs: list[tuple[Path, str]] = []
+    for file_name in file_names:
+        if file_name.lower().endswith(".zip"):
+            extract_dir, _ = _maybe_unzip(os.path.join(file_dir, file_name))
+            if extract_dir is not None:
+                clean_up_list.append(extract_dir)
+                extracted_dirs.append((extract_dir, file_name))
 
     ignore_files = _ignore_files()
     provenance_by_dir: dict[Path, Any] = {}
@@ -882,16 +893,17 @@ def build_file_section(
         except Exception as exc:
             return f"[structured spreadsheet extraction failed: {exc}]"
 
-    def _emit(directory: str, file_name: str) -> None:
+    def _emit(directory: str, file_name: str, *, label: str | None = None) -> None:
         nonlocal no_files
         if file_name in ignore_files:
             return
+        label = label or file_name
         full_path = Path(directory) / file_name
         provenance = _provenance(directory)
         parent = Path(directory)
         if full_path in provenance.suppressed_pdfs or full_path in fallback_suppressed_by_dir[parent]:
             return
-        _append_block({"type": "text", "text": f"\n{file_name}:\n"})
+        _append_block({"type": "text", "text": f"\n{label}:\n"})
         info = FILE_TYPE_MAP.get(full_path.suffix.lower().lstrip(".")) or {}
         av_identity: tuple[int, str] | None = None
         if info.get("type") in {"AUDIO", "VIDEO"}:
@@ -936,14 +948,14 @@ def build_file_section(
             if blocks:
                 _append_blocks(blocks)
                 if av_identity is not None and any(_attachment_payload(block)[0] for block in blocks):
-                    retained_av_payloads[av_identity] = file_name
+                    retained_av_payloads[av_identity] = label
                 no_files = False
             sheet_text = _structured_xlsx_text(full_path)
             if sheet_text:
                 _append_block(
                     {
                         "type": "text",
-                        "text": f"\n{file_name} (structured spreadsheet cells):\n{sheet_text}",
+                        "text": f"\n{label} (structured spreadsheet cells):\n{sheet_text}",
                     }
                 )
                 no_files = False
@@ -959,25 +971,26 @@ def build_file_section(
         if block is not None:
             _append_block(block)
             if av_identity is not None and _attachment_payload(block)[0]:
-                retained_av_payloads[av_identity] = file_name
+                retained_av_payloads[av_identity] = label
             no_files = False
         sheet_text = _structured_xlsx_text(full_path)
         if sheet_text:
-            _append_block({"type": "text", "text": f"\n{file_name} (structured spreadsheet cells):\n{sheet_text}"})
+            _append_block({"type": "text", "text": f"\n{label} (structured spreadsheet cells):\n{sheet_text}"})
             no_files = False
 
-    if file_dir is not None and os.path.exists(file_dir):
-        for file_name in sorted(os.listdir(file_dir)):
-            full_path = os.path.join(file_dir, file_name)
-            if os.path.isdir(full_path) or file_name.lower().endswith(".zip"):
-                continue
-            _emit(file_dir, file_name)
+    for file_name in sorted(file_names):
+        full_path = Path(file_dir) / file_name
+        if full_path.is_dir() or file_name.lower().endswith(".zip"):
+            continue
+        _emit(str(full_path.parent), full_path.name, label=file_name)
 
-    for extract_dir in extracted_dirs:
+    for extract_dir, archive_name in extracted_dirs:
         for member in sorted(extract_dir.rglob("*")):
             if not member.is_file():
                 continue
-            _emit(str(member.parent), member.name)
+            # Keep existing top-level ZIP labels unchanged when recursion is enabled.
+            label = f"{archive_name}!/{member.relative_to(extract_dir).as_posix()}" if "/" in archive_name else None
+            _emit(str(member.parent), member.name, label=label)
 
     if no_files:
         _append_block({"type": "text", "text": "None"})

--- a/resources_servers/gdpval/tests/test_nested_reference_inputs.py
+++ b/resources_servers/gdpval/tests/test_nested_reference_inputs.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from zipfile import ZipFile
+
+import fitz
+import openpyxl
+import pytest
+
+from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.server_utils import ServerClient
+from resources_servers.gdpval import comparison
+from resources_servers.gdpval.app import GDPValResourcesServer, GDPValResourcesServerConfig, GDPValVerifyRequest
+
+
+def _text(blocks: list[dict]) -> str:
+    return "\n".join(block.get("text", "") for block in blocks if block.get("type") == "text")
+
+
+def _attachments(blocks: list[dict]) -> list[bytes]:
+    return [
+        base64.b64decode(block["image_url"]["url"].split(",", 1)[1])
+        for block in blocks
+        if block.get("type") == "image_url"
+    ]
+
+
+def _section(path: Path, **kwargs) -> list[dict]:
+    cleanup: list[Path] = []
+    try:
+        return comparison.build_file_section(str(path), cleanup, **kwargs)
+    finally:
+        comparison.clean_up_paths(cleanup)
+
+
+def _input_tree(root: Path) -> bytes:
+    nested = root / "folder"
+    nested.mkdir(parents=True)
+    (root / "brief.txt").write_text("TOP_LEVEL_INPUT")
+    (nested / "notes.txt").write_text("NESTED_INPUT_TEXT")
+    with ZipFile(nested / "archive.zip", "w") as archive:
+        archive.writestr("inner/member.txt", "NESTED_ARCHIVE_TEXT")
+    (nested / "Plan.docx").write_bytes(b"Office source with a preconverted PDF")
+    with fitz.open() as document:
+        document.new_page().insert_text((72, 72), "Reference document")
+        pdf = document.tobytes()
+    (nested / "Plan.docx.pdf").write_bytes(pdf)
+    return pdf
+
+
+def test_nested_inputs_include_text_zip_and_office_sidecar_once(tmp_path: Path) -> None:
+    pdf = _input_tree(tmp_path)
+
+    shallow = _section(tmp_path)
+    recursive = _section(tmp_path, recursive=True)
+
+    assert _text(shallow).count("TOP_LEVEL_INPUT") == 1
+    assert "NESTED_INPUT_TEXT" not in _text(shallow)
+    assert "NESTED_ARCHIVE_TEXT" not in _text(shallow)
+    assert _attachments(shallow) == []
+    text = _text(recursive)
+    assert text.count("TOP_LEVEL_INPUT") == 1
+    assert text.count("NESTED_INPUT_TEXT") == 1
+    assert text.count("NESTED_ARCHIVE_TEXT") == 1
+    assert "folder/notes.txt:" in text
+    assert "folder/archive.zip!/inner/member.txt:" in text
+    assert text.count("folder/Plan.docx:") == 1
+    assert "Plan.docx.pdf:" not in text
+    assert _attachments(recursive) == [pdf]
+
+
+def test_flat_inputs_and_root_zip_payloads_are_unchanged(tmp_path: Path) -> None:
+    (tmp_path / "input.txt").write_text("PLAIN_INPUT")
+    # Preserve the existing root ZIP order, including when it is not alphabetical.
+    for name in ("z", "a"):
+        with ZipFile(tmp_path / f"{name}.zip", "w") as archive:
+            archive.writestr(f"inner/{name}.txt", f"ARCHIVE_{name}")
+
+    shallow = _section(tmp_path)
+
+    assert "ARCHIVE_z" in _text(shallow)
+    assert "ARCHIVE_a" in _text(shallow)
+    assert _section(tmp_path, recursive=True) == shallow
+
+
+@pytest.mark.parametrize("media_mode", ["native_pdf", "images_and_text"])
+def test_xlsx_without_pdf_keeps_existing_structured_text(tmp_path: Path, media_mode: str) -> None:
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Forecast"
+    sheet["A1"] = "BASELINE_SPREADSHEET"
+    sheet["A2"] = 12
+    sheet["A3"] = "=A2*2"
+    workbook.save(tmp_path / "Budget.xlsx")
+    workbook.close()
+
+    shallow = _section(tmp_path, media_mode=media_mode)
+    recursive = _section(tmp_path, media_mode=media_mode, recursive=True)
+
+    assert recursive == shallow
+    assert _attachments(shallow) == []
+    text = _text(shallow)
+    assert "structured spreadsheet cells" in text
+    assert "Sheet: Forecast" in text
+    assert "BASELINE_SPREADSHEET" in text
+    assert "A3: formula: =A2*2" in text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("recursive", [None, False, True], ids=["default", "disabled", "enabled"])
+async def test_verify_only_recurses_into_reference_inputs(tmp_path: Path, recursive: bool | None) -> None:
+    reference_root = tmp_path / "reference"
+    reference = reference_root / "task_task-1" / "repeat_0"
+    candidate = tmp_path / "candidate" / "task_task-1" / "repeat_0"
+    for directory, label in ((reference, "REFERENCE"), (candidate, "CANDIDATE")):
+        (directory / "nested").mkdir(parents=True)
+        (directory / "finish_params.json").write_text("{}")
+        (directory / "answer.txt").write_text(f"{label}_ANSWER")
+        (directory / "nested" / "hidden.txt").write_text(f"{label}_NESTED_SUBMISSION")
+    pdf = _input_tree(reference / "reference_files")
+    options = {} if recursive is None else {"judge_reference_files_recursive": recursive}
+    config = GDPValResourcesServerConfig(
+        host="127.0.0.1",
+        port=8080,
+        entrypoint="",
+        name="",
+        reward_mode="comparison",
+        judge_model_server={"type": "responses_api_models", "name": "judge"},
+        reference_deliverables_dir=str(reference_root),
+        preconvert_office_to_pdf=False,
+        num_comparison_trials=1,
+        **options,
+    )
+    assert config.judge_reference_files_recursive is bool(recursive)
+    server = GDPValResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+    body = GDPValVerifyRequest(
+        responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+        response=NeMoGymResponse(
+            id="resp-1",
+            created_at=0.0,
+            model="policy",
+            object="response",
+            output=[],
+            status="completed",
+            parallel_tool_calls=False,
+            tool_choice="none",
+            tools=[],
+        ),
+        task_id="task-1",
+        prompt="Compare the submissions against the provided inputs.",
+        rubric_json=None,
+        rubric_pretty="",
+        deliverables_dir=str(candidate),
+    )
+    with (
+        patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+        patch("openai.OpenAI", return_value=MagicMock()),
+        patch(
+            "resources_servers.gdpval.comparison.run_trials",
+            return_value={"winner": "[[B]]", "win_count_a": 0, "win_count_b": 1, "tie_count": 0, "task_count": 1},
+        ) as dispatch,
+    ):
+        result = await server.verify(body)
+
+    assert result.total_wins == 1
+    dispatch.assert_called_once()
+    sent = dispatch.call_args.kwargs
+    inputs = _text(sent["refs"])
+    assert inputs.count("TOP_LEVEL_INPUT") == 1
+    assert inputs.count("NESTED_INPUT_TEXT") == int(bool(recursive))
+    assert inputs.count("NESTED_ARCHIVE_TEXT") == int(bool(recursive))
+    assert _attachments(sent["refs"]) == ([pdf] if recursive else [])
+    assert "REFERENCE_ANSWER" in _text(sent["submission_a"])
+    assert "CANDIDATE_ANSWER" in _text(sent["submission_b"])
+    for section in (sent["submission_a"], sent["submission_b"]):
+        text = _text(section)
+        assert "NESTED_SUBMISSION" not in text
+        assert "TOP_LEVEL_INPUT" not in text
+        assert "NESTED_INPUT_TEXT" not in text
+    for sections in sent["sections_by_judge"].values():
+        assert sections["refs"] == sent["refs"]


### PR DESCRIPTION
GDPVal task inputs stored under `reference_files/<hash>/...` are skipped by the existing shallow reader. This adds opt-in recursive input reading while preserving the existing handling of submission directories, PDFs, spreadsheets, and attachment limits.

Enable it with:

```text
++gdpval_resources_server.resources_servers.gdpval.judge_reference_files_recursive=true
```

The flag defaults to false. Nested files and ZIP contents retain relative labels, and Office PDF previews use the existing per-directory provenance handling. Flat input payloads remain unchanged.

Validation: 91 tests passed, including seven new cases covering nested text/ZIP/PDF inputs through verification dispatch, unchanged shallow submissions and flat ZIP payloads, and XLSX extraction without a PDF. Ruff, whitespace and PR checks passed. A matched live four-task smoke produced 16 valid votes and no failures in each arm; request sizes increased when nested inputs were included.

A 220-task iter3159 judging comparison used original media, baseline judge/PDF settings, identical reference paths/ELOs, seed 42, four trials and unchanged attachment budgets:

| Recursive inputs | Judged tasks | Transport failures | Partial stage ELO |
|---|---:|---:|---:|
| Off | 218/220 | 2 | 1242.68 |
| On | 216/220 | 4 | 1242.83 |

All judged tasks had four valid votes and zero invalid votes. On the 216 shared task/reference pairs, ELO changed from 1246.35 to 1242.83 (-3.52); final reference assignments were identical. This is one paired comparison, and both complete-set headline scores remain withheld because of missing judgments. Failures were not imputed as losses.

Recursive calibration resumed from 44/45 saved judgments using the existing partial-calibration option; control completed 45/45. The two additional rejected tasks contain original inputs above the existing section budget: 657 MiB and 220 MiB videos, and five WAV files totaling 232 MiB. Media transport and compression remain separate from this input-discovery fix.
