### PR TITLE
feat(core): add typed rollout failures and resumable evaluation attempts

### DIFF
--- a/fern/versions/latest/pages/evaluation-tutorials/reverify-rollouts.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/reverify-rollouts.mdx
@@ -157,6 +157,9 @@ gym eval reverify --judge-failed-only \
 
 The output holds the successes plus the recovered rows. Re-running is idempotent, and `--resume` picks up any rows a fixed-but-still-flaky judge left behind.
 
+Judge failures without a saved `response` are reported and skipped. They need a new generation attempt through rollout
+collection; reverification cannot reconstruct the missing response.
+
 <Note>
 The judge model must be healthy (and configured the same as the original run) when you recover. Since the recovered rewards are computed now while the successes were scored during the original run, keep the verifier/judge config identical between the two so the merged metrics stay consistent.
 </Note>
@@ -170,6 +173,11 @@ gym eval reverify --judge-failed-only --append \
   --rollouts results/rollouts.jsonl \
   --output results/rollouts.jsonl
 ```
+
+For runs with a recovery manifest and attempt journal, append records a new attempt before each verifier request and
+preserves the original attempt history. Collection resume and offline aggregation then select the recovered result.
+Only the latest eligible judge failures are retried; terminal markers and the run's attempt budget still apply. See
+[Resume an Evaluation](/main/evaluation/resume) for recovery guarantees and legacy artifact behavior.
 
 ## Sharding
 

--- a/fern/versions/latest/pages/evaluation/resume.mdx
+++ b/fern/versions/latest/pages/evaluation/resume.mdx
@@ -44,7 +44,8 @@ attempts per logical rollout (default: 3); reaching that limit does not create a
 The **greatest dispatched attempt index** determines the current outcome. A late result from an older attempt remains
 in the append-only artifacts but cannot replace the newer attempt or count as an extra sample. A newer attempt with no
 saved outcome remains unknown, even if an older success arrives afterward. Recovery and `gym eval aggregate` use this
-same selection rule.
+same selection rule, recorded as `selection_policy: "latest_dispatched"` in the manifest and coverage report.
+Earlier manifests without this field use the same rule; an unrecognized policy is rejected.
 
 Gym writes `<output_stem>_coverage.json` with an exact inventory:
 
@@ -111,3 +112,8 @@ not copied into the failure record. Completed masked results remain completed di
 The evaluation runner uses structured outcomes when `route_failures_to_sidecar=true`. Its sidecar retains the existing
 `_ng_failure_*` routing aliases for row-oriented consumers and stores the canonical record under `_ng_failure_record`. Those aliases can be removed after
 the consumers and the producer migration in [#3180](https://github.com/NVIDIA-NeMo/Gym/issues/3180) adopt the new contract.
+
+For a legacy `judge_failed` result that includes the actual generated response, the sidecar also preserves that
+`response` outside the canonical failure record, without a reward. This keeps `gym eval reverify --judge-failed-only`
+working: it submits the saved response to the verifier again without rerunning inference. A structured failure that
+never included a response cannot reconstruct one. Other legacy response placeholders are discarded.

--- a/fern/versions/latest/pages/evaluation/resume.mdx
+++ b/fern/versions/latest/pages/evaluation/resume.mdx
@@ -22,7 +22,9 @@ The manifest contains a run identifier, a format version, and digests of:
 - The collection settings and resolved model/environment configuration that affect the tasks.
 
 The manifest does not store credentials or raw configuration values. Changing collection concurrency, reporting options,
-or the assigned Gym server host/port does not invalidate saved results. Changing a model, sampling settings, or tasks does.
+credentials, endpoint addresses, or capture directories does not invalidate saved results. Gym resolves configuration
+for the materialized agents and their referenced servers; unused server configurations need not resolve in the collector.
+Changing a model, sampling settings, task data paths, prompts, or tasks does invalidate saved results.
 
 Keep the manifest, materialized inputs, rollout output, failure sidecar, and attempt journal together.
 Gym records and flushes each dispatch to `<output_stem>_attempts.jsonl` before sending its request. Completed results and
@@ -40,6 +42,15 @@ A completed wrong answer is a result, so it is not retried merely because its re
 A logical rollout retains its task/rollout identity across restarts. Every redispatch receives a larger attempt index,
 including after an interruption that left no result. `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS` bounds the total number of dispatched
 attempts per logical rollout (default: 3); reaching that limit does not create a synthetic failure or reward.
+
+Explicit `_ng_rollout_id` values must be valid capture IDs. Preprocessing preserves them for single copies and adds
+`-r<rollout_index>` when repeats or agent fan-out expand a row. The resulting IDs must be unique within the run.
+Invalid or colliding IDs are configuration errors before dispatch.
+
+Reported `kill_shaped` failures consume attempts and are persisted in the failure sidecar, even when the legacy producer
+also sets `_ng_no_persist`. This differs from older collectors that discarded these failures and did not count them.
+The same policy applies when reverification appends to a journal-backed run. Legacy reverification outputs without a
+manifest retain their previous suppression behavior. A suppression without a reported failure is an intentional omission.
 
 The **greatest dispatched attempt index** determines the current outcome. A late result from an older attempt remains
 in the append-only artifacts but cannot replace the newer attempt or count as an extra sample. A newer attempt with no
@@ -76,6 +87,8 @@ Completed-result quality scoring follows the verifier/aggregation contract; thes
 `scored` retains its existing meaning: the number of completed results, plus failures explicitly counted as zero when
 aggregating. It is separate from the measurement split. Setting `count_failure_classes_as_zero` does not change a failure into
 a measured or completed result and cannot make the five outcome counts exceed `expected`.
+An explicit `skipped` entry in `count_failure_classes_as_zero` includes terminal skipped payloads in scoring while their
+completion disposition remains intentionally omitted. Omissions without a failure payload cannot be scored this way.
 
 Collection and offline aggregation export the same counts as `coverage/measured`, `coverage/masked`, `coverage/failed`,
 `coverage/omitted`, and `coverage/unknown`. For legacy shards without an inventory, observed measured/masked counts remain
@@ -96,6 +109,15 @@ and coverage reports `identity_verified=false`. Future resumes continue to requi
 payloads are preserved; newly written payloads carry the run identifier. Gym still rejects corrupt or unsupported
 manifests and materialized inputs that no longer match their saved manifest.
 Use a fresh output location when the intention is to evaluate changed tasks or a different model.
+
+The unsafe override can also reconstruct missing attempt history from saved payloads, retaining their run identifier.
+If the manifest is missing, all surviving tagged artifacts must agree on one run. Conflicting or foreign-run records
+remain errors. Dispatches that left no saved outcome cannot be reconstructed after journal loss, so attempt counts become
+lower bounds; recovered coverage remains unverified. Keep the journal whenever possible.
+
+Offline aggregation reads untagged legacy append/reverify artifacts without requiring a manifest. Where older writers
+reused an attempt index, migration orders those legacy outcomes by their recorded arrival, with sidecar failures read
+before main-file results. This compatibility rule does not relax conflict detection for journal-backed records.
 
 ## Structured failures for direct callers
 
@@ -132,8 +154,17 @@ not copied into the failure record. Completed masked results remain completed di
 The evaluation runner uses structured outcomes when `route_failures_to_sidecar=true`. Its sidecar retains the existing
 `_ng_failure_*` routing aliases for row-oriented consumers and stores the canonical record under `_ng_failure_record`. Those aliases can be removed after
 the consumers and the producer migration in [#3180](https://github.com/NVIDIA-NeMo/Gym/issues/3180) adopt the new contract.
+When routing is disabled, exceptions and malformed failure payloads can stop the run. Well-formed explicit failures are
+still accepted as data. Diagnostic observations, trajectories, and captured model calls are retained in the surrounding
+sidecar record, outside the canonical failure; they do not turn a failure into a completed training sample.
 
 For a legacy `judge_failed` result that includes the actual generated response, the sidecar also preserves that
 `response` outside the canonical failure record, without a reward. This keeps `gym eval reverify --judge-failed-only`
 working: it submits the saved response to the verifier again without rerunning inference. A structured failure that
-never included a response cannot reconstruct one. Other legacy response placeholders are discarded.
+never included a response cannot reconstruct one: reverification reports and skips it while continuing rows with saved
+responses. Resume collection to rerun generation for that work. Other legacy response placeholders are discarded.
+
+With `--judge-failed-only --append` and the original rollout file as both input and output, reverification records new
+attempts in the same journal before sending verifier requests. Recovered results then participate in the same selection
+rules as collection and aggregation. Terminal failures and exhausted attempt budgets are respected. Full reverification
+uses a separate output file so that changed scores cannot overwrite the original run's history.

--- a/fern/versions/latest/pages/evaluation/resume.mdx
+++ b/fern/versions/latest/pages/evaluation/resume.mdx
@@ -53,13 +53,33 @@ Gym writes `<output_stem>_coverage.json` with an exact inventory:
 | --- | --- |
 | `expected` | Number of logical rollouts in the materialized inputs. |
 | `successful` | Rollouts with a completed result, including wrong answers and completed masked results. |
+| `measured` | Completed results whose producer did not set `mask_sample`, including valid reward-zero results. |
+| `masked` | Completed results whose producer set `mask_sample`. These remain saved and reusable on resume. |
 | `failed` | Rollouts whose selected attempt reported a no-result failure. |
 | `intentionally_omitted` | Explicit producer omissions, including terminal `skipped` outcomes. |
 | `unknown` | Rollouts with no saved outcome, including work never dispatched. |
 
-The four outcome counts sum to `expected`. `complete` requires a completed result for every expected rollout;
-`reconciled` only requires that none remain unknown. An explicit `count_failure_classes_as_zero` reporting policy can
-increase the number of scored samples, but does not change failures into completed results in the coverage report.
+The existing `successful` field remains the completed-result total. The measurement split is additive:
+
+```text
+successful = measured + masked
+expected = measured + masked + failed + intentionally_omitted + unknown
+```
+
+Counts describe the selected attempt for each logical rollout. Older attempts cannot count again or change whether
+the selected result is masked. Failure metadata on a completed result does not by itself make it a no-result failure.
+
+`complete` requires a completed result for every expected rollout; `reconciled` only requires that none remain unknown.
+A fully masked run can be complete while containing no unmasked measurements. Masking alone does not trigger recovery.
+Completed-result quality scoring follows the verifier/aggregation contract; these counts describe collection coverage.
+
+`scored` retains its existing meaning: the number of completed results, plus failures explicitly counted as zero when
+aggregating. It is separate from the measurement split. Setting `count_failure_classes_as_zero` does not change a failure into
+a measured or completed result and cannot make the five outcome counts exceed `expected`.
+
+Collection and offline aggregation export the same counts as `coverage/measured`, `coverage/masked`, `coverage/failed`,
+`coverage/omitted`, and `coverage/unknown`. For legacy shards without an inventory, observed measured/masked counts remain
+available, while expected, omitted, and unknown totals remain unknown.
 
 The coverage file is a snapshot written at collection start and cleanup. After an abrupt process kill it may be stale;
 resume or aggregate to reconstruct it from the journal and payloads. An incomplete final JSONL write is ignored during

--- a/fern/versions/latest/pages/evaluation/resume.mdx
+++ b/fern/versions/latest/pages/evaluation/resume.mdx
@@ -1,0 +1,113 @@
+---
+title: "Resume an Evaluation"
+description: "Reuse saved rollout results and check input and configuration identity before resuming."
+position: 8
+---
+
+# Resume an Evaluation
+
+Gym resumes at completed rollout boundaries. A saved result is reused, including a valid reward of zero.
+An interrupted rollout starts a new attempt; Gym does not restore an agent's conversation, browser, or sandbox state.
+
+## Resume saved results
+
+Restart the evaluation with the same input, agent, output path, and model/environment configuration, adding
+`+resume_from_cache=true` to the command. Gym compares the current run with the saved
+`<output_stem>_manifest.json` before reusing results.
+
+The manifest contains a run identifier, a format version, and digests of:
+
+- The source dataset.
+- The fully materialized tasks, including prompt and skill expansion.
+- The collection settings and resolved model/environment configuration that affect the tasks.
+
+The manifest does not store credentials or raw configuration values. Changing collection concurrency, reporting options,
+or the assigned Gym server host/port does not invalidate saved results. Changing a model, sampling settings, or tasks does.
+
+Keep the manifest, materialized inputs, rollout output, failure sidecar, and attempt journal together.
+Gym records and flushes each dispatch to `<output_stem>_attempts.jsonl` before sending its request. Completed results and
+reported failures are appended and flushed to their respective JSONL files, then an outcome event is appended to the
+journal. Files close on completion, ordinary errors, and cancellation. These guarantees cover collector process failure;
+they do not promise survival of a machine or storage failure before buffered data reaches durable storage.
+
+Use one collector per output path. For parallel jobs, give each shard its own output path and aggregate afterward.
+
+An infrastructure failure is eligible for another attempt according to the existing attempt limit and terminal markers.
+A completed wrong answer is a result, so it is not retried merely because its reward is zero.
+
+## Attempts and completion coverage
+
+A logical rollout retains its task/rollout identity across restarts. Every redispatch receives a larger attempt index,
+including after an interruption that left no result. `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS` bounds the total number of dispatched
+attempts per logical rollout (default: 3); reaching that limit does not create a synthetic failure or reward.
+
+The **greatest dispatched attempt index** determines the current outcome. A late result from an older attempt remains
+in the append-only artifacts but cannot replace the newer attempt or count as an extra sample. A newer attempt with no
+saved outcome remains unknown, even if an older success arrives afterward. Recovery and `gym eval aggregate` use this
+same selection rule.
+
+Gym writes `<output_stem>_coverage.json` with an exact inventory:
+
+| Field | Meaning |
+| --- | --- |
+| `expected` | Number of logical rollouts in the materialized inputs. |
+| `successful` | Rollouts with a completed result, including wrong answers and completed masked results. |
+| `failed` | Rollouts whose selected attempt reported a no-result failure. |
+| `intentionally_omitted` | Explicit producer omissions, including terminal `skipped` outcomes. |
+| `unknown` | Rollouts with no saved outcome, including work never dispatched. |
+
+The four outcome counts sum to `expected`. `complete` requires a completed result for every expected rollout;
+`reconciled` only requires that none remain unknown. An explicit `count_failure_classes_as_zero` reporting policy can
+increase the number of scored samples, but does not change failures into completed results in the coverage report.
+
+The coverage file is a snapshot written at collection start and cleanup. After an abrupt process kill it may be stale;
+resume or aggregate to reconstruct it from the journal and payloads. An incomplete final JSONL write is ignored during
+reconciliation and its partial bytes are removed before appending. Malformed complete records remain errors.
+If a legacy shard has no materialized inventory, aggregation reports its completion coverage as unknown.
+Merged rollout files are selected-result projections; keep the original shard artifacts for further recovery.
+
+### Legacy artifacts and explicit overrides
+
+Older runs have no manifest. By default, Gym rejects a resume whose identity cannot be checked. To deliberately reuse
+legacy artifacts or accept an input/configuration mismatch, set `+allow_unsafe_resume=true` alongside resume.
+Gym warns and reuses the **saved materialized tasks**. The manifest records that identity was imported or overridden,
+and coverage reports `identity_verified=false`. Future resumes continue to require the override. Existing legacy
+payloads are preserved; newly written payloads carry the run identifier. Gym still rejects corrupt or unsupported
+manifests and materialized inputs that no longer match their saved manifest.
+Use a fresh output location when the intention is to evaluate changed tasks or a different model.
+
+## Structured failures for direct callers
+
+`RolloutCollectionHelper.run_outcomes()` is an opt-in interface for callers that need failure information as data.
+Each future returns `(input_row, outcome)`, where `outcome` is either the existing completed-result dictionary or a
+`RolloutFailure`. The latter contains a logical rollout ID, optional run ID, attempt index, failure kind, stage, and bounded diagnostic
+strings. Its `attempt_id` property is derived from the logical ID and attempt index.
+
+```python
+from nemo_gym.rollout_collection import RolloutCollectionHelper
+from nemo_gym.rollout_outcomes import RolloutFailure
+
+
+async def collect_outcomes(input_rows):
+    helper = RolloutCollectionHelper()
+    rows = helper.preprocess_examples(input_rows)
+    for future in helper.run_outcomes(rows):
+        row, outcome = await future
+        if isinstance(outcome, RolloutFailure):
+            print(outcome.attempt_id, outcome.failure_kind, outcome.failure_reason)
+        else:
+            print(outcome["reward"])
+```
+
+Configure and start the referenced Gym servers before calling the helper. Callers supplying explicit rollout IDs can skip
+preprocessing. The direct API does not save files, retry tasks, or make training decisions. Its caller owns those operations.
+Expected HTTP, JSON, and completed-result validation errors become failure records; programming errors and cancellation
+still propagate. A malformed completed result must not be interpreted as a reward-zero sample.
+
+`run_examples()` retains its existing dictionary/exception behavior. A legacy agent result tagged with
+`_ng_failure_class` is converted explicitly at the structured API boundary; its old reward/response placeholders are
+not copied into the failure record. Completed masked results remain completed dictionaries.
+
+The evaluation runner uses structured outcomes when `route_failures_to_sidecar=true`. Its sidecar retains the existing
+`_ng_failure_*` routing aliases for row-oriented consumers and stores the canonical record under `_ng_failure_record`. Those aliases can be removed after
+the consumers and the producer migration in [#3180](https://github.com/NVIDIA-NeMo/Gym/issues/3180) adopt the new contract.

--- a/nemo_gym/failure_kinds.py
+++ b/nemo_gym/failure_kinds.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared names for why a rollout failed.
+
+Gym describes failures with free text and component-local labels, so the same failure
+arrives at a collector, a log line and a metric under three different names and cannot be
+grouped. This module holds the one vocabulary those producers share.
+
+A name says *what kind of thing went wrong* and nothing else. Whether to retry, whether
+the request may be replayed, whether a completed result should be masked, and what to tell
+a person are all properties of the occurrence, not of the name — they live on the failure
+record, on the verify response, and in ``failure_reason`` respectively. Keeping them out is
+deliberate: metadata attached to a name goes stale the moment one caller wants to retry
+what another caller does not.
+
+Names are low cardinality on purpose. They are safe as a metric label or a span dimension;
+``failure_reason`` never is, because it carries occurrence detail and can be unbounded.
+
+This module imports only the standard library so that data tooling can read the vocabulary
+without installing any server's requirements.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+# ``<domain>_<condition>``. The domain says which layer observed the failure, so a reader
+# can tell an unreachable model server from an unreachable sandbox without a second field.
+_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# An environment may use ``<server>:<kind>`` for something the shared vocabulary should not
+# grow a name for. The prefix keeps it groupable without making it look registered.
+_NAMESPACED_PATTERN = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+
+
+# --- transport: reaching another process at all ------------------------------------- #
+TRANSPORT_UNREACHABLE = "transport_unreachable"
+TRANSPORT_PEER_DROP = "transport_peer_drop"
+TRANSPORT_TIMEOUT = "transport_timeout"
+TRANSPORT_LOCAL_RESOURCE = "transport_local_resource"
+
+# --- agent: the /run call and the harness behind it ---------------------------------- #
+# Both are produced today by rollout collection: the agent answered and broke, versus
+# something in front of it answered and the rollout never ran.
+AGENT_RUN_ERROR = "agent_run_error"
+AGENT_REQUEST_FAILED = "agent_request_failed"
+AGENT_TIMEOUT = "agent_timeout"
+AGENT_COMMAND_NOT_ALLOWED = "agent_command_not_allowed"
+
+# --- verifier and judge --------------------------------------------------------------- #
+# ``judge_failed`` is produced today by judge_failsafe and by reverification.
+JUDGE_FAILED = "judge_failed"
+JUDGE_UNPARSEABLE = "judge_unparseable"
+VERIFIER_ERROR = "verifier_error"
+
+# --- provider: sandboxes, browsers, containers ----------------------------------------- #
+PROVIDER_UNAVAILABLE = "provider_unavailable"
+PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+PROVIDER_OOM_KILLED = "provider_oom_killed"
+
+# --- resources session ------------------------------------------------------------------ #
+SESSION_LOST = "session_lost"
+SESSION_EXPIRED = "session_expired"
+SESSION_RELEASE_FAILED = "session_release_failed"
+
+# --- cancellation and process lifecycle -------------------------------------------------- #
+# ``kill_shaped`` names what rollout collection already treats as unstorable: a SIGTERM, a
+# dead Ray actor, an OOM outside the rollout's own process.
+CANCELLED = "cancelled"
+KILL_SHAPED = "kill_shaped"
+SHUTDOWN = "shutdown"
+
+# --- persistence and cohorts --------------------------------------------------------------- #
+PERSISTENCE_FAILED = "persistence_failed"
+COHORT_INCOMPLETE = "cohort_incomplete"
+
+
+FAILURE_KINDS: frozenset[str] = frozenset(
+    {
+        TRANSPORT_UNREACHABLE,
+        TRANSPORT_PEER_DROP,
+        TRANSPORT_TIMEOUT,
+        TRANSPORT_LOCAL_RESOURCE,
+        AGENT_RUN_ERROR,
+        AGENT_REQUEST_FAILED,
+        AGENT_TIMEOUT,
+        AGENT_COMMAND_NOT_ALLOWED,
+        JUDGE_FAILED,
+        JUDGE_UNPARSEABLE,
+        VERIFIER_ERROR,
+        PROVIDER_UNAVAILABLE,
+        PROVIDER_QUOTA_EXHAUSTED,
+        PROVIDER_OOM_KILLED,
+        SESSION_LOST,
+        SESSION_EXPIRED,
+        SESSION_RELEASE_FAILED,
+        CANCELLED,
+        KILL_SHAPED,
+        SHUTDOWN,
+        PERSISTENCE_FAILED,
+        COHORT_INCOMPLETE,
+    }
+)
+
+
+def is_registered(name: str) -> bool:
+    """Whether ``name`` is part of the shared vocabulary."""
+    return name in FAILURE_KINDS
+
+
+def is_namespaced(name: str) -> bool:
+    """Whether ``name`` is an environment's own ``<server>:<kind>`` extension."""
+    return bool(_NAMESPACED_PATTERN.match(name))
+
+
+def validate_failure_kind(name: str | None) -> str | None:
+    """Return ``name`` unchanged, warning once about anything unregistered.
+
+    Producers call this at their boundary. It warns rather than raises so a component that
+    still emits an old label stays visible during migration — rejecting it outright would
+    replace an observable wrong name with an invisible dropped failure, which is worse than
+    the problem this vocabulary exists to fix.
+    """
+    if name is None or is_registered(name) or is_namespaced(name):
+        return name
+    logger.warning(
+        "unregistered failure_kind %r; register it in nemo_gym/failure_kinds.py or namespace it as '<server>:%s'",
+        name,
+        name,
+    )
+    return name

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -1674,6 +1674,7 @@ class RolloutCollectionHelper(BaseModel):
         completion = store.coverage()
         print(
             f"Rollout coverage: {completion['successful']}/{completion['expected']} completed, "
+            f"of which {completion['measured']} measured and {completion['masked']} masked; "
             f"{completion['failed']} failed, {completion['intentionally_omitted']} intentionally omitted, "
             f"{completion['unknown']} unknown. Details: {coverage_path_for(output_fpath)}"
         )
@@ -1723,6 +1724,11 @@ class RolloutCollectionHelper(BaseModel):
                     "coverage/expected": expected_rollouts,
                     "coverage/scored": scored_rollouts,
                     "coverage/missing": expected_rollouts - scored_rollouts,
+                    "coverage/measured": completion["measured"],
+                    "coverage/masked": completion["masked"],
+                    "coverage/failed": completion["failed"],
+                    "coverage/omitted": completion["intentionally_omitted"],
+                    "coverage/unknown": completion["unknown"],
                 }
             )
 
@@ -2345,10 +2351,13 @@ class RolloutAggregationHelper(BaseModel):
         scored_rollouts = len(results) + len(counted)
         components = [history.coverage() for history in histories]
         inventory_known = not legacy_paths
+        masked_rollouts = sum(bool(row.get(MASK_SAMPLE_KEY)) for row in results)
         completion = {
             "schema_version": 1,
             "expected": sum(c["expected"] for c in components) if inventory_known else None,
             "successful": len(results),
+            "measured": len(results) - masked_rollouts,
+            "masked": masked_rollouts,
             "failed": sum(c["failed"] for c in components) if inventory_known else None,
             "intentionally_omitted": sum(c["intentionally_omitted"] for c in components) if inventory_known else None,
             "unknown": sum(c["unknown"] for c in components) if inventory_known else None,
@@ -2372,15 +2381,24 @@ class RolloutAggregationHelper(BaseModel):
         )
         if inventory_known:
             coverage += (
-                f"\nCoverage: {completion['successful']} successful, {completion['failed']} failed, "
+                f"\nCoverage: {completion['successful']} completed "
+                f"({completion['measured']} measured, {completion['masked']} masked), {completion['failed']} failed, "
                 f"{completion['intentionally_omitted']} intentionally omitted, {completion['unknown']} unknown. "
                 f"Details: {coverage_path_for(output_fpath)}"
             )
         if get_exporters():  # pragma: no cover
-            metrics = {"coverage/scored": scored_rollouts, "coverage/known": int(inventory_known)}
+            metrics = {
+                "coverage/scored": scored_rollouts,
+                "coverage/known": int(inventory_known),
+                "coverage/measured": completion["measured"],
+                "coverage/masked": completion["masked"],
+            }
             if inventory_known:
                 metrics["coverage/expected"] = completion["expected"]
                 metrics["coverage/missing"] = completion["expected"] - scored_rollouts
+                metrics["coverage/failed"] = completion["failed"]
+                metrics["coverage/omitted"] = completion["intentionally_omitted"]
+                metrics["coverage/unknown"] = completion["unknown"]
             export_metrics(metrics)
 
         print(f"""Finished rollout aggregation! View results at:

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -77,6 +77,7 @@ from nemo_gym.rollout_journal import (
     RUN_ID_KEY,
     coverage_path_for,
     journal_path_for,
+    logical_rollout_id,
 )
 from nemo_gym.rollout_observability import (
     AgentInvocation,
@@ -173,6 +174,7 @@ class _CompletedRollout:
     rollout_latency_ms: Optional[float]
     # Actual generation retained for judge-only recovery, outside RolloutFailure.
     verification_response: Optional[Dict[str, Any]] = None
+    diagnostics: Optional[Dict[str, Any]] = None
 
 
 def _nonnegative_int(value: Any) -> Optional[int]:
@@ -946,6 +948,17 @@ def _judge_failure_response(result: Any) -> Optional[Dict]:
     return None
 
 
+def _failure_diagnostics(result: Any) -> Dict:
+    if not isinstance(result, dict):
+        return {}
+    return {
+        key: value
+        for key, value in result.items()
+        if key in {"ng_agent_observations", "ng_model_call_capture", NG_TRAJECTORY_KEY, NG_PERF_KEY}
+        or key.startswith("_ng_failure_")
+    }
+
+
 def _failure_compatibility_row(failure: RolloutFailure, verification_response: Optional[Dict] = None) -> Dict:
     """Keep existing sidecar routing keys and diagnostics alongside the canonical failure.
 
@@ -1245,6 +1258,8 @@ class RolloutCollectionHelper(BaseModel):
                     # Resolve rollout index
                     row[ROLLOUT_INDEX_KEY_NAME] = task_idx_to_rollout_idx[row[TASK_INDEX_KEY_NAME]]
                     task_idx_to_rollout_idx[row[TASK_INDEX_KEY_NAME]] += 1
+                    if row.get(ROLLOUT_ID_KEY_NAME) is not None and (row_num_repeats > 1 or len(targets) > 1):
+                        row[ROLLOUT_ID_KEY_NAME] = f"{logical_rollout_id(row)}-r{row[ROLLOUT_INDEX_KEY_NAME]}"
 
                     if config.num_repeats_add_seed:
                         row[RESPONSES_CREATE_PARAMS_KEY_NAME] = row[RESPONSES_CREATE_PARAMS_KEY_NAME].copy()
@@ -1371,7 +1386,6 @@ class RolloutCollectionHelper(BaseModel):
         output_fpath = Path(config.output_jsonl_fpath)
         failures_fpath = failures_path_for(output_fpath)
         global_config = get_global_config_dict()
-        resolved_config = OmegaConf.to_container(OmegaConf.create(global_config), resolve=True)
 
         def prepare_inputs() -> tuple[list[dict], RunManifest]:
             input_rows = self._preprocess_rows_from_config(config)
@@ -1385,8 +1399,8 @@ class RolloutCollectionHelper(BaseModel):
             manifest = RunManifest.create(
                 _resolve_under_cwd_or_install(config.input_jsonl_fpath),
                 input_rows,
-                config.model_dump(mode="json"),
-                resolved_config,
+                config.model_dump(),
+                global_config,
             )
             return input_rows, manifest
 
@@ -1489,6 +1503,7 @@ class RolloutCollectionHelper(BaseModel):
                 completed = await future
                 row, result, rollout_latency_ms = completed.row, completed.result, completed.rollout_latency_ms
                 verification_response = completed.verification_response
+                diagnostics = completed.diagnostics or _failure_diagnostics(result)
                 if verification_response is None:
                     verification_response = _judge_failure_response(result)
                 # Custom dispatch implementations may return an already-completed
@@ -1502,7 +1517,7 @@ class RolloutCollectionHelper(BaseModel):
                         result = _failure_outcome(row, result, "agent")
                 structured_failure = isinstance(result, RolloutFailure)
                 if structured_failure:
-                    result = _failure_compatibility_row(result, verification_response)
+                    result = diagnostics | _failure_compatibility_row(result, verification_response)
 
                 result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
                 result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
@@ -1526,7 +1541,7 @@ class RolloutCollectionHelper(BaseModel):
 
                 # Fold this rollout's captured model calls into its record (uniform across agents; no-op
                 # when capture is off). Never alters the harness output/reward already in `result`.
-                if capture_dirs and not no_result:
+                if capture_dirs and not no_persist:
                     merge_model_call_capture_into_record(
                         result,
                         capture_dirs,
@@ -1707,7 +1722,7 @@ class RolloutCollectionHelper(BaseModel):
             aggregate_metrics_fpath = None
         else:
             print("Computing aggregate metrics")
-            counted[:] = _counted_failure_rows(store.selected("failure"), config.count_failure_classes_as_zero)
+            counted[:] = _counted_failure_rows(store.failures(), config.count_failure_classes_as_zero)
             if config.count_failure_classes_as_zero:
                 print(
                     f"Counting {len(counted)} failure row(s) as scored zeros: {config.count_failure_classes_as_zero}"
@@ -2044,6 +2059,7 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                     stage = "response"
                     result = await get_response_json(res)
                     verification_response = _judge_failure_response(result)
+                    diagnostics = _failure_diagnostics(result)
                     if typed_outcomes:
                         stage = "result"
                         result = _normalize_rollout_outcome(row, result)
@@ -2055,6 +2071,7 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                         result=result,
                         rollout_latency_ms=rollout_latency_ms,
                         verification_response=verification_response,
+                        diagnostics=diagnostics,
                     )
                 except Exception as e:
                     print(
@@ -2334,7 +2351,7 @@ class RolloutAggregationHelper(BaseModel):
             scored_keys,
         )
         for history in histories:
-            counted.extend(_counted_failure_rows(history.selected("failure"), config.count_failure_classes_as_zero))
+            counted.extend(_counted_failure_rows(history.failures(), config.count_failure_classes_as_zero))
         if config.count_failure_classes_as_zero:
             print(f"Counting {len(counted)} failure row(s) as scored zeros: {config.count_failure_classes_as_zero}")
 
@@ -2349,6 +2366,12 @@ class RolloutAggregationHelper(BaseModel):
             row.get(NG_FAILURE_CLASS_KEY) or "unknown"
             for key, row in _latest_failure_rows(failures_fpaths).items()
             if key not in scored_keys and key not in counted_keys
+        )
+        dropped.update(
+            row[NG_FAILURE_CLASS_KEY]
+            for history in histories
+            for row in history.failures()
+            if row[NG_FAILURE_CLASS_KEY] not in config.count_failure_classes_as_zero
         )
         scored_rollouts = len(results) + len(counted)
         components = [history.coverage() for history in histories]

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -947,7 +947,7 @@ def _judge_failure_response(result: Any) -> Optional[Dict]:
 
 
 def _failure_compatibility_row(failure: RolloutFailure, verification_response: Optional[Dict] = None) -> Dict:
-    """Keep existing sidecar routing keys while exposing the canonical failure.
+    """Keep existing sidecar routing keys and diagnostics alongside the canonical failure.
 
     Remove these aliases when row-oriented consumers and #3180 producers migrate.
     The canonical record never carries generation. The sidecar envelope retains
@@ -959,6 +959,7 @@ def _failure_compatibility_row(failure: RolloutFailure, verification_response: O
         NG_FAILURE_CLASS_KEY: failure.failure_kind,
         "_ng_failure_type": failure.exception_type,
         "_ng_failure_message": failure.failure_reason,
+        "error": failure.failure_reason,
         "_ng_failure_http_status": failure.http_status,
         "_ng_failure_response_body": failure.response_body,
     }

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -75,13 +75,8 @@ from nemo_gym.prompt import apply_prompt_to_row, load_prompt_config, validate_pr
 from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
 from nemo_gym.rollout_journal import (
     RUN_ID_KEY,
-    RolloutJournal,
     coverage_path_for,
     journal_path_for,
-    logical_rollout_id,
-    materialized_path_for,
-    prepare_append,
-    read_records,
 )
 from nemo_gym.rollout_observability import (
     AgentInvocation,
@@ -96,7 +91,8 @@ from nemo_gym.rollout_observability import (
     TrajectoryTurn,
 )
 from nemo_gym.rollout_outcomes import InvalidRolloutResult, RolloutFailure
-from nemo_gym.rollout_recovery import RunManifest, atomic_write_json, manifest_path_for, validate_resume
+from nemo_gym.rollout_recovery import RunManifest, atomic_write_json, manifest_path_for
+from nemo_gym.rollout_store import RolloutStore
 from nemo_gym.telemetry._fallbacks import is_span_group_enabled, managed_span
 from nemo_gym.telemetry.span_groups import GymSpanGroup
 
@@ -175,6 +171,8 @@ class _CompletedRollout:
     row: Dict[str, Any]
     result: Dict[str, Any] | RolloutFailure
     rollout_latency_ms: Optional[float]
+    # Actual generation retained for judge-only recovery, outside RolloutFailure.
+    verification_response: Optional[Dict[str, Any]] = None
 
 
 def _nonnegative_int(value: Any) -> Optional[int]:
@@ -938,11 +936,22 @@ def _normalize_rollout_outcome(row: Dict, result: Any) -> Dict | RolloutFailure:
     return result
 
 
-def _failure_compatibility_row(failure: RolloutFailure) -> Dict:
+def _judge_failure_response(result: Any) -> Optional[Dict]:
+    """Legacy judge_failsafe carries real generation that can be judged again."""
+    if isinstance(result, dict) and result.get(NG_FAILURE_CLASS_KEY) == "judge_failed":
+        response = result.get("response")
+        if isinstance(response, dict):
+            return response
+    return None
+
+
+def _failure_compatibility_row(failure: RolloutFailure, verification_response: Optional[Dict] = None) -> Dict:
     """Keep existing sidecar routing keys while exposing the canonical failure.
 
     Remove these aliases when row-oriented consumers and #3180 producers migrate.
-    The explicit adapter never carries legacy reward/response placeholders.
+    The canonical record never carries generation. The sidecar envelope retains
+    actual judge input for existing --judge-failed-only readers, without a reward.
+    Other legacy response placeholders are discarded.
     """
     row = {
         "_ng_failure_record": failure.model_dump(mode="json"),
@@ -954,6 +963,8 @@ def _failure_compatibility_row(failure: RolloutFailure) -> Dict:
     }
     if failure.terminal:
         row[NG_TERMINAL_KEY] = True
+    if failure.failure_kind == "judge_failed" and verification_response is not None:
+        row["response"] = verification_response
     return row
 
 
@@ -1277,11 +1288,10 @@ class RolloutCollectionHelper(BaseModel):
     ) -> Tuple[List[Dict], List[Dict], List[Dict], List[List[str]]]:
         output = Path(config.output_jsonl_fpath)
         if manifest_path_for(output).exists() and journal_path_for(output).exists():
-            manifest = RunManifest.model_validate_json(manifest_path_for(output).read_bytes())
-            history = RolloutJournal.load(output, manifest, import_legacy=manifest.legacy_import)
-            results = history.selected("success")
-            rows = [history.expected[logical_rollout_id(result)] for result in results]
-            return history.pending(_get_max_rollout_attempts()), rows, results, [[orjson.dumps(r)] for r in results]
+            store = RolloutStore.read(output)
+            results = store.selected("success")
+            rows = store.inputs_for(results)
+            return store.pending(_get_max_rollout_attempts()), rows, results, [[orjson.dumps(r)] for r in results]
         with config.materialized_jsonl_fpath.open() as f:
             original_input_rows = list(map(orjson.loads, tqdm(f, desc="Reading materialized input rows")))
         with Path(config.output_jsonl_fpath).open("rb") as f:
@@ -1358,118 +1368,35 @@ class RolloutCollectionHelper(BaseModel):
     async def _run_from_config(self, config: RolloutCollectionConfig) -> Tuple[List[Dict]]:
         output_fpath = Path(config.output_jsonl_fpath)
         failures_fpath = failures_path_for(output_fpath)
-        manifest_fpath = manifest_path_for(output_fpath)
-        history_fpath = journal_path_for(output_fpath)
-        import_history = False
         global_config = get_global_config_dict()
         resolved_config = OmegaConf.to_container(OmegaConf.create(global_config), resolve=True)
 
-        # Create the output directory up front: every artifact this run writes (materialized inputs,
-        # rollouts, failures sidecar, aggregate metrics) is derived from output_fpath and keeps its
-        # parent, and the materialized-inputs write below is the first one. Keep this above that
-        # write -- a user pointing --output at a not-yet-existing directory is the common case
-        # outside a git clone.
-        output_fpath.parent.mkdir(parents=True, exist_ok=True)
-
-        saved_artifacts = (
-            config.materialized_jsonl_fpath,
-            output_fpath,
-            manifest_fpath,
-            failures_fpath,
-            history_fpath,
-        )
-        if config.resume_from_cache and any(path.exists() for path in saved_artifacts):
-            if not config.materialized_jsonl_fpath.exists() or not output_fpath.exists():
-                raise ConfigError("Cannot resume: saved materialized inputs or rollout output are missing.")
-            current_manifest = None
-            if manifest_fpath.exists():
-                try:
-                    current_rows = self._preprocess_rows_from_config(config)
-                    if any(
-                        (row.get(AGENT_REF_KEY_NAME) or {}).get("name") is None
-                        and row.get(TASK_SOURCE_KEY_NAME) is not None
-                        for row in current_rows
-                    ):
-                        self.resolve_task_sources(current_rows, self.setup_server_client().global_config_dict)
-                    current_manifest = RunManifest.create(
-                        _resolve_under_cwd_or_install(config.input_jsonl_fpath),
-                        current_rows,
-                        config.model_dump(mode="json"),
-                        resolved_config,
-                    )
-                except (ConfigError, OSError):
-                    if not config.allow_unsafe_resume:
-                        raise
-            manifest = validate_resume(
-                manifest_fpath,
-                current_manifest,
-                config.materialized_jsonl_fpath,
-                allow_unsafe=config.allow_unsafe_resume,
-            )
-            if manifest is None:
-                manifest = RunManifest.import_legacy(list(read_records(config.materialized_jsonl_fpath)))
-                import_history = True
-            elif not history_fpath.exists():
-                if not config.allow_unsafe_resume:
-                    raise ConfigError(f"Cannot resume without attempt history: {history_fpath}.")
-                manifest = manifest.model_copy(update={"legacy_import": True})
-                import_history = True
-            history = RolloutJournal.load(output_fpath, manifest, import_legacy=manifest.legacy_import)
-            input_rows = history.pending(_get_max_rollout_attempts())
-            results = history.selected("success")
-            rows = [history.expected[logical_rollout_id(result)] for result in results]
-            if import_history or manifest.identity_overridden:
-                manifest.write(manifest_fpath)
-            persisted_rows = list(rows)
-            persisted_results = list(results)
-        else:
-            if config.resume_from_cache:
-                if not output_fpath.exists():
-                    print(f"Skipping resume_from_cache because output_fpath {output_fpath} doesn't exist!")
-                if not config.materialized_jsonl_fpath.exists():
-                    print(
-                        f"Skipping resume_from_cache because materialized_jsonl_fpath {config.materialized_jsonl_fpath} doesn't exist!"
-                    )
-            else:
-                print("Clearing output fpath since `resume_from_cache=False`!")
-
-            rows: List[Dict] = []
-            results: List[Dict] = []
-            persisted_rows: List[Dict] = []
-            persisted_results: List[Dict] = []
-
+        def prepare_inputs() -> tuple[list[dict], RunManifest]:
             input_rows = self._preprocess_rows_from_config(config)
-            # Returned rows are sorted by (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME])
-
-            # Resolve task_source rows to agents BEFORE the materialized write: materialized
-            # inputs are the run-scoped artifact and must carry the resolved agent_ref (custom
-            # drivers, e.g. gdpval's multistage orchestrator, read it from there). Guarded so
-            # legacy agent_ref-only runs never need the head server at this point.
+            # Materialized inputs must contain resolved agent routing for custom
+            # drivers and for reproducible identity checks on resume.
             if any(
-                (r.get(AGENT_REF_KEY_NAME) or {}).get("name") is None and r.get(TASK_SOURCE_KEY_NAME) is not None
-                for r in input_rows
+                (row.get(AGENT_REF_KEY_NAME) or {}).get("name") is None and row.get(TASK_SOURCE_KEY_NAME) is not None
+                for row in input_rows
             ):
                 self.resolve_task_sources(input_rows, self.setup_server_client().global_config_dict)
-
-            with config.materialized_jsonl_fpath.open("wb") as f:
-                for row in tqdm(input_rows, desc="Writing materialized rows"):
-                    f.write(orjson.dumps(row) + b"\n")
-
             manifest = RunManifest.create(
                 _resolve_under_cwd_or_install(config.input_jsonl_fpath),
                 input_rows,
                 config.model_dump(mode="json"),
                 resolved_config,
             )
-            history = RolloutJournal(manifest, input_rows)
-            # Invalidate old outputs before publishing the new run's identity.
-            output_fpath.unlink(missing_ok=True)
-            failures_fpath.unlink(missing_ok=True)
-            history_fpath.unlink(missing_ok=True)
-            coverage_path_for(output_fpath).unlink(missing_ok=True)
-            manifest.write(manifest_fpath)
+            return input_rows, manifest
 
-        input_rows = [dict(row, **{RUN_ID_KEY: manifest.run_id}) for row in input_rows]
+        store = RolloutStore.start_or_resume(
+            output_fpath,
+            prepare_inputs,
+            resume=config.resume_from_cache,
+            allow_unsafe=config.allow_unsafe_resume,
+        )
+        input_rows = store.pending(_get_max_rollout_attempts())
+        results = store.selected("success")
+        rows = store.inputs_for(results)
         semaphore = nullcontext()
         if config.num_samples_in_parallel:
             print(f"Querying with {config.num_samples_in_parallel} concurrent requests")
@@ -1543,24 +1470,14 @@ class RolloutCollectionHelper(BaseModel):
         async with AsyncExitStack() as output_files:
             if owned_token_source is not None:
                 output_files.push_async_callback(owned_token_source.close)
-            for path in (output_fpath, failures_fpath, history_fpath):
-                prepare_append(path)
-            # Register first: this runs after the output files close, including on
-            # cancellation. The journal remains the source of truth after SIGKILL.
-            output_files.callback(history.write_coverage, output_fpath)
-            history.file = output_files.enter_context(history_fpath.open("ab"))
-            results_file = output_files.enter_context(output_fpath.open("ab"))
-            failures_file = output_files.enter_context(failures_fpath.open("ab"))
-            if import_history:
-                history.seed_legacy_history()
-            history.write_coverage(output_fpath)
+            output_files.enter_context(store)
             failure_counts: Counter = Counter()
             dispatches = self._run_examples_with_metadata(
                 input_rows,
                 semaphore=semaphore,
                 route_failures_to_sidecar=config.route_failures_to_sidecar,
                 typed_outcomes=config.route_failures_to_sidecar,
-                on_dispatch=history.dispatch,
+                on_dispatch=store.record_dispatch,
             )
             if hasattr(dispatches, "aclose"):
                 output_files.push_async_callback(dispatches.aclose)
@@ -1569,10 +1486,13 @@ class RolloutCollectionHelper(BaseModel):
             for future in dispatches:
                 completed = await future
                 row, result, rollout_latency_ms = completed.row, completed.result, completed.rollout_latency_ms
+                verification_response = completed.verification_response
+                if verification_response is None:
+                    verification_response = _judge_failure_response(result)
                 # Custom dispatch implementations may return an already-completed
                 # future. Associate those outcomes too; normal HTTP dispatch records
                 # its event before the request through on_dispatch above.
-                history.dispatch(row)
+                store.record_dispatch(row)
                 if isinstance(result, dict):
                     if result.get("type") == "failure":
                         result = _normalize_rollout_outcome(row, result)
@@ -1580,12 +1500,12 @@ class RolloutCollectionHelper(BaseModel):
                         result = _failure_outcome(row, result, "agent")
                 structured_failure = isinstance(result, RolloutFailure)
                 if structured_failure:
-                    result = _failure_compatibility_row(result)
+                    result = _failure_compatibility_row(result, verification_response)
 
                 result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
                 result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
                 result[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
-                result[RUN_ID_KEY] = manifest.run_id
+                result[RUN_ID_KEY] = store.manifest.run_id
                 if TASK_SOURCE_KEY_NAME in row:
                     result[TASK_SOURCE_KEY_NAME] = row[TASK_SOURCE_KEY_NAME]
                 if SKILLS_REF_KEY_NAME in row:
@@ -1662,12 +1582,11 @@ class RolloutCollectionHelper(BaseModel):
 
                 rows.append(row)
                 results.append(result)
-                serialized = orjson.dumps(result)
 
                 if no_persist:
                     # A returned suppression without a failure is an intentional
                     # omission. Known kill-shaped failures were converted above.
-                    history.omit(row, str(result.get("error") or "Producer requested no result persistence"))
+                    store.record_omission(row, str(result.get("error") or "Producer requested no result persistence"))
                 elif failure_class is not None:
                     # Failures remain separate from completed generation data.
                     failure_counts[failure_class] += 1
@@ -1679,16 +1598,10 @@ class RolloutCollectionHelper(BaseModel):
                         f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)} "
                         f"class={failure_class} error={detail}"
                     )
-                    failures_file.write(serialized + b"\n")
-                    failures_file.flush()
-                    history.outcome(result)
+                    store.record_outcome(result)
                 else:
                     # Success → main jsonl.
-                    results_file.write(serialized + b"\n")
-                    results_file.flush()
-                    history.outcome(result)
-                    persisted_rows.append(row)
-                    persisted_results.append(result)
+                    store.record_outcome(result, sync=capture_build_can_retire(token_capture_build))
                     try:
                         rollout_id = maybe_rollout_id_from_run_body(result)
                     except (TypeError, ValueError) as error:
@@ -1702,7 +1615,6 @@ class RolloutCollectionHelper(BaseModel):
                                 stacklevel=2,
                             )
                     if rollout_id is not None and capture_build_can_retire(token_capture_build):
-                        os.fsync(results_file.fileno())
                         await retire_rollout_token_capture(rollout_id, token_source, token_capture_build)
 
                 counts_left[row[AGENT_REF_KEY_NAME]["name"]] -= 1
@@ -1757,9 +1669,9 @@ class RolloutCollectionHelper(BaseModel):
 
                         export_metrics(step_metrics, step=int(current_pct))
 
-        persisted_results = history.selected("success")
-        persisted_rows = [history.expected[logical_rollout_id(result)] for result in persisted_results]
-        completion = history.coverage()
+        persisted_results = store.selected("success")
+        persisted_rows = store.inputs_for(persisted_results)
+        completion = store.coverage()
         print(
             f"Rollout coverage: {completion['successful']}/{completion['expected']} completed, "
             f"{completion['failed']} failed, {completion['intentionally_omitted']} intentionally omitted, "
@@ -1792,7 +1704,7 @@ class RolloutCollectionHelper(BaseModel):
             aggregate_metrics_fpath = None
         else:
             print("Computing aggregate metrics")
-            counted[:] = _counted_failure_rows(history.selected("failure"), config.count_failure_classes_as_zero)
+            counted[:] = _counted_failure_rows(store.selected("failure"), config.count_failure_classes_as_zero)
             if config.count_failure_classes_as_zero:
                 print(
                     f"Counting {len(counted)} failure row(s) as scored zeros: {config.count_failure_classes_as_zero}"
@@ -1803,9 +1715,7 @@ class RolloutCollectionHelper(BaseModel):
 
         expected_rollouts = completion["expected"]
         scored_rollouts = len(persisted_results) + len(counted)
-        completion["scored"] = scored_rollouts
-        completion["failures_counted_as_zero"] = len(counted)
-        atomic_write_json(coverage_path_for(output_fpath), completion)
+        store.write_coverage(scored=scored_rollouts, failures_counted_as_zero=len(counted))
         coverage = _coverage_report(expected_rollouts, scored_rollouts, failure_counts, failures_fpath)
         if get_exporters():  # pragma: no cover
             export_metrics(
@@ -2125,13 +2035,19 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                     await raise_for_status(res)
                     stage = "response"
                     result = await get_response_json(res)
+                    verification_response = _judge_failure_response(result)
                     if typed_outcomes:
                         stage = "result"
                         result = _normalize_rollout_outcome(row, result)
                     # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
                     # from summed model-call/tool latencies to account for additional overhead.
                     rollout_latency_ms = (time() - started_at) * 1000
-                    return _CompletedRollout(row=row, result=result, rollout_latency_ms=rollout_latency_ms)
+                    return _CompletedRollout(
+                        row=row,
+                        result=result,
+                        rollout_latency_ms=rollout_latency_ms,
+                        verification_response=verification_response,
+                    )
                 except Exception as e:
                     print(
                         "[rollout_collection] /run failed "
@@ -2366,24 +2282,16 @@ class RolloutAggregationHelper(BaseModel):
             print(f"  - {p}")
 
         results: List[Dict] = []
-        histories: List[RolloutJournal] = []
+        histories: List[RolloutStore] = []
         legacy_paths: List[Path] = []
         run_ids: set[str] = set()
         for shard_path in input_paths:
             shard = Path(shard_path)
-            manifest_path = manifest_path_for(shard)
-            if manifest_path.exists():
-                manifest = RunManifest.model_validate_json(manifest_path.read_bytes())
-                if manifest.run_id in run_ids:
+            history = RolloutStore.read(shard)
+            if history is not None:
+                if history.manifest.run_id in run_ids:
                     raise ConfigError("The same run was supplied through multiple shard paths.")
-                run_ids.add(manifest.run_id)
-                history = RolloutJournal.load(shard, manifest, import_legacy=manifest.legacy_import)
-                histories.append(history)
-                results.extend(history.selected("success"))
-                continue
-            if materialized_path_for(shard).exists():
-                manifest = RunManifest.import_legacy(list(read_records(materialized_path_for(shard))))
-                history = RolloutJournal.load(shard, manifest, import_legacy=True)
+                run_ids.add(history.manifest.run_id)
                 histories.append(history)
                 results.extend(history.selected("success"))
                 continue

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -21,19 +21,20 @@ import warnings
 from asyncio import Future, Semaphore
 from collections import Counter, defaultdict
 from collections.abc import Mapping
-from contextlib import nullcontext
+from contextlib import AsyncExitStack, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
 from difflib import get_close_matches
 from itertools import repeat
+from math import isfinite
 from pathlib import Path
 from time import time
-from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import orjson
 from aiohttp import ClientError
 from omegaconf import DictConfig, OmegaConf
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from tqdm.asyncio import tqdm
 
 from nemo_gym import _resolve_under_cwd_or_install
@@ -72,6 +73,16 @@ from nemo_gym.global_config import (
 from nemo_gym.path_utils import aggregate_metrics_path_for, failures_path_for
 from nemo_gym.prompt import apply_prompt_to_row, load_prompt_config, validate_prompt_compatibility
 from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
+from nemo_gym.rollout_journal import (
+    RUN_ID_KEY,
+    RolloutJournal,
+    coverage_path_for,
+    journal_path_for,
+    logical_rollout_id,
+    materialized_path_for,
+    prepare_append,
+    read_records,
+)
 from nemo_gym.rollout_observability import (
     AgentInvocation,
     AgentObservationBundle,
@@ -84,6 +95,8 @@ from nemo_gym.rollout_observability import (
     TrajectoryToolCall,
     TrajectoryTurn,
 )
+from nemo_gym.rollout_outcomes import InvalidRolloutResult, RolloutFailure
+from nemo_gym.rollout_recovery import RunManifest, atomic_write_json, manifest_path_for, validate_resume
 from nemo_gym.telemetry._fallbacks import is_span_group_enabled, managed_span
 from nemo_gym.telemetry.span_groups import GymSpanGroup
 
@@ -133,15 +146,13 @@ logger = logging.getLogger(__name__)
 #     per attempt, with ``_ng_failure_class`` set. An ``agent_run_error`` or
 #     ``agent_request_failed`` row holds no reward and no response: there was
 #     no rollout. The two differ in whether the agent answered at all.
-#   - ``kill_shaped`` failures (Slurm SIGTERM, Ray actor died, OOM, ...) go
-#     NOWHERE: the absence of a row is the canonical signal. Resume's
-#     set-difference re-dispatches them naturally; per-task timeout bounds
-#     the chain-hop wallclock.
-#   - On resume, ``_load_from_cache`` reads BOTH files: main jsonl tells
-#     it what's permanently done, sidecar tells it how many attempts each
-#     non-success has consumed (capped at NEMO_GYM_MAX_ROLLOUT_ATTEMPTS,
-#     default 3). Rows flagged ``_ng_failure_terminal=True`` are never
-#     retried regardless of attempt count.
+#   - Reported ``kill_shaped`` failures are persisted without generation
+#     placeholders. A process that dies without reporting leaves a durable
+#     dispatch with an unknown outcome in ``<output_stem>_attempts.jsonl``.
+#   - Resume reconciles both payload files with that journal. The greatest
+#     dispatched attempt index wins. Failed and unknown work can start a new
+#     attempt, capped at NEMO_GYM_MAX_ROLLOUT_ATTEMPTS (default 3). Terminal
+#     failures and explicit omissions are not retried.
 # ---------------------------------------------------------------------------
 
 NG_FAILURE_CLASS_KEY = "_ng_failure_class"
@@ -162,7 +173,7 @@ class _CompletedRollout:
     """A finished ``/run`` dispatch, with timing carried alongside (not inside) the raw result."""
 
     row: Dict[str, Any]
-    result: Dict[str, Any]
+    result: Dict[str, Any] | RolloutFailure
     rollout_latency_ms: Optional[float]
 
 
@@ -755,6 +766,13 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
         default=False,
         description="If the same command is run multiple times, check the materialized inputs and current outputs and remove the inputs that have already been run",
     )
+    allow_unsafe_resume: bool = Field(
+        default=False,
+        description=(
+            "Explicitly reuse legacy or identity-mismatched saved rollouts. Warns and reuses the saved "
+            "materialized inputs. Unsupported or corrupt manifests are still rejected."
+        ),
+    )
     prompt_config: Optional[str] = Field(
         default=None,
         description="Path to a prompt YAML file. Builds responses_create_params.input from the template at rollout time. Mutually exclusive with pre-populated responses_create_params.input in the JSONL data.",
@@ -866,6 +884,79 @@ def _truncated_body(body: Optional[bytes]) -> Optional[str]:
     return text[:_MAX_FAILURE_BODY_CHARS] + ("…" if len(body) > _MAX_FAILURE_BODY_CHARS else "")
 
 
+def _failure_outcome(row: Dict, failure: Dict, stage: str) -> RolloutFailure:
+    logical_row = {key: value for key, value in row.items() if key != ATTEMPT_INDEX_KEY_NAME}
+    rollout_id = maybe_rollout_id_from_run_body(logical_row)
+    if rollout_id is None:
+        raise ValueError("Structured outcomes require a rollout id or preprocessed task/rollout indices.")
+    return RolloutFailure(
+        rollout_id=rollout_id,
+        run_id=row.get(RUN_ID_KEY),
+        attempt_index=row.get(ATTEMPT_INDEX_KEY_NAME, 0),
+        failure_kind=failure[NG_FAILURE_CLASS_KEY],
+        stage=stage,
+        failure_reason=str(
+            failure.get("_ng_failure_message")
+            or failure.get("failure_reason")
+            or failure.get("error")
+            or failure.get("_ng_failure_judge_error")
+            or "Agent reported a no-result failure"
+        ),
+        exception_type=failure.get("_ng_failure_type"),
+        http_status=failure.get("_ng_failure_http_status"),
+        response_body=failure.get("_ng_failure_response_body"),
+        terminal=bool(failure.get(NG_TERMINAL_KEY)),
+    )
+
+
+def _normalize_rollout_outcome(row: Dict, result: Any) -> Dict | RolloutFailure:
+    if not isinstance(result, dict):
+        raise InvalidRolloutResult("Agent /run must return a JSON object.")
+    try:
+        if result.get("type") == "failure":
+            failure = RolloutFailure.model_validate(result)
+            logical_row = {key: value for key, value in row.items() if key != ATTEMPT_INDEX_KEY_NAME}
+            if failure.rollout_id != maybe_rollout_id_from_run_body(logical_row) or failure.attempt_index != row.get(
+                ATTEMPT_INDEX_KEY_NAME, 0
+            ):
+                raise InvalidRolloutResult("Returned failure does not match the dispatched rollout attempt.")
+            if failure.run_id is not None and failure.run_id != row.get(RUN_ID_KEY):
+                raise InvalidRolloutResult("Returned failure belongs to a different run.")
+            if failure.run_id is None and RUN_ID_KEY in row:
+                failure = failure.model_copy(update={"run_id": row[RUN_ID_KEY]})
+            return failure
+        if result.get(NG_FAILURE_CLASS_KEY) is not None:
+            return _failure_outcome(row, result, "agent")
+        if (
+            type(result.get("reward")) not in (int, float)
+            or not isfinite(result["reward"])
+            or not isinstance(result.get("response"), dict)
+        ):
+            raise InvalidRolloutResult("Completed results require a finite reward and a response object.")
+    except (ValidationError, OverflowError) as error:
+        raise InvalidRolloutResult(str(error)) from error
+    return result
+
+
+def _failure_compatibility_row(failure: RolloutFailure) -> Dict:
+    """Keep existing sidecar routing keys while exposing the canonical failure.
+
+    Remove these aliases when row-oriented consumers and #3180 producers migrate.
+    The explicit adapter never carries legacy reward/response placeholders.
+    """
+    row = {
+        "_ng_failure_record": failure.model_dump(mode="json"),
+        NG_FAILURE_CLASS_KEY: failure.failure_kind,
+        "_ng_failure_type": failure.exception_type,
+        "_ng_failure_message": failure.failure_reason,
+        "_ng_failure_http_status": failure.http_status,
+        "_ng_failure_response_body": failure.response_body,
+    }
+    if failure.terminal:
+        row[NG_TERMINAL_KEY] = True
+    return row
+
+
 def _latest_failure_rows(failures_fpaths: List[Path]) -> Dict[Tuple[Any, Any], Dict[str, Any]]:
     """The last attempt recorded for each rollout across the failures sidecars."""
     latest_by_key: Dict[Tuple[Any, Any], Dict[str, Any]] = {}
@@ -878,8 +969,22 @@ def _latest_failure_rows(failures_fpaths: List[Path]) -> Dict[Tuple[Any, Any], D
                 if not line:
                     continue
                 row = loads_jsonl_line(line, fpath, line_no)
-                latest_by_key[(row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME))] = row
+                key = row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME)
+                previous = latest_by_key.get(key)
+                if previous is None or row.get(ATTEMPT_INDEX_KEY_NAME, 0) >= previous.get(ATTEMPT_INDEX_KEY_NAME, 0):
+                    latest_by_key[key] = row
     return latest_by_key
+
+
+def _counted_failure_rows(rows: List[Dict], failure_classes: List[str]) -> List[Dict]:
+    counted = []
+    for row in rows:
+        if row.get(NG_FAILURE_CLASS_KEY) not in failure_classes:
+            continue
+        scored = {key: value for key, value in row.items() if not key.startswith("_ng_failure_")}
+        scored.setdefault("reward", 0.0)
+        counted.append(scored)
+    return counted
 
 
 def _failure_rows_counted_as_zero(
@@ -900,17 +1005,9 @@ def _failure_rows_counted_as_zero(
         return []
 
     latest_by_key = _latest_failure_rows(failures_fpaths)
-    wanted = set(failure_classes)
-    counted = []
-    for key, row in latest_by_key.items():
-        if key in scored_keys or row.get(NG_FAILURE_CLASS_KEY) not in wanted:
-            continue
-        # Diagnostics stay in the sidecar: an HTTP status is a number, and the aggregator
-        # averages every number it is handed.
-        scored = {k: v for k, v in row.items() if not k.startswith("_ng_failure_")}
-        scored.setdefault("reward", 0.0)
-        counted.append(scored)
-    return counted
+    return _counted_failure_rows(
+        [row for key, row in latest_by_key.items() if key not in scored_keys], failure_classes
+    )
 
 
 def _coverage_report(expected: int, scored: int, failure_counts: Counter, failures_hint: Any) -> str:
@@ -1178,6 +1275,13 @@ class RolloutCollectionHelper(BaseModel):
     def _load_from_cache(
         self, config: RolloutCollectionConfig
     ) -> Tuple[List[Dict], List[Dict], List[Dict], List[List[str]]]:
+        output = Path(config.output_jsonl_fpath)
+        if manifest_path_for(output).exists() and journal_path_for(output).exists():
+            manifest = RunManifest.model_validate_json(manifest_path_for(output).read_bytes())
+            history = RolloutJournal.load(output, manifest, import_legacy=manifest.legacy_import)
+            results = history.selected("success")
+            rows = [history.expected[logical_rollout_id(result)] for result in results]
+            return history.pending(_get_max_rollout_attempts()), rows, results, [[orjson.dumps(r)] for r in results]
         with config.materialized_jsonl_fpath.open() as f:
             original_input_rows = list(map(orjson.loads, tqdm(f, desc="Reading materialized input rows")))
         with Path(config.output_jsonl_fpath).open("rb") as f:
@@ -1254,6 +1358,11 @@ class RolloutCollectionHelper(BaseModel):
     async def _run_from_config(self, config: RolloutCollectionConfig) -> Tuple[List[Dict]]:
         output_fpath = Path(config.output_jsonl_fpath)
         failures_fpath = failures_path_for(output_fpath)
+        manifest_fpath = manifest_path_for(output_fpath)
+        history_fpath = journal_path_for(output_fpath)
+        import_history = False
+        global_config = get_global_config_dict()
+        resolved_config = OmegaConf.to_container(OmegaConf.create(global_config), resolve=True)
 
         # Create the output directory up front: every artifact this run writes (materialized inputs,
         # rollouts, failures sidecar, aggregate metrics) is derived from output_fpath and keeps its
@@ -1262,13 +1371,55 @@ class RolloutCollectionHelper(BaseModel):
         # outside a git clone.
         output_fpath.parent.mkdir(parents=True, exist_ok=True)
 
-        if config.resume_from_cache and config.materialized_jsonl_fpath.exists() and output_fpath.exists():
-            (
-                input_rows,
-                rows,
-                results,
-                result_strs,
-            ) = self._load_from_cache(config)
+        saved_artifacts = (
+            config.materialized_jsonl_fpath,
+            output_fpath,
+            manifest_fpath,
+            failures_fpath,
+            history_fpath,
+        )
+        if config.resume_from_cache and any(path.exists() for path in saved_artifacts):
+            if not config.materialized_jsonl_fpath.exists() or not output_fpath.exists():
+                raise ConfigError("Cannot resume: saved materialized inputs or rollout output are missing.")
+            current_manifest = None
+            if manifest_fpath.exists():
+                try:
+                    current_rows = self._preprocess_rows_from_config(config)
+                    if any(
+                        (row.get(AGENT_REF_KEY_NAME) or {}).get("name") is None
+                        and row.get(TASK_SOURCE_KEY_NAME) is not None
+                        for row in current_rows
+                    ):
+                        self.resolve_task_sources(current_rows, self.setup_server_client().global_config_dict)
+                    current_manifest = RunManifest.create(
+                        _resolve_under_cwd_or_install(config.input_jsonl_fpath),
+                        current_rows,
+                        config.model_dump(mode="json"),
+                        resolved_config,
+                    )
+                except (ConfigError, OSError):
+                    if not config.allow_unsafe_resume:
+                        raise
+            manifest = validate_resume(
+                manifest_fpath,
+                current_manifest,
+                config.materialized_jsonl_fpath,
+                allow_unsafe=config.allow_unsafe_resume,
+            )
+            if manifest is None:
+                manifest = RunManifest.import_legacy(list(read_records(config.materialized_jsonl_fpath)))
+                import_history = True
+            elif not history_fpath.exists():
+                if not config.allow_unsafe_resume:
+                    raise ConfigError(f"Cannot resume without attempt history: {history_fpath}.")
+                manifest = manifest.model_copy(update={"legacy_import": True})
+                import_history = True
+            history = RolloutJournal.load(output_fpath, manifest, import_legacy=manifest.legacy_import)
+            input_rows = history.pending(_get_max_rollout_attempts())
+            results = history.selected("success")
+            rows = [history.expected[logical_rollout_id(result)] for result in results]
+            if import_history or manifest.identity_overridden:
+                manifest.write(manifest_fpath)
             persisted_rows = list(rows)
             persisted_results = list(results)
         else:
@@ -1304,9 +1455,21 @@ class RolloutCollectionHelper(BaseModel):
                 for row in tqdm(input_rows, desc="Writing materialized rows"):
                     f.write(orjson.dumps(row) + b"\n")
 
+            manifest = RunManifest.create(
+                _resolve_under_cwd_or_install(config.input_jsonl_fpath),
+                input_rows,
+                config.model_dump(mode="json"),
+                resolved_config,
+            )
+            history = RolloutJournal(manifest, input_rows)
+            # Invalidate old outputs before publishing the new run's identity.
             output_fpath.unlink(missing_ok=True)
             failures_fpath.unlink(missing_ok=True)
+            history_fpath.unlink(missing_ok=True)
+            coverage_path_for(output_fpath).unlink(missing_ok=True)
+            manifest.write(manifest_fpath)
 
+        input_rows = [dict(row, **{RUN_ID_KEY: manifest.run_id}) for row in input_rows]
         semaphore = nullcontext()
         if config.num_samples_in_parallel:
             print(f"Querying with {config.num_samples_in_parallel} concurrent requests")
@@ -1314,7 +1477,6 @@ class RolloutCollectionHelper(BaseModel):
 
         # Resolve capture dirs once so each rollout's captured model calls can be folded
         # into its record below (uniform across agents; no-op when capture is off / dirs absent).
-        global_config = get_global_config_dict()
         capture_dirs = model_call_capture_dirs_from_config(global_config)
         observability_enabled = observability_enabled_from_config(global_config)
         # Resolve the training-token store directory once.
@@ -1336,8 +1498,8 @@ class RolloutCollectionHelper(BaseModel):
             if isinstance(token_source, TokenCaptureStore):
                 owned_token_source = token_source
 
-        # Clear only rows about to be dispatched, after resume has assigned retry suffixes. This also
-        # removes a kill-shaped attempt's partial capture when its rollout-attempt id is reused.
+        # Clear only the attempts about to be dispatched. Recovery allocates a new
+        # attempt index even when an earlier attempt died without a result.
         if capture_dirs:
             print("Clearing existing model-call captures for rollouts being dispatched")
             clear_model_call_captures_for_rollouts(input_rows, capture_dirs)
@@ -1378,194 +1540,236 @@ class RolloutCollectionHelper(BaseModel):
                 flush=True,
             )
 
-        results_file = output_fpath.open("ab")
-        failures_file = failures_fpath.open("ab")
-        failure_counts: Counter = Counter()
-        for future in self._run_examples_with_metadata(
-            input_rows,
-            semaphore=semaphore,
-            route_failures_to_sidecar=config.route_failures_to_sidecar,
-        ):
-            completed = await future
-            row, result, rollout_latency_ms = completed.row, completed.result, completed.rollout_latency_ms
+        async with AsyncExitStack() as output_files:
+            if owned_token_source is not None:
+                output_files.push_async_callback(owned_token_source.close)
+            for path in (output_fpath, failures_fpath, history_fpath):
+                prepare_append(path)
+            # Register first: this runs after the output files close, including on
+            # cancellation. The journal remains the source of truth after SIGKILL.
+            output_files.callback(history.write_coverage, output_fpath)
+            history.file = output_files.enter_context(history_fpath.open("ab"))
+            results_file = output_files.enter_context(output_fpath.open("ab"))
+            failures_file = output_files.enter_context(failures_fpath.open("ab"))
+            if import_history:
+                history.seed_legacy_history()
+            history.write_coverage(output_fpath)
+            failure_counts: Counter = Counter()
+            dispatches = self._run_examples_with_metadata(
+                input_rows,
+                semaphore=semaphore,
+                route_failures_to_sidecar=config.route_failures_to_sidecar,
+                typed_outcomes=config.route_failures_to_sidecar,
+                on_dispatch=history.dispatch,
+            )
+            if hasattr(dispatches, "aclose"):
+                output_files.push_async_callback(dispatches.aclose)
+            elif hasattr(dispatches, "close"):
+                output_files.callback(dispatches.close)
+            for future in dispatches:
+                completed = await future
+                row, result, rollout_latency_ms = completed.row, completed.result, completed.rollout_latency_ms
+                # Custom dispatch implementations may return an already-completed
+                # future. Associate those outcomes too; normal HTTP dispatch records
+                # its event before the request through on_dispatch above.
+                history.dispatch(row)
+                if isinstance(result, dict):
+                    if result.get("type") == "failure":
+                        result = _normalize_rollout_outcome(row, result)
+                    elif result.get(NG_FAILURE_CLASS_KEY) is not None:
+                        result = _failure_outcome(row, result, "agent")
+                structured_failure = isinstance(result, RolloutFailure)
+                if structured_failure:
+                    result = _failure_compatibility_row(result)
 
-            result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
-            result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
-            result[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
-            if TASK_SOURCE_KEY_NAME in row:
-                result[TASK_SOURCE_KEY_NAME] = row[TASK_SOURCE_KEY_NAME]
-            if SKILLS_REF_KEY_NAME in row:
-                result[SKILLS_REF_KEY_NAME] = row[SKILLS_REF_KEY_NAME]
-            if ATTEMPT_INDEX_KEY_NAME in row:
-                result[ATTEMPT_INDEX_KEY_NAME] = row[ATTEMPT_INDEX_KEY_NAME]
-            if ROLLOUT_ID_KEY_NAME in row:
-                # Capture readback recomputes the id from the finished record.
-                # Preserve an explicit id on the result just like the indices.
-                result[ROLLOUT_ID_KEY_NAME] = row[ROLLOUT_ID_KEY_NAME]
+                result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
+                result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
+                result[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
+                result[RUN_ID_KEY] = manifest.run_id
+                if TASK_SOURCE_KEY_NAME in row:
+                    result[TASK_SOURCE_KEY_NAME] = row[TASK_SOURCE_KEY_NAME]
+                if SKILLS_REF_KEY_NAME in row:
+                    result[SKILLS_REF_KEY_NAME] = row[SKILLS_REF_KEY_NAME]
+                if ATTEMPT_INDEX_KEY_NAME in row:
+                    result[ATTEMPT_INDEX_KEY_NAME] = row[ATTEMPT_INDEX_KEY_NAME]
+                if ROLLOUT_ID_KEY_NAME in row:
+                    # Capture readback recomputes the id from the finished record.
+                    # Preserve an explicit id on the result just like the indices.
+                    result[ROLLOUT_ID_KEY_NAME] = row[ROLLOUT_ID_KEY_NAME]
 
-            no_persist = bool(result.get(NG_NO_PERSIST_KEY))
-            failure_class = result.get(NG_FAILURE_CLASS_KEY)
-            # No rollout happened, so there is nothing to capture, tokenize or average.
-            no_result = failure_class in _NO_RESULT_FAILURE_CLASSES
+                no_persist = bool(result.get(NG_NO_PERSIST_KEY))
+                failure_class = result.get(NG_FAILURE_CLASS_KEY)
+                # No rollout happened, so there is nothing to capture, tokenize or average.
+                no_result = no_persist or structured_failure or failure_class in _NO_RESULT_FAILURE_CLASSES
 
-            # Fold this rollout's captured model calls into its record (uniform across agents; no-op
-            # when capture is off). Never alters the harness output/reward already in `result`.
-            if capture_dirs and not no_result:
-                merge_model_call_capture_into_record(
-                    result,
-                    capture_dirs,
-                    include_payloads=not _has_observation_gap(result, "multimodal_history_redacted"),
+                # Fold this rollout's captured model calls into its record (uniform across agents; no-op
+                # when capture is off). Never alters the harness output/reward already in `result`.
+                if capture_dirs and not no_result:
+                    merge_model_call_capture_into_record(
+                        result,
+                        capture_dirs,
+                        include_payloads=not _has_observation_gap(result, "multimodal_history_redacted"),
+                    )
+
+                if (
+                    "ng_model_call_capture" in result
+                    or "ng_agent_observations" in result
+                    or NG_TRAJECTORY_KEY in result
+                ):
+                    _attach_trajectory_record(row, result)
+
+                # Assembles ng_perf from ng_trajectory when observability is enabled.
+                _attach_ng_perf(
+                    result, observability_enabled=observability_enabled, rollout_latency_ms=rollout_latency_ms
                 )
 
-            if "ng_model_call_capture" in result or "ng_agent_observations" in result or NG_TRAJECTORY_KEY in result:
-                _attach_trajectory_record(row, result)
+                # Freeze and rebuild tokens only for participating agents.
+                # This step does not retire the frozen snapshot.
+                # It leaves harness output and reward unchanged.
+                # Direct callers of run_examples finalize each record themselves.
+                token_capture_build = None
+                if not no_result and token_id_capture_enabled_for_agent(
+                    global_config,
+                    (row.get(AGENT_REF_KEY_NAME) or {}).get("name"),
+                ):
+                    token_capture_build = await finalize_rollout_token_capture(result, token_source)
+                    if token_capture_build is not None:
+                        finalized_count += 1
+                        if token_capture_build.get(MASK_SAMPLE_KEY):
+                            masked_count += 1
+                            # Aggregate available reasons for the abort message.
+                            build_metrics = token_capture_build.get("metrics") or {}
+                            if build_metrics.get("capture_incomplete"):
+                                mask_reasons["capture_incomplete"] += 1
+                            if build_metrics.get("unresolved_parent_calls"):
+                                mask_reasons["unresolved_parent_calls"] += 1
+                            build_error = token_capture_build.get("error") or build_metrics.get("error")
+                            if build_error:
+                                mask_reasons[str(build_error)] += 1
+                        settings = token_capture_config.token_id_capture
+                        if (
+                            settings.max_mask_fraction is not None
+                            and finalized_count >= settings.mask_fraction_min_samples
+                            and masked_count / finalized_count > settings.max_mask_fraction
+                        ):
+                            raise RuntimeError(
+                                f"{masked_count}/{finalized_count} finalized rollouts "
+                                f"({masked_count / finalized_count:.1%}) are masked, exceeding "
+                                f"token_id_capture.max_mask_fraction={settings.max_mask_fraction}. "
+                                f"Mask reasons: {dict(mask_reasons)}. Aborting instead of collecting "
+                                "mostly token-less data."
+                            )
 
-            # Assembles ng_perf from ng_trajectory when observability is enabled.
-            _attach_ng_perf(result, observability_enabled=observability_enabled, rollout_latency_ms=rollout_latency_ms)
+                rows.append(row)
+                results.append(result)
+                serialized = orjson.dumps(result)
 
-            # Freeze and rebuild tokens only for participating agents.
-            # This step does not retire the frozen snapshot.
-            # It leaves harness output and reward unchanged.
-            # Direct callers of run_examples finalize each record themselves.
-            token_capture_build = None
-            if not no_result and token_id_capture_enabled_for_agent(
-                global_config,
-                (row.get(AGENT_REF_KEY_NAME) or {}).get("name"),
-            ):
-                token_capture_build = await finalize_rollout_token_capture(result, token_source)
-                if token_capture_build is not None:
-                    finalized_count += 1
-                    if token_capture_build.get(MASK_SAMPLE_KEY):
-                        masked_count += 1
-                        # Aggregate available reasons for the abort message.
-                        build_metrics = token_capture_build.get("metrics") or {}
-                        if build_metrics.get("capture_incomplete"):
-                            mask_reasons["capture_incomplete"] += 1
-                        if build_metrics.get("unresolved_parent_calls"):
-                            mask_reasons["unresolved_parent_calls"] += 1
-                        build_error = token_capture_build.get("error") or build_metrics.get("error")
-                        if build_error:
-                            mask_reasons[str(build_error)] += 1
-                    settings = token_capture_config.token_id_capture
-                    if (
-                        settings.max_mask_fraction is not None
-                        and finalized_count >= settings.mask_fraction_min_samples
-                        and masked_count / finalized_count > settings.max_mask_fraction
-                    ):
-                        raise RuntimeError(
-                            f"{masked_count}/{finalized_count} finalized rollouts "
-                            f"({masked_count / finalized_count:.1%}) are masked, exceeding "
-                            f"token_id_capture.max_mask_fraction={settings.max_mask_fraction}. "
-                            f"Mask reasons: {dict(mask_reasons)}. Aborting instead of collecting "
-                            "mostly token-less data."
-                        )
+                if no_persist:
+                    # A returned suppression without a failure is an intentional
+                    # omission. Known kill-shaped failures were converted above.
+                    history.omit(row, str(result.get("error") or "Producer requested no result persistence"))
+                elif failure_class is not None:
+                    # Failures remain separate from completed generation data.
+                    failure_counts[failure_class] += 1
+                    # Every dropped rollout says so as it happens, whichever layer classified it.
+                    # tqdm.write keeps the line off the progress bar it would otherwise collide with.
+                    detail = str(result.get("_ng_failure_message") or result.get("error") or "")[:200]
+                    tqdm.write(
+                        "🚨 [rollout_collection] rollout dropped from the score: "
+                        f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)} "
+                        f"class={failure_class} error={detail}"
+                    )
+                    failures_file.write(serialized + b"\n")
+                    failures_file.flush()
+                    history.outcome(result)
+                else:
+                    # Success → main jsonl.
+                    results_file.write(serialized + b"\n")
+                    results_file.flush()
+                    history.outcome(result)
+                    persisted_rows.append(row)
+                    persisted_results.append(result)
+                    try:
+                        rollout_id = maybe_rollout_id_from_run_body(result)
+                    except (TypeError, ValueError) as error:
+                        # Preserve capture evidence when the rollout id is invalid.
+                        rollout_id = None
+                        if not warned_malformed_rollout_id:
+                            warned_malformed_rollout_id = True
+                            warnings.warn(
+                                f"a result carries a malformed rollout id ({error}); "
+                                "its token capture will not be retired.",
+                                stacklevel=2,
+                            )
+                    if rollout_id is not None and capture_build_can_retire(token_capture_build):
+                        os.fsync(results_file.fileno())
+                        await retire_rollout_token_capture(rollout_id, token_source, token_capture_build)
 
-            rows.append(row)
-            results.append(result)
-            serialized = orjson.dumps(result)
+                counts_left[row[AGENT_REF_KEY_NAME]["name"]] -= 1
+                if counts_left[row[AGENT_REF_KEY_NAME]["name"]] <= 0:
+                    counts_left.pop(row[AGENT_REF_KEY_NAME]["name"])
 
-            if no_persist:
-                # kill_shaped: don't write anywhere. Set-difference on resume
-                # naturally re-dispatches; per-task timeout bounds wallclock.
-                pass
-            elif failure_class is not None:
-                # Non-kill_shaped failure → sidecar. The aggregator only reads
-                # the main jsonl, so this keeps win-rate uncontaminated.
-                failure_counts[failure_class] += 1
-                # Every dropped rollout says so as it happens, whichever layer classified it.
-                # tqdm.write keeps the line off the progress bar it would otherwise collide with.
-                detail = str(result.get("_ng_failure_message") or result.get("error") or "")[:200]
-                tqdm.write(
-                    "🚨 [rollout_collection] rollout dropped from the score: "
-                    f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)} "
-                    f"class={failure_class} error={detail}"
-                )
-                failures_file.write(serialized + b"\n")
-                failures_file.flush()
-            else:
-                # Success → main jsonl.
-                results_file.write(serialized + b"\n")
-                results_file.flush()
-                persisted_rows.append(row)
-                persisted_results.append(result)
-                try:
-                    rollout_id = maybe_rollout_id_from_run_body(result)
-                except (TypeError, ValueError) as error:
-                    # Preserve capture evidence when the rollout id is invalid.
-                    rollout_id = None
-                    if not warned_malformed_rollout_id:
-                        warned_malformed_rollout_id = True
-                        warnings.warn(
-                            f"a result carries a malformed rollout id ({error}); "
-                            "its token capture will not be retired.",
-                            stacklevel=2,
-                        )
-                if rollout_id is not None and capture_build_can_retire(token_capture_build):
-                    os.fsync(results_file.fileno())
-                    await retire_rollout_token_capture(rollout_id, token_source, token_capture_build)
+                agent_name = result["agent_ref"]["name"]
+                if not no_result:
+                    # An infrastructure failure is not a score of zero, and not a sample either.
+                    metrics = agent_name_to_metrics[agent_name]
+                    metrics.update(
+                        {k: v for k, v in result.items() if isinstance(v, (int, float)) and not k.startswith("_")}
+                    )
+                    agent_name_to_counts[agent_name] += 1
 
-            counts_left[row[AGENT_REF_KEY_NAME]["name"]] -= 1
-            if counts_left[row[AGENT_REF_KEY_NAME]["name"]] <= 0:
-                counts_left.pop(row[AGENT_REF_KEY_NAME]["name"])
+                current_pct = 100 * len(results) / len(input_rows)
+                if pcts_to_print and current_pct >= pcts_to_print[0]:
+                    while pcts_to_print and current_pct >= pcts_to_print[0]:
+                        pcts_to_print.pop(0)
 
-            agent_name = result["agent_ref"]["name"]
-            if not no_result:
-                # An infrastructure failure is not a score of zero, and not a sample either.
-                metrics = agent_name_to_metrics[agent_name]
-                metrics.update(
-                    {k: v for k, v in result.items() if isinstance(v, (int, float)) and not k.startswith("_")}
-                )
-                agent_name_to_counts[agent_name] += 1
+                    time_taken_s = time() - start_time
+                    time_taken = timedelta(seconds=int(time_taken_s))
+                    rollouts_per_min = len(results) / (time_taken_s / 60)
+                    print_str = f"Finished {len(results)} / {len(input_rows)} rollouts ({int(current_pct)}%) in {time_taken} ({rollouts_per_min:.2f} rollouts/min). "
 
-            current_pct = 100 * len(results) / len(input_rows)
-            if pcts_to_print and current_pct >= pcts_to_print[0]:
-                while pcts_to_print and current_pct >= pcts_to_print[0]:
-                    pcts_to_print.pop(0)
-
-                time_taken_s = time() - start_time
-                time_taken = timedelta(seconds=int(time_taken_s))
-                rollouts_per_min = len(results) / (time_taken_s / 60)
-                print_str = f"Finished {len(results)} / {len(input_rows)} rollouts ({int(current_pct)}%) in {time_taken} ({rollouts_per_min:.2f} rollouts/min). "
-
-                top_left = counts_left.most_common()
-                top_left_str = "\n".join(f"{i + 1}. {k}: {v}" for i, (k, v) in enumerate(top_left))
-                print_str += f"""Examples left:
+                    top_left = counts_left.most_common()
+                    top_left_str = "\n".join(f"{i + 1}. {k}: {v}" for i, (k, v) in enumerate(top_left))
+                    print_str += f"""Examples left:
 {top_left_str}
 """
-                for agent_name in sorted(agent_name_to_metrics):
-                    metrics = agent_name_to_metrics[agent_name]
-                    agent_total_samples = dispatched_per_agent[agent_name]
-                    agent_sample_pct = 100 * agent_name_to_counts[agent_name] / agent_total_samples
-                    avg_metrics = {k: v / agent_name_to_counts[agent_name] for k, v in metrics.items()}
-                    print_str += f"""Found {agent_name_to_counts[agent_name]} / {agent_total_samples} ({agent_sample_pct:.2f}%) rollouts for `{agent_name}`.
+                    for agent_name in sorted(agent_name_to_metrics):
+                        metrics = agent_name_to_metrics[agent_name]
+                        agent_total_samples = dispatched_per_agent[agent_name]
+                        agent_sample_pct = 100 * agent_name_to_counts[agent_name] / agent_total_samples
+                        avg_metrics = {k: v / agent_name_to_counts[agent_name] for k, v in metrics.items()}
+                        print_str += f"""Found {agent_name_to_counts[agent_name]} / {agent_total_samples} ({agent_sample_pct:.2f}%) rollouts for `{agent_name}`.
 {json.dumps(avg_metrics, indent=4)}
 """
-                # Use tqdm.write here so we can print properly with tqdm being used.
-                tqdm.write(print_str)
+                    # Use tqdm.write here so we can print properly with tqdm being used.
+                    tqdm.write(print_str)
 
-                if get_exporters():
-                    step_metrics = {"progress/total/rollouts_per_min": rollouts_per_min}
-                    for agent_name, metrics in agent_name_to_metrics.items():
-                        step_metrics[f"progress/{agent_name}/reward"] = round(
-                            100 * metrics["reward"] / agent_name_to_counts[agent_name], 2
-                        )
-                        step_metrics[f"progress/{agent_name}/reward_lower_bound"] = round(
-                            100 * metrics["reward"] / (counts_left[agent_name] + agent_name_to_counts[agent_name]), 2
-                        )
+                    if get_exporters():
+                        step_metrics = {"progress/total/rollouts_per_min": rollouts_per_min}
+                        for agent_name, metrics in agent_name_to_metrics.items():
+                            step_metrics[f"progress/{agent_name}/reward"] = round(
+                                100 * metrics["reward"] / agent_name_to_counts[agent_name], 2
+                            )
+                            step_metrics[f"progress/{agent_name}/reward_lower_bound"] = round(
+                                100 * metrics["reward"] / (counts_left[agent_name] + agent_name_to_counts[agent_name]),
+                                2,
+                            )
 
-                    export_metrics(step_metrics, step=int(current_pct))
+                        export_metrics(step_metrics, step=int(current_pct))
 
-        results_file.close()
-        failures_file.close()
-
+        persisted_results = history.selected("success")
+        persisted_rows = [history.expected[logical_rollout_id(result)] for result in persisted_results]
+        completion = history.coverage()
+        print(
+            f"Rollout coverage: {completion['successful']}/{completion['expected']} completed, "
+            f"{completion['failed']} failed, {completion['intentionally_omitted']} intentionally omitted, "
+            f"{completion['unknown']} unknown. Details: {coverage_path_for(output_fpath)}"
+        )
         if input_rows and not persisted_results:
             raise RuntimeError(
                 f"None of the {len(input_rows)} dispatched rollouts produced a result "
                 f"{dict(failure_counts)}. Inspect {failures_fpath}; the run has no score to report."
             )
-        if owned_token_source is not None:
-            await owned_token_source.close()
-
         if config.upload_rollouts and get_exporters():  # pragma: no cover
             print("Uploading rollouts. This may take a few minutes if your data is large.")
             export_rollouts([_rollout_for_export(result) for result in results])
@@ -1588,11 +1792,7 @@ class RolloutCollectionHelper(BaseModel):
             aggregate_metrics_fpath = None
         else:
             print("Computing aggregate metrics")
-            counted[:] = _failure_rows_counted_as_zero(
-                [failures_fpath],
-                config.count_failure_classes_as_zero,
-                {(r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) for r in persisted_results},
-            )
+            counted[:] = _counted_failure_rows(history.selected("failure"), config.count_failure_classes_as_zero)
             if config.count_failure_classes_as_zero:
                 print(
                     f"Counting {len(counted)} failure row(s) as scored zeros: {config.count_failure_classes_as_zero}"
@@ -1601,12 +1801,11 @@ class RolloutCollectionHelper(BaseModel):
                 persisted_results + counted, persisted_rows + counted, output_fpath
             )
 
-        expected_rollouts = (
-            sum(1 for _ in config.materialized_jsonl_fpath.open("rb"))
-            if config.materialized_jsonl_fpath.exists()
-            else len(input_rows) + len(persisted_results)
-        )
+        expected_rollouts = completion["expected"]
         scored_rollouts = len(persisted_results) + len(counted)
+        completion["scored"] = scored_rollouts
+        completion["failures_counted_as_zero"] = len(counted)
+        atomic_write_json(coverage_path_for(output_fpath), completion)
         coverage = _coverage_report(expected_rollouts, scored_rollouts, failure_counts, failures_fpath)
         if get_exporters():  # pragma: no cover
             export_metrics(
@@ -1897,6 +2096,8 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
         head_server_config: Optional[BaseServerConfig] = None,
         semaphore: Optional[Semaphore] = None,
         route_failures_to_sidecar: bool = False,
+        typed_outcomes: bool = False,
+        on_dispatch: Optional[Callable[[Dict], None]] = None,
     ) -> Iterator[Future]:  # pragma: no cover
         """
         Internal dispatch shared by ``run_examples`` and Gym's own collection paths.
@@ -1916,10 +2117,17 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
             async with semaphore:
                 started_at = time()
                 res = None
+                stage = "request"
+                if on_dispatch is not None:
+                    on_dispatch(row)
                 try:
                     res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
                     await raise_for_status(res)
+                    stage = "response"
                     result = await get_response_json(res)
+                    if typed_outcomes:
+                        stage = "result"
+                        result = _normalize_rollout_outcome(row, result)
                     # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
                     # from summed model-call/tool latencies to account for additional overhead.
                     rollout_latency_ms = (time() - started_at) * 1000
@@ -1931,23 +2139,87 @@ Aggregate metrics: {aggregate_metrics_fpath}{coverage}""")
                         f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)}",
                         flush=True,
                     )
-                    if not route_failures_to_sidecar or not isinstance(e, _RUN_FAILURE_ERRORS):
+                    if not (route_failures_to_sidecar or typed_outcomes) or not isinstance(
+                        e, (*_RUN_FAILURE_ERRORS, InvalidRolloutResult)
+                    ):
                         raise
                     if res is not None:
                         res.release()
                     # The status comes from the error when it carries one, and from the response
                     # when the body was the part that failed.
                     status = getattr(e, "status", None) or getattr(res, "status", None)
+                    failure = _agent_request_failure_row(e, status)
                     return _CompletedRollout(
-                        row=row, result=_agent_request_failure_row(e, status), rollout_latency_ms=None
+                        row=row,
+                        result=_failure_outcome(row, failure, stage) if typed_outcomes else failure,
+                        rollout_latency_ms=None,
                     )
 
-        return tqdm.as_completed(
-            map(_post_subroutine, examples),
-            desc="Collecting rollouts",
-            miniters=10,
-            total=len(examples),
-            maxinterval=60,
+        class Dispatches:
+            def __init__(self):
+                self.tasks = []
+                self.futures = None
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self.futures is None:
+                    self.tasks = [asyncio.create_task(_post_subroutine(row)) for row in examples]
+                    for task in self.tasks:
+                        # A direct caller may consume only one future. Retrieve
+                        # other errors without changing what awaiting them raises.
+                        task.add_done_callback(lambda done: None if done.cancelled() else done.exception())
+                    self.futures = tqdm.as_completed(
+                        self.tasks,
+                        desc="Collecting rollouts",
+                        miniters=10,
+                        total=len(examples),
+                        maxinterval=60,
+                    )
+                return next(self.futures)
+
+            def close(self):
+                # Explicit runner ownership: garbage-collecting the iterator in
+                # `await next(run_examples(...))` must not cancel that one future.
+                for task in self.tasks:
+                    if not task.done():
+                        task.cancel()
+                if self.futures is not None:
+                    self.futures.close()
+
+            async def aclose(self):
+                self.close()
+                await asyncio.gather(*self.tasks, return_exceptions=True)
+
+        return Dispatches()
+
+    def run_outcomes(
+        self,
+        examples: List[Dict],
+        head_server_config: Optional[BaseServerConfig] = None,
+        semaphore: Optional[Semaphore] = None,
+    ) -> Iterator[Future]:
+        """Yield ``(row, completed_dict | RolloutFailure)`` in completion order.
+
+        Expected HTTP, JSON and result-shape failures become bounded records. Programming
+        errors and cancellation still propagate. Call ``preprocess_examples`` first, or
+        provide stable explicit rollout ids. This does not persist or retry work; a direct
+        caller owns those decisions. ``run_examples`` retains its existing behavior.
+        """
+        for row in examples:
+            if maybe_rollout_id_from_run_body(row) is None:
+                raise ValueError("run_outcomes requires rollout ids; call preprocess_examples first.")
+
+        async def without_metadata(future: Future) -> Tuple[Dict, Dict | RolloutFailure]:
+            completed = await future
+            return completed.row, completed.result
+
+        return map(
+            without_metadata,
+            self._run_examples_with_metadata(
+                examples, head_server_config=head_server_config, semaphore=semaphore, typed_outcomes=True
+            ),
         )
 
     def run_examples(
@@ -2077,6 +2349,9 @@ def _expand_input_glob(input_glob: str) -> List[str]:
     seen: Dict[str, None] = {}  # preserve insertion order while deduping
     for pattern in patterns:
         for path in sorted(glob_module.glob(pattern)):
+            if Path(path).stem.endswith(("_attempts", "_failures", "_materialized_inputs")):
+                # Broad shard globs must not score recovery artifacts as results.
+                continue
             seen.setdefault(path, None)
     return list(seen)
 
@@ -2091,7 +2366,28 @@ class RolloutAggregationHelper(BaseModel):
             print(f"  - {p}")
 
         results: List[Dict] = []
+        histories: List[RolloutJournal] = []
+        legacy_paths: List[Path] = []
+        run_ids: set[str] = set()
         for shard_path in input_paths:
+            shard = Path(shard_path)
+            manifest_path = manifest_path_for(shard)
+            if manifest_path.exists():
+                manifest = RunManifest.model_validate_json(manifest_path.read_bytes())
+                if manifest.run_id in run_ids:
+                    raise ConfigError("The same run was supplied through multiple shard paths.")
+                run_ids.add(manifest.run_id)
+                history = RolloutJournal.load(shard, manifest, import_legacy=manifest.legacy_import)
+                histories.append(history)
+                results.extend(history.selected("success"))
+                continue
+            if materialized_path_for(shard).exists():
+                manifest = RunManifest.import_legacy(list(read_records(materialized_path_for(shard))))
+                history = RolloutJournal.load(shard, manifest, import_legacy=True)
+                histories.append(history)
+                results.extend(history.selected("success"))
+                continue
+            legacy_paths.append(shard)
             with open(shard_path, "rb") as f:
                 for line_no, line in enumerate(f, 1):
                     line = line.strip()
@@ -2107,18 +2403,22 @@ class RolloutAggregationHelper(BaseModel):
         output_fpath.parent.mkdir(parents=True, exist_ok=True)
 
         if config.merge_shards:
+            if output_fpath.resolve() in {Path(path).resolve() for path in input_paths}:
+                raise ConfigError("Merged output must not overwrite a source rollout artifact or its attempt history.")
             print(f"Merging shards into {output_fpath}")
             with output_fpath.open("wb") as out:
                 for r in results:
                     out.write(orjson.dumps(r) + b"\n")
 
-        failures_fpaths = [failures_path_for(Path(path)) for path in input_paths]
+        failures_fpaths = [failures_path_for(path) for path in legacy_paths]
         scored_keys = {(r.get(TASK_INDEX_KEY_NAME), r.get(ROLLOUT_INDEX_KEY_NAME)) for r in results}
         counted = _failure_rows_counted_as_zero(
             failures_fpaths,
             config.count_failure_classes_as_zero,
             scored_keys,
         )
+        for history in histories:
+            counted.extend(_counted_failure_rows(history.selected("failure"), config.count_failure_classes_as_zero))
         if config.count_failure_classes_as_zero:
             print(f"Counting {len(counted)} failure row(s) as scored zeros: {config.count_failure_classes_as_zero}")
 
@@ -2135,20 +2435,45 @@ class RolloutAggregationHelper(BaseModel):
             if key not in scored_keys and key not in counted_keys
         )
         scored_rollouts = len(results) + len(counted)
+        components = [history.coverage() for history in histories]
+        inventory_known = not legacy_paths
+        completion = {
+            "schema_version": 1,
+            "expected": sum(c["expected"] for c in components) if inventory_known else None,
+            "successful": len(results),
+            "failed": sum(c["failed"] for c in components) if inventory_known else None,
+            "intentionally_omitted": sum(c["intentionally_omitted"] for c in components) if inventory_known else None,
+            "unknown": sum(c["unknown"] for c in components) if inventory_known else None,
+            "complete": inventory_known and all(c["complete"] for c in components),
+            "coverage_known": inventory_known,
+            "scored": scored_rollouts,
+            "failures_counted_as_zero": len(counted),
+            "shards": components,
+            "shards_without_inventory": [str(path) for path in legacy_paths],
+        }
+        atomic_write_json(coverage_path_for(output_fpath), completion)
+        if not inventory_known:
+            print(
+                "Completion coverage is unknown for legacy shards without materialized inputs; scores may be partial."
+            )
         coverage = _coverage_report(
-            scored_rollouts + sum(dropped.values()),
+            completion["expected"] if inventory_known else scored_rollouts + sum(dropped.values()),
             scored_rollouts,
             dropped,
             "the shards' _failures.jsonl sidecars",
         )
-        if get_exporters():  # pragma: no cover
-            export_metrics(
-                {
-                    "coverage/expected": scored_rollouts + sum(dropped.values()),
-                    "coverage/scored": scored_rollouts,
-                    "coverage/missing": sum(dropped.values()),
-                }
+        if inventory_known:
+            coverage += (
+                f"\nCoverage: {completion['successful']} successful, {completion['failed']} failed, "
+                f"{completion['intentionally_omitted']} intentionally omitted, {completion['unknown']} unknown. "
+                f"Details: {coverage_path_for(output_fpath)}"
             )
+        if get_exporters():  # pragma: no cover
+            metrics = {"coverage/scored": scored_rollouts, "coverage/known": int(inventory_known)}
+            if inventory_known:
+                metrics["coverage/expected"] = completion["expected"]
+                metrics["coverage/missing"] = completion["expected"] - scored_rollouts
+            export_metrics(metrics)
 
         print(f"""Finished rollout aggregation! View results at:
 Merged rollouts: {output_fpath if config.merge_shards else "<not merged>"}

--- a/nemo_gym/rollout_journal.py
+++ b/nemo_gym/rollout_journal.py
@@ -52,7 +52,10 @@ def materialized_path_for(output: Path) -> Path:
 
 def logical_rollout_id(row: dict) -> str:
     logical = {key: value for key, value in row.items() if key != ATTEMPT_INDEX_KEY_NAME}
-    identity = maybe_rollout_id_from_run_body(logical)
+    try:
+        identity = maybe_rollout_id_from_run_body(logical)
+    except (TypeError, ValueError) as error:
+        raise ConfigError(f"Invalid rollout identity: {error}") from error
     if identity is None:
         raise ConfigError("Recovery requires a rollout id or materialized task/rollout indices.")
     return identity
@@ -207,13 +210,15 @@ class RolloutJournal:
         self.omitted.add(key)
 
     @classmethod
-    def load(cls, output: Path, manifest: RunManifest, *, import_legacy: bool = False) -> "RolloutJournal":
+    def load(
+        cls, output: Path, manifest: RunManifest, *, import_legacy: bool = False, rebuild_history: bool = False
+    ) -> "RolloutJournal":
         expected = list(read_records(materialized_path_for(output)))
         if _digest(expected) != manifest.materialized_digest:
             raise ConfigError("Saved materialized inputs do not match the run manifest.")
         state = cls(manifest, expected)
         history = journal_path_for(output)
-        if not history.exists() and not import_legacy:
+        if not history.exists() and not (import_legacy or rebuild_history):
             raise ConfigError(f"Cannot resume without attempt history: {history}.")
         for value in read_records(history):
             try:
@@ -239,10 +244,18 @@ class RolloutJournal:
                     identity = logical_rollout_id(payload)
                     payload = dict(payload)
                     payload.setdefault(ATTEMPT_INDEX_KEY_NAME, legacy_counts[identity])
+                    key = state._key(payload)
+                    if key in state.payloads and state.payloads[key] != payload:
+                        # Old append/reverify writers reused explicit attempt IDs.
+                        # Only untagged legacy rows use arrival-order migration;
+                        # journal-backed records still reject conflicting payloads.
+                        payload[ATTEMPT_INDEX_KEY_NAME] = max(legacy_counts[identity], key[1] + 1)
                     legacy_counts[identity] = max(legacy_counts[identity], payload[ATTEMPT_INDEX_KEY_NAME] + 1)
-                if (path == output) == (payload.get("_ng_failure_class") is not None):
+                if (path == output) == (payload.get("_ng_failure_class") is not None) and not (
+                    import_legacy and RUN_ID_KEY not in payload
+                ):
                     raise ConfigError(f"Outcome in the wrong artifact: {path}.")
-                state._payload(payload, legacy=import_legacy and RUN_ID_KEY not in payload)
+                state._payload(payload, legacy=rebuild_history or (import_legacy and RUN_ID_KEY not in payload))
         return state
 
     def seed_legacy_history(self) -> None:

--- a/nemo_gym/rollout_journal.py
+++ b/nemo_gym/rollout_journal.py
@@ -32,7 +32,7 @@ from nemo_gym.config_types import ConfigError
 from nemo_gym.global_config import ATTEMPT_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.path_utils import failures_path_for
 from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
-from nemo_gym.rollout_recovery import RunManifest, _digest, atomic_write_json
+from nemo_gym.rollout_recovery import RunManifest, _digest
 
 
 RUN_ID_KEY = "_ng_run_id"
@@ -172,19 +172,24 @@ class RolloutJournal:
             self._event(key, "dispatched")
             self._dispatch(key)
 
-    def _payload(self, row: dict, *, legacy: bool = False) -> None:
+    def check_outcome(self, row: dict, *, legacy: bool = False) -> tuple[str, int]:
+        """Validate without mutation, before a writer appends the payload."""
         key = self._key(row)
         if row.get(RUN_ID_KEY) != self.manifest.run_id and not (legacy and RUN_ID_KEY not in row):
             raise ConfigError("Saved outcome belongs to a different run.")
         if not legacy and key not in self.dispatched:
             raise ConfigError(f"Saved outcome {key!r} has no dispatch in this run's attempt history.")
-        if legacy:
-            self._dispatch(key)
         previous = self.payloads.get(key)
         if previous is not None and previous != row:
             raise ConfigError(f"Conflicting outcomes for rollout attempt {key!r}.")
         if key in self.omitted:
             raise ConfigError(f"Omitted rollout attempt {key!r} also has an outcome.")
+        return key
+
+    def _payload(self, row: dict, *, legacy: bool = False) -> None:
+        key = self.check_outcome(row, legacy=legacy)
+        if legacy:
+            self._dispatch(key)
         self.payloads[key] = row
 
     def outcome(self, row: dict) -> None:
@@ -288,6 +293,7 @@ class RolloutJournal:
         expected = len(self.expected)
         return {
             "schema_version": 1,
+            "selection_policy": self.manifest.selection_policy,
             "run_id": self.manifest.run_id,
             "expected": expected,
             "successful": counts["success"],
@@ -301,6 +307,3 @@ class RolloutJournal:
             "reconciled": counts["unknown"] == 0,
             "identity_verified": not (self.manifest.legacy_import or self.manifest.identity_overridden),
         }
-
-    def write_coverage(self, output: Path) -> None:
-        atomic_write_json(coverage_path_for(output), self.coverage())

--- a/nemo_gym/rollout_journal.py
+++ b/nemo_gym/rollout_journal.py
@@ -291,12 +291,17 @@ class RolloutJournal:
     def coverage(self) -> dict:
         counts = Counter(self.disposition(identity) for identity in self.expected)
         expected = len(self.expected)
+        # A producer-masked result completed execution, so recovery still reuses
+        # it. Report its measurement status separately, after selecting attempts.
+        masked = sum(bool(row.get("mask_sample")) for row in self.selected("success"))
         return {
             "schema_version": 1,
             "selection_policy": self.manifest.selection_policy,
             "run_id": self.manifest.run_id,
             "expected": expected,
             "successful": counts["success"],
+            "measured": counts["success"] - masked,
+            "masked": masked,
             "failed": counts["failure"],
             "intentionally_omitted": counts["omitted"],
             "unknown": counts["unknown"],

--- a/nemo_gym/rollout_journal.py
+++ b/nemo_gym/rollout_journal.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Single-writer attempt history and reconciliation for Gym's evaluation runner.
+
+Dispatch is flushed before the request starts. Payloads stay in the existing
+result/sidecar artifacts, carrying the manifest's run id. A complete payload can
+therefore be recovered even if the collector died before journaling its outcome.
+The greatest dispatched attempt index wins, independent of arrival order.
+"""
+
+import warnings
+from collections import Counter
+from pathlib import Path
+from typing import BinaryIO, Literal
+
+import orjson
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from nemo_gym.config_types import ConfigError
+from nemo_gym.global_config import ATTEMPT_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.path_utils import failures_path_for
+from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
+from nemo_gym.rollout_recovery import RunManifest, _digest, atomic_write_json
+
+
+RUN_ID_KEY = "_ng_run_id"
+
+
+def journal_path_for(output: Path) -> Path:
+    return output.with_name(output.stem + "_attempts.jsonl")
+
+
+def coverage_path_for(output: Path) -> Path:
+    return output.with_name(output.stem + "_coverage.json")
+
+
+def materialized_path_for(output: Path) -> Path:
+    return output.with_name(output.stem + "_materialized_inputs.jsonl")
+
+
+def logical_rollout_id(row: dict) -> str:
+    logical = {key: value for key, value in row.items() if key != ATTEMPT_INDEX_KEY_NAME}
+    identity = maybe_rollout_id_from_run_body(logical)
+    if identity is None:
+        raise ConfigError("Recovery requires a rollout id or materialized task/rollout indices.")
+    return identity
+
+
+def read_records(path: Path):
+    """Read committed JSONL records; an incomplete final write is not a record."""
+    if not path.exists():
+        return
+    with path.open("rb") as file:
+        for number, raw in enumerate(file, 1):
+            if not raw.strip():
+                continue
+            try:
+                value = orjson.loads(raw)
+            except orjson.JSONDecodeError as error:
+                if not raw.endswith(b"\n"):
+                    warnings.warn(f"Ignoring incomplete final record in {path} at line {number}.", stacklevel=2)
+                    return
+                raise ConfigError(f"Malformed JSON in {path} at line {number}: {error}") from error
+            if not isinstance(value, dict):
+                raise ConfigError(f"Expected an object in {path} at line {number}.")
+            yield value
+
+
+def prepare_append(path: Path) -> None:
+    """Repair only an unterminated tail; preserve every complete history record."""
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    with path.open("r+b") as file:
+        file.seek(-1, 2)
+        if file.read(1) == b"\n":
+            return
+        end = file.tell()
+        start = end
+        tail = b""
+        while start:
+            size = min(start, 8192)
+            start -= size
+            file.seek(start)
+            tail = file.read(size) + tail
+            split = tail.rfind(b"\n")
+            if split >= 0:
+                start += split + 1
+                tail = tail[split + 1 :]
+                break
+        try:
+            orjson.loads(tail)
+        except orjson.JSONDecodeError:
+            file.truncate(start)
+            warnings.warn(f"Removed {end - start} bytes of incomplete final JSON from {path}.", stacklevel=2)
+        else:
+            file.seek(0, 2)
+            file.write(b"\n")
+        file.flush()
+
+
+class AttemptEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    run_id: str
+    rollout_id: str
+    attempt_index: int = Field(ge=0, strict=True)
+    status: Literal["dispatched", "success", "failure", "omitted"]
+    reason: str | None = Field(default=None, max_length=2000)
+
+
+class RolloutJournal:
+    def __init__(self, manifest: RunManifest, expected: list[dict]):
+        self.manifest = manifest
+        self.expected = {}
+        for row in expected:
+            identity = logical_rollout_id(row)
+            if identity in self.expected:
+                raise ConfigError(f"Duplicate logical rollout id {identity!r} in materialized inputs.")
+            self.expected[identity] = row
+        self.dispatched: set[tuple[str, int]] = set()
+        self.latest: dict[str, int] = {}
+        self.payloads: dict[tuple[str, int], dict] = {}
+        self.omitted: set[tuple[str, int]] = set()
+        self.file: BinaryIO | None = None
+
+    def _key(self, row: dict) -> tuple[str, int]:
+        identity = logical_rollout_id(row)
+        index = row.get(ATTEMPT_INDEX_KEY_NAME, 0)
+        if identity not in self.expected:
+            raise ConfigError(f"Rollout {identity!r} is not in this run's materialized inputs.")
+        if type(index) is not int or index < 0:
+            raise ConfigError("Attempt indices must be non-negative integers.")
+        expected = self.expected[identity]
+        for field in (TASK_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME):
+            if row.get(field) != expected.get(field):
+                raise ConfigError(f"Rollout {identity!r} has mismatched {field}.")
+        return identity, index
+
+    def _dispatch(self, key: tuple[str, int]) -> None:
+        self.dispatched.add(key)
+        self.latest[key[0]] = max(key[1], self.latest.get(key[0], -1))
+
+    def _event(self, key: tuple[str, int], status: str, reason: str | None = None) -> None:
+        if self.file is None:
+            raise RuntimeError("Attempt history is not open for writing.")
+        event = AttemptEvent(
+            run_id=self.manifest.run_id,
+            rollout_id=key[0],
+            attempt_index=key[1],
+            status=status,
+            reason=reason[:2000] if reason else None,
+        )
+        self.file.write(event.model_dump_json().encode() + b"\n")
+        self.file.flush()
+
+    def dispatch(self, row: dict) -> None:
+        key = self._key(row)
+        if key not in self.dispatched:
+            self._event(key, "dispatched")
+            self._dispatch(key)
+
+    def _payload(self, row: dict, *, legacy: bool = False) -> None:
+        key = self._key(row)
+        if row.get(RUN_ID_KEY) != self.manifest.run_id and not (legacy and RUN_ID_KEY not in row):
+            raise ConfigError("Saved outcome belongs to a different run.")
+        if not legacy and key not in self.dispatched:
+            raise ConfigError(f"Saved outcome {key!r} has no dispatch in this run's attempt history.")
+        if legacy:
+            self._dispatch(key)
+        previous = self.payloads.get(key)
+        if previous is not None and previous != row:
+            raise ConfigError(f"Conflicting outcomes for rollout attempt {key!r}.")
+        if key in self.omitted:
+            raise ConfigError(f"Omitted rollout attempt {key!r} also has an outcome.")
+        self.payloads[key] = row
+
+    def outcome(self, row: dict) -> None:
+        """Called after the payload artifact is flushed, so it is already recoverable."""
+        key = self._key(row)
+        self._payload(row)
+        self._event(key, "failure" if row.get("_ng_failure_class") is not None else "success")
+
+    def omit(self, row: dict, reason: str) -> None:
+        self.dispatch(row)
+        key = self._key(row)
+        if key in self.payloads:
+            raise ConfigError(f"Completed rollout attempt {key!r} cannot be omitted.")
+        self._event(key, "omitted", reason)
+        self.omitted.add(key)
+
+    @classmethod
+    def load(cls, output: Path, manifest: RunManifest, *, import_legacy: bool = False) -> "RolloutJournal":
+        expected = list(read_records(materialized_path_for(output)))
+        if _digest(expected) != manifest.materialized_digest:
+            raise ConfigError("Saved materialized inputs do not match the run manifest.")
+        state = cls(manifest, expected)
+        history = journal_path_for(output)
+        if not history.exists() and not import_legacy:
+            raise ConfigError(f"Cannot resume without attempt history: {history}.")
+        for value in read_records(history):
+            try:
+                event = AttemptEvent.model_validate(value)
+            except ValidationError as error:
+                raise ConfigError(f"Invalid attempt history in {history}: {error}") from error
+            if event.run_id != manifest.run_id or event.rollout_id not in state.expected:
+                raise ConfigError("Attempt history belongs to a different run or input inventory.")
+            key = event.rollout_id, event.attempt_index
+            if event.status == "dispatched":
+                state._dispatch(key)
+            elif key not in state.dispatched:
+                raise ConfigError(f"Outcome event {key!r} has no preceding dispatch.")
+            elif event.status == "omitted":
+                state.omitted.add(key)
+
+        # Legacy files lacked an attempt id on some rows. Import once in their
+        # recorded order, preserving the old failure-count-based numbering.
+        legacy_counts: Counter = Counter()
+        for path in (failures_path_for(output), output):
+            for payload in read_records(path):
+                if import_legacy and RUN_ID_KEY not in payload:
+                    identity = logical_rollout_id(payload)
+                    payload = dict(payload)
+                    payload.setdefault(ATTEMPT_INDEX_KEY_NAME, legacy_counts[identity])
+                    legacy_counts[identity] = max(legacy_counts[identity], payload[ATTEMPT_INDEX_KEY_NAME] + 1)
+                if (path == output) == (payload.get("_ng_failure_class") is not None):
+                    raise ConfigError(f"Outcome in the wrong artifact: {path}.")
+                state._payload(payload, legacy=import_legacy and RUN_ID_KEY not in payload)
+        return state
+
+    def seed_legacy_history(self) -> None:
+        """Import existing outcomes explicitly; all subsequent writes have run identity."""
+        for key, payload in self.payloads.items():
+            self._event(key, "dispatched")
+            self._event(key, "failure" if payload.get("_ng_failure_class") is not None else "success")
+
+    def disposition(self, identity: str) -> str:
+        index = self.latest.get(identity)
+        if index is None:
+            return "unknown"
+        key = identity, index
+        if key in self.omitted:
+            return "omitted"
+        payload = self.payloads.get(key)
+        if payload is None:
+            return "unknown"
+        if payload.get("_ng_failure_class") == "skipped" and payload.get("_ng_failure_terminal"):
+            return "omitted"
+        return "failure" if payload.get("_ng_failure_class") is not None else "success"
+
+    def selected(self, disposition: str) -> list[dict]:
+        return [
+            self.payloads[(identity, self.latest[identity])]
+            for identity in self.expected
+            if self.disposition(identity) == disposition and (identity, self.latest.get(identity)) in self.payloads
+        ]
+
+    def pending(self, max_attempts: int) -> list[dict]:
+        attempts = Counter(identity for identity, _ in self.dispatched)
+        pending = []
+        for identity, original in self.expected.items():
+            disposition = self.disposition(identity)
+            payload = self.payloads.get((identity, self.latest.get(identity)), {})
+            if disposition in {"success", "omitted"} or payload.get("_ng_failure_terminal"):
+                continue
+            if attempts[identity] >= max_attempts:
+                continue
+            row = dict(original)
+            if identity in self.latest:
+                row[ATTEMPT_INDEX_KEY_NAME] = self.latest[identity] + 1
+            pending.append(row)
+        return pending
+
+    def coverage(self) -> dict:
+        counts = Counter(self.disposition(identity) for identity in self.expected)
+        expected = len(self.expected)
+        return {
+            "schema_version": 1,
+            "run_id": self.manifest.run_id,
+            "expected": expected,
+            "successful": counts["success"],
+            "failed": counts["failure"],
+            "intentionally_omitted": counts["omitted"],
+            "unknown": counts["unknown"],
+            "never_dispatched": expected - len(self.latest),
+            "attempts": len(self.dispatched),
+            "completion_fraction": counts["success"] / expected if expected else 1.0,
+            "complete": counts["success"] == expected,
+            "reconciled": counts["unknown"] == 0,
+            "identity_verified": not (self.manifest.legacy_import or self.manifest.identity_overridden),
+        }
+
+    def write_coverage(self, output: Path) -> None:
+        atomic_write_json(coverage_path_for(output), self.coverage())

--- a/nemo_gym/rollout_outcomes.py
+++ b/nemo_gym/rollout_outcomes.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""No-result outcomes for callers that opt into Gym's structured failure API.
+
+Completed results retain their existing dictionaries, including valid reward-zero and
+masked results. A failure carries identifiers and bounded diagnostics, never generation
+data. It describes an attempt; retry and replacement decisions belong to the caller.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from nemo_gym.failure_kinds import validate_failure_kind
+
+
+class RolloutFailure(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    type: Literal["failure"] = "failure"
+    rollout_id: str = Field(min_length=1)
+    run_id: str | None = None
+    attempt_index: int = Field(default=0, ge=0, strict=True)
+    failure_kind: str = Field(min_length=1)
+    stage: Literal["request", "response", "result", "agent", "verifier"]
+    failure_reason: str
+    exception_type: str | None = None
+    http_status: int | None = None
+    response_body: str | None = None
+    terminal: bool = False
+
+    @property
+    def attempt_id(self) -> str:
+        return f"{self.rollout_id}-a{self.attempt_index}"
+
+    @field_validator("failure_kind")
+    @classmethod
+    def _validate_kind(cls, value: str) -> str:
+        return validate_failure_kind(value)
+
+    @field_validator("failure_reason", "exception_type", "response_body")
+    @classmethod
+    def _bound_diagnostics(cls, value: str | None) -> str | None:
+        return value[:2000] if value is not None else None
+
+
+class InvalidRolloutResult(ValueError):
+    """An agent returned a body that cannot represent a completed result."""

--- a/nemo_gym/rollout_recovery.py
+++ b/nemo_gym/rollout_recovery.py
@@ -112,6 +112,8 @@ class RunManifest(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     schema_version: Literal[1] = 1
+    # Selection is a run policy, not an inference from payload arrival order.
+    selection_policy: Literal["latest_dispatched"] = "latest_dispatched"
     run_id: str
     source_digest: str
     materialized_digest: str

--- a/nemo_gym/rollout_recovery.py
+++ b/nemo_gym/rollout_recovery.py
@@ -21,12 +21,13 @@ completed rollouts; it does not checkpoint an agent's conversation or remote san
 import hashlib
 import json
 import os
-import tempfile
+import stat
 import warnings
 from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
 
+from omegaconf import OmegaConf
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from nemo_gym.config_types import ConfigError
@@ -52,8 +53,34 @@ _COLLECTION_OPTIONS = frozenset(
 # Server addresses and credentials are resolved anew when a job restarts. Keep model
 # names, prompts, generation settings and environment configuration in the digest.
 _SERVER_RUNTIME_OPTIONS = frozenset(
-    {"host", "port", "api_key", "head_server", "disallowed_ports", "port_range_low", "port_range_high"}
+    {
+        "host",
+        "port",
+        "api_key",
+        "openai_api_key",
+        "policy_api_key",
+        "base_url",
+        "openai_base_url",
+        "policy_base_url",
+        "head_server",
+        "disallowed_ports",
+        "port_range_low",
+        "port_range_high",
+        "model_call_capture_dir",
+    }
 )
+_SERVER_KINDS = ("responses_api_agents", "responses_api_models", "resources_servers")
+
+
+def _plain(value: Any) -> Any:
+    """Pydantic's Python dump may still contain nested Hydra containers."""
+    if OmegaConf.is_config(value):
+        return OmegaConf.to_container(value, resolve=False)
+    if isinstance(value, dict):
+        return {key: _plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    return value
 
 
 def manifest_path_for(output: Path) -> Path:
@@ -69,20 +96,71 @@ def _without_runtime_options(value: Any) -> Any:
     # Exclude only known configuration boundaries. Recursively dropping names such
     # as "port" would also erase meaningful tool schemas or environment parameters.
     result = {k: v for k, v in value.items() if k not in _SERVER_RUNTIME_OPTIONS and k not in _COLLECTION_OPTIONS}
+
+    def settings_identity(settings):
+        if not isinstance(settings, dict):
+            return settings
+        settings = {k: v for k, v in settings.items() if k not in _SERVER_RUNTIME_OPTIONS}
+        if isinstance(settings.get("token_id_capture"), dict):
+            settings["token_id_capture"] = {k: v for k, v in settings["token_id_capture"].items() if k != "dir"}
+        return settings
+
     for name, block in list(result.items()):
         if not isinstance(block, dict):
             continue
         updated = dict(block)
-        for kind in ("responses_api_agents", "responses_api_models", "resources_servers"):
+        for kind in _SERVER_KINDS:
             if kind in block and isinstance(block[kind], dict):
                 updated[kind] = {
-                    implementation: {k: v for k, v in settings.items() if k not in {"host", "port", "api_key"}}
-                    if isinstance(settings, dict)
-                    else settings
-                    for implementation, settings in block[kind].items()
+                    implementation: settings_identity(settings) for implementation, settings in block[kind].items()
                 }
         result[name] = updated
     return result
+
+
+def _configuration_identity(config: dict, global_config: dict, rows: list[dict]) -> dict:
+    # Resolve only the servers reachable from the materialized agents. Keep the
+    # original root as interpolation context, but do not evaluate unused servers
+    # (which may require credentials/environment variables unavailable here).
+    raw = _plain(global_config)
+    context = OmegaConf.create(raw)
+    filtered = _without_runtime_options(raw)
+    servers = {
+        name for name, block in raw.items() if isinstance(block, dict) and any(k in block for k in _SERVER_KINDS)
+    }
+    pending = {row.get("agent_ref", {}).get("name") for row in rows} - {None}
+    pending.update(row["task_source"] for row in rows if isinstance(row.get("task_source"), str))
+    if not pending:
+        pending = set(servers)
+    selected = {}
+
+    def references(value):
+        if isinstance(value, dict):
+            if isinstance(value.get("name"), str) and value["name"] in servers:
+                pending.add(value["name"])
+            for item in value.values():
+                references(item)
+        elif isinstance(value, list):
+            for item in value:
+                references(item)
+
+    while pending:
+        name = pending.pop()
+        if name in selected or name not in servers:
+            continue
+        context[name] = filtered[name]
+        selected[name] = OmegaConf.to_container(context[name], resolve=True)
+        references(selected[name])
+    # Collection overrides may themselves contain DictConfig/ListConfig values.
+    collection = {key: _plain(value) for key, value in config.items() if key not in _COLLECTION_OPTIONS}
+    context["_collection_identity"] = collection
+    capture = raw.get("token_id_capture", {})
+    context["_capture_identity"] = {key: value for key, value in capture.items() if key != "dir"}
+    return {
+        "collection": OmegaConf.to_container(context._collection_identity, resolve=True),
+        "servers": selected,
+        "token_id_capture": OmegaConf.to_container(context._capture_identity, resolve=True),
+    }
 
 
 def _file_digest(path: Path) -> str:
@@ -96,8 +174,13 @@ def _file_digest(path: Path) -> str:
 def atomic_write_json(path: Path, value: dict) -> None:
     temporary = None
     try:
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, delete=False) as file:
-            temporary = Path(file.name)
+        temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+        # Exclusive creation honors the caller's umask. Rewrites retain existing
+        # sharing permissions instead of inheriting NamedTemporaryFile's 0600.
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            if path.exists():
+                os.fchmod(file.fileno(), stat.S_IMODE(path.stat().st_mode))
             json.dump(value, file, indent=2, allow_nan=False)
             file.write("\n")
             file.flush()
@@ -127,12 +210,7 @@ class RunManifest(BaseModel):
             run_id=uuid4().hex,
             source_digest=_file_digest(source),
             materialized_digest=_digest(rows),
-            config_digest=_digest(
-                {
-                    "collection": {k: v for k, v in config.items() if k not in _COLLECTION_OPTIONS},
-                    "servers": _without_runtime_options(global_config),
-                }
-            ),
+            config_digest=_digest(_configuration_identity(config, global_config, rows)),
         )
 
     def write(self, path: Path) -> None:

--- a/nemo_gym/rollout_recovery.py
+++ b/nemo_gym/rollout_recovery.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Identity checks for resuming saved evaluation results.
+
+The manifest stores digests, not configuration values or credentials. Recovery reuses
+completed rollouts; it does not checkpoint an agent's conversation or remote sandbox.
+"""
+
+import hashlib
+import json
+import os
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from nemo_gym.config_types import ConfigError
+
+
+# Collection/output choices can change between invocations without changing a task.
+_COLLECTION_OPTIONS = frozenset(
+    {
+        "resume_from_cache",
+        "allow_unsafe_resume",
+        "output_jsonl_fpath",
+        "input_jsonl_fpath",
+        "num_samples_in_parallel",
+        "disable_aggregation",
+        "disable_health_check",
+        "health_check_workers",
+        "health_check_ignored_checks",
+        "upload_rollouts",
+        "count_failure_classes_as_zero",
+        "route_failures_to_sidecar",
+    }
+)
+# Server addresses and credentials are resolved anew when a job restarts. Keep model
+# names, prompts, generation settings and environment configuration in the digest.
+_SERVER_RUNTIME_OPTIONS = frozenset(
+    {"host", "port", "api_key", "head_server", "disallowed_ports", "port_range_low", "port_range_high"}
+)
+
+
+def manifest_path_for(output: Path) -> Path:
+    return output.with_name(output.stem + "_manifest.json")
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _without_runtime_options(value: Any) -> Any:
+    # Exclude only known configuration boundaries. Recursively dropping names such
+    # as "port" would also erase meaningful tool schemas or environment parameters.
+    result = {k: v for k, v in value.items() if k not in _SERVER_RUNTIME_OPTIONS and k not in _COLLECTION_OPTIONS}
+    for name, block in list(result.items()):
+        if not isinstance(block, dict):
+            continue
+        updated = dict(block)
+        for kind in ("responses_api_agents", "responses_api_models", "resources_servers"):
+            if kind in block and isinstance(block[kind], dict):
+                updated[kind] = {
+                    implementation: {k: v for k, v in settings.items() if k not in {"host", "port", "api_key"}}
+                    if isinstance(settings, dict)
+                    else settings
+                    for implementation, settings in block[kind].items()
+                }
+        result[name] = updated
+    return result
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_write_json(path: Path, value: dict) -> None:
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, delete=False) as file:
+            temporary = Path(file.name)
+            json.dump(value, file, indent=2, allow_nan=False)
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        temporary.replace(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+class RunManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    run_id: str
+    source_digest: str
+    materialized_digest: str
+    config_digest: str
+    legacy_import: bool = False
+    identity_overridden: bool = False
+
+    @classmethod
+    def create(cls, source: Path, rows: list[dict], config: dict, global_config: dict) -> "RunManifest":
+        return cls(
+            run_id=uuid4().hex,
+            source_digest=_file_digest(source),
+            materialized_digest=_digest(rows),
+            config_digest=_digest(
+                {
+                    "collection": {k: v for k, v in config.items() if k not in _COLLECTION_OPTIONS},
+                    "servers": _without_runtime_options(global_config),
+                }
+            ),
+        )
+
+    def write(self, path: Path) -> None:
+        # Publish a complete manifest, or leave the previous one intact.
+        atomic_write_json(path, self.model_dump(mode="json"))
+
+    @classmethod
+    def import_legacy(cls, rows: list[dict]) -> "RunManifest":
+        return cls(
+            run_id=uuid4().hex,
+            source_digest="unverified",
+            materialized_digest=_digest(rows),
+            config_digest="unverified",
+            legacy_import=True,
+        )
+
+
+def validate_resume(
+    path: Path,
+    current: RunManifest | None,
+    materialized_path: Path,
+    *,
+    allow_unsafe: bool = False,
+) -> RunManifest | None:
+    """Reject unknown or incompatible saved work before any output is modified.
+
+    ``allow_unsafe`` is an explicit compatibility escape hatch for legacy artifacts or
+    deliberate identity overrides. Unsupported/corrupt manifests remain errors.
+    """
+    if not path.exists():
+        problem = "Saved rollouts have no run manifest; their input/configuration identity cannot be verified."
+        saved = None
+    else:
+        try:
+            saved = RunManifest.model_validate_json(path.read_bytes())
+            with materialized_path.open(encoding="utf-8") as file:
+                saved_rows = [json.loads(line) for line in file if line.strip()]
+        except (ValidationError, ValueError, OSError) as error:
+            raise ConfigError(f"Cannot read recovery manifest or materialized inputs: {error}") from error
+        mismatches = []
+        if saved.legacy_import:
+            mismatches.append("unverified legacy run identity")
+        if saved.identity_overridden:
+            mismatches.append("previously overridden run identity")
+        if saved.materialized_digest != _digest(saved_rows):
+            mismatches.append("saved materialized inputs")
+        if current is None:
+            mismatches.append("current input/configuration identity")
+        else:
+            for field, description in (
+                ("source_digest", "source dataset"),
+                ("materialized_digest", "current materialized inputs"),
+                ("config_digest", "resolved configuration"),
+            ):
+                if getattr(saved, field) != getattr(current, field):
+                    mismatches.append(description)
+        if not mismatches:
+            return saved
+        problem = "Cannot resume with incompatible " + ", ".join(mismatches) + "."
+    if not allow_unsafe:
+        raise ConfigError(problem + " Start a fresh run or explicitly set allow_unsafe_resume=true.")
+    warnings.warn(problem + " Continuing because allow_unsafe_resume=true; saved inputs will be reused.", stacklevel=2)
+    return saved.model_copy(update={"identity_overridden": True}) if saved is not None else None

--- a/nemo_gym/rollout_reverification.py
+++ b/nemo_gym/rollout_reverification.py
@@ -17,7 +17,7 @@ import json
 import warnings
 from asyncio import Future, Semaphore
 from collections import Counter, defaultdict
-from contextlib import nullcontext
+from contextlib import ExitStack, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
@@ -33,6 +33,8 @@ from nemo_gym.config_types import BaseNeMoGymCLIConfig, ConfigError, UploadRollo
 from nemo_gym.exporters import export_metrics, export_rollouts, get_exporters
 from nemo_gym.global_config import (
     AGENT_REF_KEY_NAME,
+    ATTEMPT_INDEX_KEY_NAME,
+    ROLLOUT_ID_KEY_NAME,
     ROLLOUT_INDEX_KEY_NAME,
     SKILLS_REF_KEY_NAME,
     TASK_INDEX_KEY_NAME,
@@ -48,6 +50,9 @@ from nemo_gym.rollout_collection import (
     _rollout_for_export,
     _rollout_request_debug_summary,
 )
+from nemo_gym.rollout_journal import RUN_ID_KEY, logical_rollout_id
+from nemo_gym.rollout_recovery import manifest_path_for
+from nemo_gym.rollout_store import RolloutStore
 from nemo_gym.server_utils import (
     ServerClient,
     get_response_json,
@@ -437,6 +442,13 @@ def _yield_inputs_and_rollouts_paired(
             if limit is not None and n_yielded >= limit:
                 break
             rollout_row = orjson.loads(line)
+            if _is_judge_failure(rollout_row) and not isinstance(rollout_row.get("response"), dict):
+                warnings.warn(
+                    f"Skipping judge failure without a saved response: {_rollout_request_debug_summary(rollout_row)}. "
+                    "Resume rollout collection to generate a new response.",
+                    stacklevel=2,
+                )
+                continue
             if rollout_predicate is not None and not rollout_predicate(rollout_row):
                 continue
             input_row = inputs_by_key.get((rollout_row[TASK_INDEX_KEY_NAME], rollout_row[ROLLOUT_INDEX_KEY_NAME]))
@@ -479,6 +491,8 @@ def _prepare_payloads(
 def _run_verification_payloads(
     payloads: List[Dict],
     semaphore: Semaphore | nullcontext[None] | None = None,
+    on_dispatch: Optional[Callable[[Dict], None]] = None,
+    owned_tasks: Optional[list[asyncio.Task]] = None,
 ) -> Iterator[Future]:  # pragma: no cover
     semaphore = semaphore or nullcontext[None]()
     server_client = setup_server_client()
@@ -487,6 +501,8 @@ def _run_verification_payloads(
     async def _post_subroutine(row: Dict) -> Tuple[Dict, Dict]:
         async with semaphore:
             rs_name = _rs_for_row(row, agent_to_rs, server_client.global_config_dict)
+            if on_dispatch is not None:
+                on_dispatch(row)
             res = await server_client.post(server_name=rs_name, url_path="/verify", json=row)
             try:
                 await raise_for_status(
@@ -504,8 +520,12 @@ def _run_verification_payloads(
                 raise
             return row, await get_response_json(res)
 
+    requests = map(_post_subroutine, payloads)
+    if owned_tasks is not None:
+        owned_tasks.extend(asyncio.create_task(request) for request in requests)
+        requests = owned_tasks
     return tqdm.as_completed(
-        map(_post_subroutine, payloads),
+        requests,
         desc="Collecting reverification results",
         miniters=10,
         total=len(payloads),
@@ -682,6 +702,8 @@ def _prepare_output_fpaths(
     output_fpath = Path(output_jsonl_fpath)
     output_fpath = output_fpath.with_name(output_name_prefix + output_fpath.name)
     output_fpath.parent.mkdir(parents=True, exist_ok=True)
+    if overwrite and manifest_path_for(output_fpath).exists():
+        raise ConfigError("Cannot overwrite a journal-backed run with reverification; choose a new output path.")
     failures_fpath = failures_path_for(output_fpath)
     if not (append or resume_from_cache):
         # A fresh run must not silently clobber a prior run's rollouts: delete only when the user
@@ -708,8 +730,12 @@ def _load_reverified_results(output_fpath: Path) -> Tuple[List[Dict], List[Dict]
     ``{agent_ref, task_source}`` projection used only to route each result to its resources server
     (with the same resolver as /verify). Read once and reused for both so the file is never read twice.
     """
-    with output_fpath.open("rb") as f:
-        results = [orjson.loads(line) for line in f if line.strip()]
+    store = RolloutStore.read(output_fpath)
+    if store is not None:
+        results = store.selected("success")
+    else:
+        with output_fpath.open("rb") as f:
+            results = [orjson.loads(line) for line in f if line.strip()]
     results.sort(key=lambda r: (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]))
     rows = [{k: r[k] for k in (AGENT_REF_KEY_NAME, TASK_SOURCE_KEY_NAME) if k in r} for r in results]
     return results, rows
@@ -727,6 +753,9 @@ class RolloutReverificationHelper(BaseModel):
         output_fpaths = _prepare_output_fpaths(
             output_name_prefix, config.output_jsonl_fpath, config.resume_from_cache, config.overwrite, config.append
         )
+        store = RolloutStore.append_existing(output_fpaths.output)
+        if store is not None and not config.judge_failed_only:
+            raise ConfigError("Use a new output path for full reverification of a journal-backed run.")
         materialized_inputs_jsonl_fpath = _resolve_under_cwd_or_install(config.materialized_inputs_jsonl_fpath)
         rollouts_jsonl_fpath = _resolve_under_cwd_or_install(
             config.rollouts_jsonl_fpath
@@ -739,17 +768,32 @@ class RolloutReverificationHelper(BaseModel):
             print(_RECOVERY_TWO_SOURCES_WARNING)
             reverify_source_fpath = failures_path_for(rollouts_jsonl_fpath)
             # Seed the successes and dedup so the re-verification doesn't judge successes again.
-            skip_keys = _seed_output_with_successes(rollouts_jsonl_fpath, output_fpaths.output)
+            if store is not None:
+                if rollouts_jsonl_fpath.resolve() != output_fpaths.output.resolve():
+                    raise ConfigError("Append to a journal-backed run requires --rollouts and --output to match.")
+                skip_keys = {(r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) for r in store.selected("success")}
+            else:
+                skip_keys = _seed_output_with_successes(rollouts_jsonl_fpath, output_fpaths.output)
             rollout_predicate = _recovery_rollout_predicate(skip_keys)
+            if store is not None:
+                eligible = {logical_rollout_id(row) for row in store.pending(_get_max_rollout_attempts())}
+                latest = {logical_rollout_id(row): row for row in store.failures()}
+                recovery_predicate = rollout_predicate
+
+                def rollout_predicate(row):
+                    identity = logical_rollout_id(row)
+                    return identity in eligible and row == latest.get(identity) and recovery_predicate(row)
 
         payloads_to_reverify = _prepare_payloads(
             materialized_inputs_jsonl_fpath,
             reverify_source_fpath,
             output_fpaths,
-            config.resume_from_cache,
+            config.resume_from_cache and store is None,
             config.limit,
             rollout_predicate=rollout_predicate,
         )
+        if store is not None:
+            payloads_to_reverify = store.for_reverification(payloads_to_reverify)
 
         semaphore = nullcontext()
         if config.num_samples_in_parallel is not None:
@@ -758,12 +802,19 @@ class RolloutReverificationHelper(BaseModel):
 
         pcts_to_print = [20, 40, 60, 80, 90, 95, 98, 99, 100]
         counts_left = Counter(r[AGENT_REF_KEY_NAME]["name"] for r in payloads_to_reverify)
-        results_file = output_fpaths.output.open("ab")
-        failures_file = output_fpaths.failures.open("ab")
+        files = ExitStack()
+        verification_tasks = []
         failure_counts: Counter = Counter()
         completed = 0  # number of rows re-verified this run (for progress reporting)
         try:
-            for future in _run_verification_payloads(payloads_to_reverify, semaphore=semaphore):
+            if store is not None:
+                files.enter_context(store)
+            results_file = files.enter_context(output_fpaths.output.open("ab"))
+            failures_file = files.enter_context(output_fpaths.failures.open("ab"))
+            dispatch_options = (
+                {"on_dispatch": store.record_dispatch, "owned_tasks": verification_tasks} if store else {}
+            )
+            for future in _run_verification_payloads(payloads_to_reverify, semaphore=semaphore, **dispatch_options):
                 row, result = await future
 
                 result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
@@ -775,9 +826,20 @@ class RolloutReverificationHelper(BaseModel):
                     result[TASK_SOURCE_KEY_NAME] = row[TASK_SOURCE_KEY_NAME]
                 if SKILLS_REF_KEY_NAME in row:
                     result[SKILLS_REF_KEY_NAME] = row[SKILLS_REF_KEY_NAME]
+                for key in (ROLLOUT_ID_KEY_NAME, ATTEMPT_INDEX_KEY_NAME, RUN_ID_KEY):
+                    if key in row:
+                        result[key] = row[key]
 
                 no_persist = bool(result.get(NG_NO_PERSIST_KEY))
                 failure_class = result.get(NG_FAILURE_CLASS_KEY)
+                if store is not None:
+                    if no_persist and failure_class is None:
+                        store.record_omission(row, "Producer requested no result persistence")
+                    else:
+                        # Reported kill-shaped failures consume a dispatched
+                        # attempt, matching collection's journal policy.
+                        result.pop(NG_NO_PERSIST_KEY, None)
+                        store.record_outcome(result)
 
                 serialized = orjson.dumps(result)
 
@@ -796,12 +858,14 @@ class RolloutReverificationHelper(BaseModel):
                         f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)} "
                         f"class={failure_class} error={detail}"
                     )
-                    failures_file.write(serialized + b"\n")
-                    failures_file.flush()
+                    if store is None:
+                        failures_file.write(serialized + b"\n")
+                        failures_file.flush()
                 else:
                     # Success → main jsonl.
-                    results_file.write(serialized + b"\n")
-                    results_file.flush()
+                    if store is None:
+                        results_file.write(serialized + b"\n")
+                        results_file.flush()
 
                 counts_left[row[AGENT_REF_KEY_NAME]["name"]] -= 1
                 if counts_left[row[AGENT_REF_KEY_NAME]["name"]] <= 0:
@@ -819,8 +883,14 @@ class RolloutReverificationHelper(BaseModel):
                         # Use tqdm.write here so we can print properly with tqdm being used.
                         tqdm.write(f"Examples left:\n{top_left_str}")
         finally:
-            results_file.close()
-            failures_file.close()
+            try:
+                for task in verification_tasks:
+                    if not task.done():
+                        task.cancel()
+                if verification_tasks:
+                    await asyncio.gather(*verification_tasks, return_exceptions=True)
+            finally:
+                files.close()
 
         # Read the full main jsonl (cached + newly re-verified successes) ONCE — the source of truth,
         # reused for both the rollouts export and aggregate metrics so the file is never re-read.
@@ -841,14 +911,16 @@ class RolloutReverificationHelper(BaseModel):
             print("Computing aggregate metrics")
             aggregate_metrics_fpath = await _call_aggregate_metrics(results, agg_rows, output_fpaths.output)
 
-        expected_rollouts = len(results) + sum(failure_counts.values())
+        if store is not None:
+            failure_counts = Counter(row[NG_FAILURE_CLASS_KEY] for row in store.failures())
+        expected_rollouts = store.coverage()["expected"] if store else len(results) + sum(failure_counts.values())
         coverage = _coverage_report(expected_rollouts, len(results), failure_counts, output_fpaths.failures)
         if get_exporters():  # pragma: no cover
             export_metrics(
                 {
                     "coverage/expected": expected_rollouts,
                     "coverage/scored": len(results),
-                    "coverage/missing": sum(failure_counts.values()),
+                    "coverage/missing": expected_rollouts - len(results),
                 }
             )
 

--- a/nemo_gym/rollout_store.py
+++ b/nemo_gym/rollout_store.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Own the evaluation runner's artifacts and their recovery protocol.
+
+One writer owns each output path. Request dispatch, capture finalization and
+scoring policy belong to the caller; this store owns file lifetime and ordering.
+The journal reconstructs state for both collection and read-only aggregation.
+"""
+
+import os
+from collections.abc import Callable
+from contextlib import ExitStack
+from pathlib import Path
+
+import orjson
+
+from nemo_gym.config_types import ConfigError
+from nemo_gym.path_utils import failures_path_for
+from nemo_gym.rollout_journal import (
+    RUN_ID_KEY,
+    RolloutJournal,
+    coverage_path_for,
+    journal_path_for,
+    logical_rollout_id,
+    materialized_path_for,
+    prepare_append,
+    read_records,
+)
+from nemo_gym.rollout_recovery import RunManifest, atomic_write_json, manifest_path_for, validate_resume
+
+
+class RolloutStore:
+    def __init__(self, output: Path, state: RolloutJournal, *, seed_legacy: bool = False, read_only: bool = False):
+        self.output = output
+        self.manifest = state.manifest
+        self._state = state
+        self._seed_legacy = seed_legacy
+        self._read_only = read_only
+        self._files = None
+        self._results_file = None
+        self._failures_file = None
+
+    @classmethod
+    def start_or_resume(
+        cls,
+        output: Path,
+        prepare_inputs: Callable[[], tuple[list[dict], RunManifest]],
+        *,
+        resume: bool,
+        allow_unsafe: bool = False,
+    ) -> "RolloutStore":
+        """Validate saved work before mutation; materialize fresh work once.
+
+        The callback keeps dataset/configuration preparation in the collector.
+        Legacy imports need not have their original dataset available, so they
+        deliberately do not invoke it when no saved manifest exists.
+        """
+        manifest_path = manifest_path_for(output)
+        materialized = materialized_path_for(output)
+        journal = journal_path_for(output)
+        artifacts = (output, failures_path_for(output), materialized, manifest_path, journal)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if resume and any(path.exists() for path in artifacts):
+            if not materialized.exists() or not output.exists():
+                raise ConfigError("Cannot resume: saved materialized inputs or rollout output are missing.")
+            current = None
+            if manifest_path.exists():
+                try:
+                    _, current = prepare_inputs()
+                except (ConfigError, OSError):
+                    if not allow_unsafe:
+                        raise
+            manifest = validate_resume(manifest_path, current, materialized, allow_unsafe=allow_unsafe)
+            seed_legacy = False
+            if manifest is None:
+                manifest = RunManifest.import_legacy(list(read_records(materialized)))
+                seed_legacy = True
+            elif not journal.exists():
+                if not allow_unsafe:
+                    raise ConfigError(f"Cannot resume without attempt history: {journal}.")
+                manifest = manifest.model_copy(update={"legacy_import": True})
+                seed_legacy = True
+            state = RolloutJournal.load(output, manifest, import_legacy=manifest.legacy_import)
+            if seed_legacy or manifest.identity_overridden:
+                manifest.write(manifest_path)
+            return cls(output, state, seed_legacy=seed_legacy)
+
+        rows, manifest = prepare_inputs()
+        state = RolloutJournal(manifest, rows)
+        with materialized.open("wb") as file:
+            for row in rows:
+                file.write(orjson.dumps(row) + b"\n")
+        # Invalidate prior outputs before publishing the fresh run's identity.
+        for path in (output, failures_path_for(output), journal, coverage_path_for(output)):
+            path.unlink(missing_ok=True)
+        manifest.write(manifest_path)
+        return cls(output, state)
+
+    @classmethod
+    def read(cls, output: Path) -> "RolloutStore | None":
+        """Read the same selected outcomes offline, without modifying artifacts.
+
+        A legacy file without an input inventory has unknown completion coverage;
+        return None so its caller can choose its documented compatibility path.
+        """
+        path = manifest_path_for(output)
+        if path.exists():
+            manifest = RunManifest.model_validate_json(path.read_bytes())
+        elif materialized_path_for(output).exists():
+            manifest = RunManifest.import_legacy(list(read_records(materialized_path_for(output))))
+        else:
+            return None
+        state = RolloutJournal.load(output, manifest, import_legacy=manifest.legacy_import)
+        return cls(output, state, read_only=True)
+
+    def __enter__(self) -> "RolloutStore":
+        if self._read_only or self._files is not None:
+            raise RuntimeError("Cannot open a read-only or already open rollout store for writing.")
+        files = ExitStack()
+        try:
+            journal = journal_path_for(self.output)
+            failures = failures_path_for(self.output)
+            for path in (self.output, failures, journal):
+                prepare_append(path)
+            # Registered first, so the snapshot follows file closure on every exit.
+            files.callback(self.write_coverage)
+            self._state.file = files.enter_context(journal.open("ab"))
+            self._results_file = files.enter_context(self.output.open("ab"))
+            self._failures_file = files.enter_context(failures.open("ab"))
+            if self._seed_legacy:
+                self._state.seed_legacy_history()
+                self._seed_legacy = False
+            self.write_coverage()
+        except BaseException:
+            try:
+                files.close()
+            finally:
+                self._state.file = None
+                self._results_file = self._failures_file = None
+            raise
+        self._files = files
+        return self
+
+    def __exit__(self, *exc):
+        try:
+            return self._files.__exit__(*exc)
+        finally:
+            self._files = None
+            self._state.file = None
+            self._results_file = self._failures_file = None
+
+    def _require_open(self) -> None:
+        if self._files is None:
+            raise RuntimeError("Rollout persistence requires an open store context.")
+
+    def record_dispatch(self, row: dict) -> None:
+        self._require_open()
+        self._state.dispatch(row)
+
+    def record_outcome(self, result: dict, *, sync: bool = False) -> None:
+        """Commit a payload before its outcome event; reject conflicts before writing.
+
+        A crash between those writes is recoverable from the dispatch and payload.
+        Callers retiring external capture evidence request fsync before retirement.
+        """
+        self._require_open()
+        self._state.check_outcome(result)
+        file = self._failures_file if result.get("_ng_failure_class") is not None else self._results_file
+        file.write(orjson.dumps(result) + b"\n")
+        file.flush()
+        if sync:
+            os.fsync(file.fileno())
+        self._state.outcome(result)
+
+    def record_omission(self, row: dict, reason: str) -> None:
+        self._require_open()
+        self._state.omit(row, reason)
+
+    def pending(self, max_attempts: int) -> list[dict]:
+        # The caller supplies its attempt budget; the stored selection policy is
+        # latest_dispatched, including newer attempts with unknown outcomes.
+        return [dict(row, **{RUN_ID_KEY: self.manifest.run_id}) for row in self._state.pending(max_attempts)]
+
+    def selected(self, disposition: str) -> list[dict]:
+        return self._state.selected(disposition)
+
+    def inputs_for(self, results: list[dict]) -> list[dict]:
+        return [self._state.expected[logical_rollout_id(result)] for result in results]
+
+    def coverage(self) -> dict:
+        return self._state.coverage()
+
+    def write_coverage(self, **reporting: int) -> None:
+        atomic_write_json(coverage_path_for(self.output), self.coverage() | reporting)

--- a/nemo_gym/rollout_store.py
+++ b/nemo_gym/rollout_store.py
@@ -20,6 +20,7 @@ The journal reconstructs state for both collection and read-only aggregation.
 """
 
 import os
+import warnings
 from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
@@ -27,6 +28,7 @@ from pathlib import Path
 import orjson
 
 from nemo_gym.config_types import ConfigError
+from nemo_gym.global_config import ATTEMPT_INDEX_KEY_NAME
 from nemo_gym.path_utils import failures_path_for
 from nemo_gym.rollout_journal import (
     RUN_ID_KEY,
@@ -51,6 +53,24 @@ class RolloutStore:
         self._files = None
         self._results_file = None
         self._failures_file = None
+
+    @staticmethod
+    def _unverified_manifest(output: Path) -> RunManifest:
+        manifest = RunManifest.import_legacy(list(read_records(materialized_path_for(output))))
+        # Losing a manifest must not silently relabel a mixture of foreign runs.
+        run_ids = {
+            row[key]
+            for path, key in (
+                (output, RUN_ID_KEY),
+                (failures_path_for(output), RUN_ID_KEY),
+                (journal_path_for(output), "run_id"),
+            )
+            for row in read_records(path)
+            if row.get(key) is not None
+        }
+        if len(run_ids) > 1:
+            raise ConfigError("Saved artifacts belong to different runs.")
+        return manifest.model_copy(update={"run_id": run_ids.pop()}) if run_ids else manifest
 
     @classmethod
     def start_or_resume(
@@ -85,15 +105,22 @@ class RolloutStore:
             manifest = validate_resume(manifest_path, current, materialized, allow_unsafe=allow_unsafe)
             seed_legacy = False
             if manifest is None:
-                manifest = RunManifest.import_legacy(list(read_records(materialized)))
-                seed_legacy = True
+                manifest = cls._unverified_manifest(output)
+                seed_legacy = not journal.exists()
             elif not journal.exists():
                 if not allow_unsafe:
                     raise ConfigError(f"Cannot resume without attempt history: {journal}.")
-                manifest = manifest.model_copy(update={"legacy_import": True})
+                warnings.warn(
+                    "Rebuilding missing attempt history from saved outcomes because allow_unsafe_resume=true. "
+                    "Dispatches without saved outcomes cannot be recovered; attempt counts are lower bounds.",
+                    stacklevel=2,
+                )
+                manifest = manifest.model_copy(update={"identity_overridden": True})
                 seed_legacy = True
-            state = RolloutJournal.load(output, manifest, import_legacy=manifest.legacy_import)
-            if seed_legacy or manifest.identity_overridden:
+            state = RolloutJournal.load(
+                output, manifest, import_legacy=manifest.legacy_import, rebuild_history=seed_legacy
+            )
+            if seed_legacy or manifest.identity_overridden or not manifest_path.exists():
                 manifest.write(manifest_path)
             return cls(output, state, seed_legacy=seed_legacy)
 
@@ -105,6 +132,11 @@ class RolloutStore:
         # Invalidate prior outputs before publishing the fresh run's identity.
         for path in (output, failures_path_for(output), journal, coverage_path_for(output)):
             path.unlink(missing_ok=True)
+        # Publish the manifest only after the empty payload/history files exist.
+        # Preparation can then be interrupted before __enter__ without stranding
+        # an otherwise valid run with missing required artifacts.
+        output.touch()
+        journal.touch()
         manifest.write(manifest_path)
         return cls(output, state)
 
@@ -119,10 +151,15 @@ class RolloutStore:
         if path.exists():
             manifest = RunManifest.model_validate_json(path.read_bytes())
         elif materialized_path_for(output).exists():
-            manifest = RunManifest.import_legacy(list(read_records(materialized_path_for(output))))
+            manifest = cls._unverified_manifest(output)
         else:
             return None
-        state = RolloutJournal.load(output, manifest, import_legacy=manifest.legacy_import)
+        state = RolloutJournal.load(
+            output,
+            manifest,
+            import_legacy=manifest.legacy_import,
+            rebuild_history=manifest.legacy_import and not journal_path_for(output).exists(),
+        )
         return cls(output, state, read_only=True)
 
     def __enter__(self) -> "RolloutStore":
@@ -152,6 +189,18 @@ class RolloutStore:
             raise
         self._files = files
         return self
+
+    @classmethod
+    def append_existing(cls, output: Path) -> "RolloutStore | None":
+        """Reverification may append to a validated journal-backed run."""
+        if not manifest_path_for(output).exists():
+            return None
+        if not journal_path_for(output).exists():
+            raise ConfigError(
+                "Cannot append without attempt history; explicitly recover the run before reverification."
+            )
+        reader = cls.read(output)
+        return cls(output, reader._state)
 
     def __exit__(self, *exc):
         try:
@@ -195,6 +244,28 @@ class RolloutStore:
 
     def selected(self, disposition: str) -> list[dict]:
         return self._state.selected(disposition)
+
+    def failures(self) -> list[dict]:
+        """Latest failure payloads, including terminal skips classified as omitted."""
+        return self.selected("failure") + self.selected("omitted")
+
+    def for_reverification(self, payloads: list[dict]) -> list[dict]:
+        """Allocate new attempt identities without dispatching or changing files."""
+        rows = []
+        for payload in payloads:
+            identity = logical_rollout_id(payload)
+            if identity not in self._state.expected:
+                raise ConfigError("Reverification input is outside the saved run's inventory.")
+            if any(payload.get(key) != value for key, value in self._state.expected[identity].items()):
+                raise ConfigError("Reverification inputs differ from the saved run's materialized inputs.")
+            rows.append(
+                payload
+                | {
+                    RUN_ID_KEY: self.manifest.run_id,
+                    ATTEMPT_INDEX_KEY_NAME: self._state.latest.get(identity, -1) + 1,
+                }
+            )
+        return rows
 
     def inputs_for(self, results: list[dict]) -> list[dict]:
         return [self._state.expected[logical_rollout_id(result)] for result in results]

--- a/tests/unit_tests/test_failure_kinds.py
+++ b/tests/unit_tests/test_failure_kinds.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The shared failure vocabulary has to stay small, stable and label-safe."""
+
+import logging
+import re
+
+from nemo_gym import failure_kinds
+from nemo_gym.failure_kinds import (
+    FAILURE_KINDS,
+    is_namespaced,
+    is_registered,
+    validate_failure_kind,
+)
+
+
+class TestNamingConvention:
+    def test_every_name_matches_one_convention(self) -> None:
+        assert all(re.fullmatch(r"[a-z][a-z0-9_]*", name) for name in FAILURE_KINDS)
+
+    def test_no_name_differs_from_another_only_by_case_or_separator(self) -> None:
+        """Two spellings of one failure defeat the grouping this vocabulary exists for."""
+        normalized = [name.lower().replace("_", "") for name in FAILURE_KINDS]
+
+        assert len(set(normalized)) == len(normalized)
+
+    def test_every_name_states_the_layer_that_observed_the_failure(self) -> None:
+        """`transport_timeout` and `agent_timeout` are different failures, not one."""
+        domains = ("transport_", "agent_", "judge_", "verifier_", "provider_", "session_", "cohort_", "persistence_")
+        lifecycle = {"cancelled", "kill_shaped", "shutdown"}
+
+        undomained = {n for n in FAILURE_KINDS if not n.startswith(domains)} - lifecycle
+
+        assert undomained == set()
+
+
+class TestRegistryLookup:
+    def test_a_registered_name_is_recognized(self) -> None:
+        assert is_registered("judge_failed")
+
+    def test_an_unregistered_name_is_not(self) -> None:
+        assert not is_registered("something_invented")
+
+    def test_an_environment_can_namespace_its_own(self) -> None:
+        assert is_namespaced("lexmount_browser:quota_exhausted")
+
+    def test_a_bare_name_is_not_namespaced(self) -> None:
+        assert not is_namespaced("judge_failed")
+
+
+class TestValidation:
+    def test_a_registered_name_passes_silently(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert validate_failure_kind("judge_failed") == "judge_failed"
+
+        assert caplog.records == []
+
+    def test_a_namespaced_name_passes_silently(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert validate_failure_kind("my_server:odd_case") == "my_server:odd_case"
+
+        assert caplog.records == []
+
+    def test_an_unknown_name_warns_but_survives(self, caplog) -> None:
+        """Rejecting it would trade a visible wrong name for an invisible dropped failure."""
+        with caplog.at_level(logging.WARNING):
+            result = validate_failure_kind("legacy_label")
+
+        assert result == "legacy_label"
+        assert any("legacy_label" in record.getMessage() for record in caplog.records)
+
+    def test_absent_is_not_a_failure(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING):
+            assert validate_failure_kind(None) is None
+
+        assert caplog.records == []
+
+
+class TestLabelSafety:
+    def test_the_vocabulary_stays_small_enough_to_be_a_metric_label(self) -> None:
+        """A name is a metric dimension. Free text belongs in `failure_reason` instead."""
+        assert len(FAILURE_KINDS) < 64
+
+    def test_no_name_carries_occurrence_detail(self) -> None:
+        assert all(len(name) < 40 and " " not in name for name in FAILURE_KINDS)
+
+
+class TestNamesTheRepoAlreadyProduces:
+    """Labels main emits today must be in the vocabulary, or it describes nothing."""
+
+    def test_rollout_collection_row_routing_classes(self) -> None:
+        from nemo_gym.rollout_collection import AGENT_REQUEST_FAILED_FAILURE_CLASS, AGENT_RUN_ERROR_FAILURE_CLASS
+
+        assert is_registered(AGENT_RUN_ERROR_FAILURE_CLASS)
+        assert is_registered(AGENT_REQUEST_FAILED_FAILURE_CLASS)
+
+    def test_the_judge_failsafe_class(self) -> None:
+        from nemo_gym.rollout_reverification import JUDGE_FAILED_FAILURE_CLASS
+
+        assert is_registered(JUDGE_FAILED_FAILURE_CLASS)
+
+
+class TestDependencyWeight:
+    def test_the_module_imports_nothing_from_the_server_stack(self) -> None:
+        """Data tooling reads the vocabulary without installing any server's requirements."""
+        source = open(failure_kinds.__file__).read()
+
+        assert "import fastapi" not in source
+        assert "from nemo_gym" not in source

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -1000,7 +1000,7 @@ class TestRolloutCollection:
         async def post(server_name: str, url_path: str, json: dict, **kwargs):
             if url_path == "/run":
                 dispatched.append(json)
-                return FakeResponse(200, {"reward": 1.0})
+                return FakeResponse(200, {"reward": 1.0, "response": {}})
             return FakeResponse(200, compute_aggregate_metrics([dict(r) for r in json.verify_responses]).model_dump())
 
         install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
@@ -1009,6 +1009,7 @@ class TestRolloutCollection:
             input_jsonl_fpath=str(tmp_path / "input.jsonl"),
             output_jsonl_fpath=str(output_jsonl_fpath),
             resume_from_cache=True,
+            allow_unsafe_resume=True,
             disable_health_check=True,
         )
         await RolloutCollectionHelper().run_from_config(config)
@@ -1098,7 +1099,7 @@ class TestRolloutCollection:
             if url_path == "/run":
                 if json["x"] == 0:
                     raise http_error(500, "unhandled tool-call json")
-                return FakeResponse(200, {"reward": 1.0})
+                return FakeResponse(200, {"reward": 1.0, "response": {}})
             aggregated["verify_responses"] = [dict(r) for r in json.verify_responses]
             return FakeResponse(200, compute_aggregate_metrics(aggregated["verify_responses"]).model_dump())
 
@@ -1363,6 +1364,7 @@ class TestRolloutCollection:
             input_jsonl_fpath=str(tmp_path / "input.jsonl"),
             output_jsonl_fpath=str(output_jsonl_fpath),
             resume_from_cache=True,
+            allow_unsafe_resume=True,
             disable_health_check=True,
         )
         await Helper().run_from_config(config)
@@ -1861,6 +1863,9 @@ class TestRolloutCollection:
             },
         ]
 
+        manifest = json.loads((tmp_path / "output_manifest.json").read_text())
+        for expected in expected_results:
+            expected["_ng_run_id"] = manifest["run_id"]
         assert expected_results == actual_returned_results
 
         expected_materialized_inputs_len = 6
@@ -2167,6 +2172,7 @@ class TestRolloutCollection:
             input_jsonl_fpath=str(input_fpath),
             output_jsonl_fpath=str(output_fpath),
             resume_from_cache=resume_from_cache,
+            allow_unsafe_resume=True,  # This fixture represents artifacts from before manifests existed.
             disable_aggregation=True,
         )
         if resume_from_cache:
@@ -2505,6 +2511,9 @@ class TestRolloutCollection:
             },
         ]
 
+        manifest = json.loads((tmp_path / "output_manifest.json").read_text())
+        for expected in expected_results:
+            expected["_ng_run_id"] = manifest["run_id"]
         assert expected_results == actual_returned_results
 
     async def test_run_from_config_aggregate_metrics_excludes_non_persisted_rows(
@@ -2558,7 +2567,7 @@ class TestRolloutCollection:
 
         actual_returned_results = await TestRolloutCollectionHelper().run_from_config(config)
 
-        assert [result["case"] for result in actual_returned_results] == ["case-0", "case-1", "case-2"]
+        assert [result.get("case") for result in actual_returned_results] == ["case-0", None, "case-2"]
         assert [result["case"] for result in captured["results"]] == ["case-0"]
         assert [row["x"] for row in captured["rows"]] == [0]
 
@@ -2569,7 +2578,10 @@ class TestRolloutCollection:
         failures_fpath = _failures_path_for(output_jsonl_fpath)
         with failures_fpath.open() as f:
             actual_failure_results = [json.loads(line) for line in f]
-        assert [result["case"] for result in actual_failure_results] == ["case-1"]
+        assert len(actual_failure_results) == 1
+        assert actual_failure_results[0][TASK_INDEX_KEY_NAME] == 1
+        assert "response" not in actual_failure_results[0]
+        assert actual_failure_results[0]["_ng_failure_record"]["type"] == "failure"
         assert actual_failure_results[0][NG_FAILURE_CLASS_KEY] == "verify_failed"
 
     async def test_run_from_config_aggregate_metrics_includes_cached_persisted_rows(
@@ -2581,6 +2593,7 @@ class TestRolloutCollection:
             input_jsonl_fpath=str(input_jsonl_fpath),
             output_jsonl_fpath=str(output_jsonl_fpath),
             resume_from_cache=True,
+            allow_unsafe_resume=True,
         )
 
         materialized_rows = [

--- a/tests/unit_tests/test_rollout_health.py
+++ b/tests/unit_tests/test_rollout_health.py
@@ -237,6 +237,12 @@ async def test_health_on_and_off_leave_collection_and_metrics_byte_identical(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    from uuid import UUID
+
+    import nemo_gym.rollout_recovery as recovery
+
+    # Hold run identity fixed while comparing the effect of health checks.
+    monkeypatch.setattr(recovery, "uuid4", lambda: UUID(int=1))
     monkeypatch.setattr(rollout_collection, "get_global_config_dict", lambda: {})
     source = {
         "responses_create_params": {"input": []},

--- a/tests/unit_tests/test_rollout_journal.py
+++ b/tests/unit_tests/test_rollout_journal.py
@@ -16,8 +16,9 @@
 import multiprocessing
 import os
 import signal
+from collections import Counter
 from contextlib import contextmanager
-from itertools import permutations
+from itertools import permutations, product
 
 import orjson
 import pytest
@@ -89,6 +90,49 @@ def test_every_expected_rollout_has_one_disposition(run):
     assert not coverage["complete"] and not coverage["reconciled"]
     assert [row["_ng_task_index"] for row in recovered.pending(3)] == [1, 3, 4]
     assert recovered.selected("success")[0]["reward"] == 0.0
+
+
+@pytest.mark.parametrize("dispositions", product(("measured", "masked", "failed", "omitted", "unknown"), repeat=2))
+def test_measurement_split_reconciles_without_changing_recovery(run, dispositions):
+    output, manifest, rows = run
+    with writer(run) as history:
+        for row, disposition in zip(rows, dispositions):
+            history.dispatch(row)
+            if disposition == "omitted":
+                history.omit(row, "Intentionally skipped")
+            elif disposition == "failed":
+                save(run, history, row, failure="agent_run_error")
+            elif disposition != "unknown":
+                save(run, history, row | {"mask_sample": disposition == "masked"}, reward=0.0)
+    recovered = RolloutJournal.load(output, manifest)
+    report = recovered.coverage()
+    expected = Counter(dispositions)
+    assert report["measured"] == expected["measured"]
+    assert report["masked"] == expected["masked"]
+    assert report["successful"] == report["measured"] + report["masked"]
+    assert report["failed"] == expected["failed"]
+    assert report["intentionally_omitted"] == expected["omitted"]
+    assert report["unknown"] == expected["unknown"] + 3  # Remaining inventory was never dispatched.
+    assert sum(report[key] for key in ("measured", "masked", "failed", "intentionally_omitted", "unknown")) == 5
+    assert [row["_ng_task_index"] for row in recovered.pending(3)] == [
+        i
+        for i, disposition in enumerate((*dispositions, "unknown", "unknown", "unknown"))
+        if disposition in {"failed", "unknown"}
+    ]
+
+
+def test_fully_masked_run_is_complete_without_unmasked_measurements(run):
+    output, manifest, rows = run
+    with writer(run) as history:
+        for row in rows:
+            history.dispatch(row)
+            save(run, history, row | {"mask_sample": True})
+    recovered = RolloutJournal.load(output, manifest)
+    report = recovered.coverage()
+    assert (report["expected"], report["successful"], report["measured"], report["masked"]) == (5, 5, 0, 5)
+    assert report["complete"] and report["reconciled"]
+    assert recovered.pending(3) == []
+    assert len(recovered.selected("success")) == 5
 
 
 @pytest.mark.parametrize("corruption", ["schema", "undispatched", "indices", "artifact", "scalar"])
@@ -289,7 +333,12 @@ def test_killed_worker_leaves_durable_unknown_attempt(run):
             process.join()
 
 
-async def test_offline_aggregation_uses_newest_attempt_and_full_inventory(run, monkeypatch):
+@pytest.mark.parametrize("masked", [False, True])
+@pytest.mark.parametrize("count_failures_as_zero", [False, True])
+async def test_offline_aggregation_uses_newest_attempt_and_full_inventory(
+    run, monkeypatch, masked, count_failures_as_zero
+):
+    import nemo_gym.rollout_collection as collection
     from nemo_gym.rollout_collection import (
         RolloutAggregationConfig,
         RolloutAggregationHelper,
@@ -302,8 +351,12 @@ async def test_offline_aggregation_uses_newest_attempt_and_full_inventory(run, m
     with writer(run) as history:
         history.dispatch(rows[0])
         history.dispatch(retry)
-        save(run, history, retry, reward=0.0)
-        save(run, history, rows[0], reward=1.0)  # Late older success must not inflate the score.
+        save(run, history, retry | {"mask_sample": masked}, reward=0.0)
+        save(run, history, rows[0] | {"mask_sample": not masked}, reward=1.0)
+        history.dispatch(rows[1])
+        save(run, history, rows[1], failure="agent_run_error")
+        history.omit(rows[2], "No cached deliverable")
+        history.dispatch(rows[3])  # Dispatched unknown; row 4 was never dispatched.
 
     scored = []
 
@@ -312,28 +365,56 @@ async def test_offline_aggregation_uses_newest_attempt_and_full_inventory(run, m
         return None
 
     monkeypatch.setattr(RolloutCollectionHelper, "_call_aggregate_metrics", aggregate)
+    exported = []
+    monkeypatch.setattr(collection, "get_exporters", lambda: True)
+    monkeypatch.setattr(collection, "export_metrics", exported.append)
     merged = output.with_name("merged.jsonl")
     await RolloutAggregationHelper().run_from_config(
         RolloutAggregationConfig(
             input_glob=str(output.with_name("rollouts*.jsonl")),
             output_jsonl_fpath=str(merged),
             disable_health_check=True,
+            count_failure_classes_as_zero=["agent_run_error"] if count_failures_as_zero else [],
         )
     )
-    assert [row["reward"] for row in scored] == [0.0]
+    assert [row["_ng_task_index"] for row in scored] == ([0, 1] if count_failures_as_zero else [0])
+    assert all(row["reward"] == 0.0 for row in scored)
     assert [row["reward"] for row in read_records(merged)] == [0.0]
     report = orjson.loads(coverage_path_for(merged).read_bytes())
-    assert (report["expected"], report["successful"], report["unknown"]) == (5, 1, 4)
+    assert (report["expected"], report["successful"], report["unknown"]) == (5, 1, 2)
+    assert (report["measured"], report["masked"], report["failed"], report["intentionally_omitted"]) == (
+        int(not masked),
+        int(masked),
+        1,
+        1,
+    )
+    assert report["scored"] == 1 + int(count_failures_as_zero)
+    assert report["failures_counted_as_zero"] == int(count_failures_as_zero)
+    assert sum(report[key] for key in ("measured", "masked", "failed", "intentionally_omitted", "unknown")) == 5
+    assert exported[-1] == {
+        "coverage/expected": 5,
+        "coverage/scored": report["scored"],
+        "coverage/missing": 5 - report["scored"],
+        "coverage/known": 1,
+        "coverage/measured": int(not masked),
+        "coverage/masked": int(masked),
+        "coverage/failed": 1,
+        "coverage/omitted": 1,
+        "coverage/unknown": 2,
+    }
     assert report["coverage_known"] and not report["complete"]
     assert len(list(read_records(output))) == 2  # Aggregating does not rewrite history.
 
 
-async def test_legacy_aggregation_cannot_claim_complete_without_inventory(tmp_path, monkeypatch, capsys):
+@pytest.mark.parametrize("masked", [False, True])
+async def test_legacy_aggregation_cannot_claim_complete_without_inventory(tmp_path, monkeypatch, capsys, masked):
     import nemo_gym.rollout_collection as collection
     from nemo_gym.rollout_journal import coverage_path_for
 
     output = tmp_path / "legacy.jsonl"
-    output.write_bytes(orjson.dumps({"_ng_task_index": 0, "_ng_rollout_index": 0, "reward": 1.0}) + b"\n")
+    output.write_bytes(
+        orjson.dumps({"_ng_task_index": 0, "_ng_rollout_index": 0, "reward": 1.0, "mask_sample": masked}) + b"\n"
+    )
 
     async def aggregate(*args):
         return None
@@ -350,6 +431,14 @@ async def test_legacy_aggregation_cannot_claim_complete_without_inventory(tmp_pa
     )
     report = orjson.loads(coverage_path_for(merged).read_bytes())
     assert report["expected"] is None and report["unknown"] is None
+    assert (report["measured"], report["masked"]) == (int(not masked), int(masked))
     assert not report["coverage_known"] and not report["complete"]
-    assert exported == [{"coverage/scored": 1, "coverage/known": 0}]
+    assert exported == [
+        {
+            "coverage/scored": 1,
+            "coverage/known": 0,
+            "coverage/measured": int(not masked),
+            "coverage/masked": int(masked),
+        }
+    ]
     assert "scores may be partial" in capsys.readouterr().out

--- a/tests/unit_tests/test_rollout_journal.py
+++ b/tests/unit_tests/test_rollout_journal.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing
+import os
+import signal
+from contextlib import contextmanager
+from itertools import permutations
+
+import orjson
+import pytest
+
+from nemo_gym.config_types import ConfigError
+from nemo_gym.path_utils import failures_path_for
+from nemo_gym.rollout_journal import (
+    RUN_ID_KEY,
+    RolloutJournal,
+    journal_path_for,
+    materialized_path_for,
+    prepare_append,
+    read_records,
+)
+from nemo_gym.rollout_recovery import RunManifest, manifest_path_for
+
+
+@pytest.fixture
+def run(tmp_path):
+    rows = [{"_ng_task_index": i, "_ng_rollout_index": 0, "agent_ref": {"name": "agent"}} for i in range(5)]
+    output = tmp_path / "rollouts.jsonl"
+    materialized_path_for(output).write_bytes(b"".join(orjson.dumps(row) + b"\n" for row in rows))
+    manifest = RunManifest.create(materialized_path_for(output), rows, {}, {})
+    manifest.write(manifest_path_for(output))
+    output.touch()
+    failures_path_for(output).touch()
+    return output, manifest, rows
+
+
+@contextmanager
+def writer(run, *, resume=False):
+    output, manifest, rows = run
+    history = RolloutJournal.load(output, manifest) if resume else RolloutJournal(manifest, rows)
+    with journal_path_for(output).open("ab") as file:
+        history.file = file
+        yield history
+
+
+def save(run, history, row, *, failure=None, reward=0.0, record_outcome=True):
+    output, manifest, _ = run
+    result = dict(row, **{RUN_ID_KEY: manifest.run_id})
+    if failure is not None:
+        result["_ng_failure_class"] = failure
+        target = failures_path_for(output)
+    else:
+        result.update(reward=reward, response={})
+        target = output
+    with target.open("ab") as file:
+        file.write(orjson.dumps(result) + b"\n")
+        file.flush()
+    if record_outcome:
+        history.outcome(result)
+    return result
+
+
+def test_every_expected_rollout_has_one_disposition(run):
+    output, manifest, rows = run
+    with writer(run) as history:
+        for row in rows[:4]:
+            history.dispatch(row)
+        save(run, history, rows[0], reward=0.0)
+        save(run, history, rows[1], failure="agent_request_failed")
+        history.omit(rows[2], "No cached deliverable; producer intentionally skipped this task")
+        # Row 3 was dispatched and disappeared. Row 4 was never dispatched.
+    recovered = RolloutJournal.load(output, manifest)
+    coverage = recovered.coverage()
+    assert (coverage["expected"], coverage["successful"], coverage["failed"]) == (5, 1, 1)
+    assert (coverage["intentionally_omitted"], coverage["unknown"], coverage["never_dispatched"]) == (1, 2, 1)
+    assert not coverage["complete"] and not coverage["reconciled"]
+    assert [row["_ng_task_index"] for row in recovered.pending(3)] == [1, 3, 4]
+    assert recovered.selected("success")[0]["reward"] == 0.0
+
+
+@pytest.mark.parametrize("corruption", ["schema", "undispatched", "indices", "artifact", "scalar"])
+def test_corrupt_history_or_payload_is_rejected_without_mutation(run, corruption):
+    output, manifest, rows = run
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        payload = save(run, history, rows[0])
+    journal = journal_path_for(output)
+    events = list(read_records(journal))
+    if corruption == "schema":
+        events[0]["schema_version"] = 99
+    elif corruption == "undispatched":
+        events = events[1:]
+    elif corruption == "indices":
+        payload["_ng_rollout_id"] = "0-0"
+        payload["_ng_task_index"] = 1
+    elif corruption == "artifact":
+        payload["_ng_failure_class"] = "judge_failed"
+    else:
+        payload = []
+    journal.write_bytes(b"".join(orjson.dumps(event) + b"\n" for event in events))
+    output.write_bytes(orjson.dumps(payload) + b"\n")
+    before = (journal.read_bytes(), output.read_bytes())
+    with pytest.raises(ConfigError):
+        RolloutJournal.load(output, manifest)
+    assert (journal.read_bytes(), output.read_bytes()) == before
+
+
+def test_duplicate_inventory_cannot_conflate_distinct_tasks(run):
+    _, manifest, rows = run
+    with pytest.raises(ConfigError, match="Duplicate logical rollout"):
+        RolloutJournal(manifest, [rows[0], rows[0] | {"question": "Different question"}])
+
+
+@pytest.mark.parametrize("arrival_order", list(permutations(range(3))))
+def test_latest_attempt_wins_independently_of_arrival_order(run, arrival_order):
+    output, manifest, rows = run
+    attempts = [dict(rows[0], _ng_attempt_index=index) for index in range(3)]
+    with writer(run) as history:
+        for row in attempts:
+            history.dispatch(row)
+        prefix = journal_path_for(output).read_bytes()
+        for index in arrival_order:
+            save(run, history, attempts[index], reward=index / 2)
+    assert journal_path_for(output).read_bytes().startswith(prefix)
+    assert len(list(read_records(output))) == 3  # Older payloads remain append-only.
+    recovered = RolloutJournal.load(output, manifest)
+    assert [row["reward"] for row in recovered.selected("success")] == [1.0]
+    assert recovered.coverage()["successful"] == 1
+    assert all(row["_ng_task_index"] != 0 for row in recovered.pending(3))
+
+
+def test_new_dispatch_fences_late_success_and_unknown_attempt_is_not_reused(run):
+    output, manifest, rows = run
+    retry = dict(rows[0], _ng_attempt_index=1)
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        history.dispatch(retry)
+        save(run, history, rows[0])
+    recovered = RolloutJournal.load(output, manifest)
+    assert recovered.selected("success") == []
+    assert recovered.pending(3)[0]["_ng_attempt_index"] == 2
+    assert all(row["_ng_task_index"] != 0 for row in recovered.pending(2))
+    assert recovered.coverage()["unknown"] == 5  # Exhaustion does not invent a failure/reward.
+
+
+def test_latest_failure_is_not_hidden_by_a_late_older_success(run):
+    output, manifest, rows = run
+    retry = dict(rows[0], _ng_attempt_index=1)
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        history.dispatch(retry)
+        save(run, history, retry, failure="judge_failed")
+        save(run, history, rows[0], reward=1.0)
+    recovered = RolloutJournal.load(output, manifest)
+    assert recovered.selected("success") == []
+    assert recovered.selected("failure")[0]["_ng_attempt_index"] == 1
+
+
+def test_crash_between_payload_flush_and_outcome_event_keeps_result(run):
+    output, manifest, rows = run
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        save(run, history, rows[0], record_outcome=False)
+    assert [event["status"] for event in read_records(journal_path_for(output))] == ["dispatched"]
+    recovered = RolloutJournal.load(output, manifest)
+    assert recovered.selected("success")[0]["reward"] == 0.0
+    assert all(row["_ng_task_index"] != 0 for row in recovered.pending(3))
+
+
+@pytest.mark.parametrize("artifact", ["history", "payload"])
+def test_incomplete_tail_is_repaired_without_rewriting_prior_records(run, artifact):
+    output, manifest, rows = run
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        save(run, history, rows[0])
+    path = journal_path_for(output) if artifact == "history" else output
+    prefix = path.read_bytes()
+    with path.open("ab") as file:
+        file.write(b'{"interrupted":')
+    with pytest.warns(UserWarning, match="incomplete final"):
+        recovered = RolloutJournal.load(output, manifest)
+    assert recovered.coverage()["successful"] == 1
+    with pytest.warns(UserWarning, match="incomplete final"):
+        prepare_append(path)
+    assert path.read_bytes() == prefix
+    with writer(run, resume=True) as history:
+        history.dispatch(rows[1])
+        save(run, history, rows[1])
+    assert RolloutJournal.load(output, manifest).coverage()["successful"] == 2
+
+
+def test_complete_unterminated_tail_gets_a_newline(tmp_path):
+    path = tmp_path / "records.jsonl"
+    original = b'{"a": 1}\n{"a": 2}'
+    path.write_bytes(original)
+    prepare_append(path)
+    assert path.read_bytes() == original + b"\n"
+    assert list(read_records(path)) == [{"a": 1}, {"a": 2}]
+
+
+def test_interior_corruption_is_rejected(tmp_path):
+    path = tmp_path / "records.jsonl"
+    path.write_bytes(b'{"a": 1}\n{bad}\n{"a": 2}\n')
+    with pytest.raises(ConfigError, match="line 2"):
+        list(read_records(path))
+
+
+@pytest.mark.parametrize("artifact", ["history", "payload", "materialized"])
+def test_foreign_run_or_changed_inventory_is_rejected(run, artifact):
+    output, manifest, rows = run
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        save(run, history, rows[0])
+    if artifact == "materialized":
+        path = materialized_path_for(output)
+        path.write_bytes(path.read_bytes().replace(b'"agent"', b'"other-agent"'))
+    else:
+        path = journal_path_for(output) if artifact == "history" else output
+        path.write_bytes(path.read_bytes().replace(manifest.run_id.encode(), b"another-run"))
+    with pytest.raises(ConfigError, match="different run|do not match"):
+        RolloutJournal.load(output, manifest)
+
+
+def test_duplicate_delivery_is_idempotent_but_conflicting_payloads_are_rejected(run):
+    output, manifest, rows = run
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        save(run, history, rows[0])
+        save(run, history, rows[0])
+    assert RolloutJournal.load(output, manifest).coverage()["successful"] == 1
+    with writer(run, resume=True) as history:
+        with pytest.raises(ConfigError, match="Conflicting outcomes"):
+            save(run, history, rows[0], reward=1.0)
+    with pytest.raises(ConfigError, match="Conflicting outcomes"):
+        RolloutJournal.load(output, manifest)
+
+
+def test_terminal_skip_is_a_durable_omission(run):
+    output, manifest, rows = run
+    row = dict(rows[0], _ng_failure_terminal=True)
+    with writer(run) as history:
+        history.dispatch(row)
+        save(run, history, row, failure="skipped")
+    recovered = RolloutJournal.load(output, manifest)
+    assert recovered.coverage()["intentionally_omitted"] == 1
+    assert recovered.coverage()["failed"] == 0
+    assert all(row["_ng_task_index"] != 0 for row in recovered.pending(3))
+
+
+def dispatch_then_die(output, manifest_dict, rows):
+    history = RolloutJournal(RunManifest.model_validate(manifest_dict), rows)
+    with journal_path_for(output).open("ab") as file:
+        history.file = file
+        history.dispatch(rows[0])
+        os.kill(os.getpid(), signal.SIGKILL)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="Requires process kill without cleanup")
+def test_killed_worker_leaves_durable_unknown_attempt(run):
+    output, manifest, rows = run
+    process = multiprocessing.get_context("spawn").Process(
+        target=dispatch_then_die, args=(output, manifest.model_dump(), rows)
+    )
+    process.start()
+    try:
+        process.join(30)
+        assert process.exitcode == -signal.SIGKILL
+        history = RolloutJournal.load(output, manifest)
+        assert history.coverage()["unknown"] == 5
+        assert history.coverage()["never_dispatched"] == 4
+        assert history.pending(3)[0]["_ng_attempt_index"] == 1
+        assert output.read_bytes() == b""
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join()
+
+
+async def test_offline_aggregation_uses_newest_attempt_and_full_inventory(run, monkeypatch):
+    from nemo_gym.rollout_collection import (
+        RolloutAggregationConfig,
+        RolloutAggregationHelper,
+        RolloutCollectionHelper,
+    )
+    from nemo_gym.rollout_journal import coverage_path_for
+
+    output, _, rows = run
+    retry = dict(rows[0], _ng_attempt_index=1)
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        history.dispatch(retry)
+        save(run, history, retry, reward=0.0)
+        save(run, history, rows[0], reward=1.0)  # Late older success must not inflate the score.
+
+    scored = []
+
+    async def aggregate(self, results, rows, path):
+        scored.extend(results)
+        return None
+
+    monkeypatch.setattr(RolloutCollectionHelper, "_call_aggregate_metrics", aggregate)
+    merged = output.with_name("merged.jsonl")
+    await RolloutAggregationHelper().run_from_config(
+        RolloutAggregationConfig(
+            input_glob=str(output.with_name("rollouts*.jsonl")),
+            output_jsonl_fpath=str(merged),
+            disable_health_check=True,
+        )
+    )
+    assert [row["reward"] for row in scored] == [0.0]
+    assert [row["reward"] for row in read_records(merged)] == [0.0]
+    report = orjson.loads(coverage_path_for(merged).read_bytes())
+    assert (report["expected"], report["successful"], report["unknown"]) == (5, 1, 4)
+    assert report["coverage_known"] and not report["complete"]
+    assert len(list(read_records(output))) == 2  # Aggregating does not rewrite history.
+
+
+async def test_legacy_aggregation_cannot_claim_complete_without_inventory(tmp_path, monkeypatch, capsys):
+    import nemo_gym.rollout_collection as collection
+    from nemo_gym.rollout_journal import coverage_path_for
+
+    output = tmp_path / "legacy.jsonl"
+    output.write_bytes(orjson.dumps({"_ng_task_index": 0, "_ng_rollout_index": 0, "reward": 1.0}) + b"\n")
+
+    async def aggregate(*args):
+        return None
+
+    exported = []
+    monkeypatch.setattr(collection.RolloutCollectionHelper, "_call_aggregate_metrics", aggregate)
+    monkeypatch.setattr(collection, "get_exporters", lambda: True)
+    monkeypatch.setattr(collection, "export_metrics", exported.append)
+    merged = tmp_path / "merged.jsonl"
+    await collection.RolloutAggregationHelper().run_from_config(
+        collection.RolloutAggregationConfig(
+            input_glob=str(output), output_jsonl_fpath=str(merged), disable_health_check=True
+        )
+    )
+    report = orjson.loads(coverage_path_for(merged).read_bytes())
+    assert report["expected"] is None and report["unknown"] is None
+    assert not report["coverage_known"] and not report["complete"]
+    assert exported == [{"coverage/scored": 1, "coverage/known": 0}]
+    assert "scores may be partial" in capsys.readouterr().out

--- a/tests/unit_tests/test_rollout_journal.py
+++ b/tests/unit_tests/test_rollout_journal.py
@@ -442,3 +442,33 @@ async def test_legacy_aggregation_cannot_claim_complete_without_inventory(tmp_pa
         }
     ]
     assert "scores may be partial" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("mixed_legacy", [False, True])
+async def test_aggregation_reports_journal_failure_classes(run, monkeypatch, capsys, mixed_legacy):
+    import nemo_gym.rollout_collection as collection
+
+    output, _, rows = run
+    with writer(run) as history:
+        history.dispatch(rows[0])
+        save(run, history, rows[0], reward=1.0)
+        history.dispatch(rows[1])
+        save(run, history, rows[1], failure="judge_failed")
+    if mixed_legacy:
+        output.with_name("rollouts_legacy.jsonl").write_bytes(
+            orjson.dumps(rows[0] | {"reward": 0, "response": {}}) + b"\n"
+        )
+
+    async def aggregate(*args):
+        return None
+
+    monkeypatch.setattr(collection.RolloutCollectionHelper, "_call_aggregate_metrics", aggregate)
+    monkeypatch.setattr(collection, "get_exporters", list)
+    await collection.RolloutAggregationHelper().run_from_config(
+        collection.RolloutAggregationConfig(
+            input_glob=str(output.with_name("rollouts*.jsonl")),
+            output_jsonl_fpath=str(output.with_name("merged.jsonl")),
+            disable_health_check=True,
+        )
+    )
+    assert "1 judge_failed" in capsys.readouterr().out

--- a/tests/unit_tests/test_rollout_recovery.py
+++ b/tests/unit_tests/test_rollout_recovery.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
+from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 import nemo_gym.rollout_collection as collection
@@ -423,7 +424,10 @@ def runner_config(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize("route_failures", [False, True])
-async def test_collected_judge_failure_can_be_reverified_without_inference(runner_config, monkeypatch, route_failures):
+@pytest.mark.parametrize("append", [False, True])
+async def test_collected_judge_failure_can_be_reverified_without_inference(
+    runner_config, monkeypatch, route_failures, append
+):
     runner_config.route_failures_to_sidecar = route_failures
     generated_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "42"}]}]}
 
@@ -444,7 +448,15 @@ async def test_collected_judge_failure_can_be_reverified_without_inference(runne
                 },
             )
         if row["task"] == 2:
-            return FakeResponse(200, {"_ng_failure_class": "agent_request_failed", "reward": 0, "response": {}})
+            return FakeResponse(
+                200,
+                RolloutFailure(
+                    rollout_id=logical_rollout_id(row),
+                    failure_kind="judge_failed",
+                    stage="verifier",
+                    failure_reason="No generation saved",
+                ).model_dump(),
+            )
         return FakeResponse(200, {"reward": 0.0, "response": {"output": []}})
 
     client = install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
@@ -469,17 +481,301 @@ async def test_collected_judge_failure_can_be_reverified_without_inference(runne
     config = reverification.RolloutReverificationConfig(
         materialized_inputs_jsonl_fpath=str(runner_config.materialized_jsonl_fpath),
         rollouts_jsonl_fpath=str(output),
-        output_jsonl_fpath=str(output.with_name("reverified.jsonl")),
+        output_jsonl_fpath=str(output if append else output.with_name("reverified.jsonl")),
         judge_failed_only=True,
+        append=append,
         disable_aggregation=True,
     )
-    returned = await reverification.RolloutReverificationHelper().run_from_config(config)
+    with pytest.warns(UserWarning, match="without a saved response"):
+        returned = await reverification.RolloutReverificationHelper().run_from_config(config)
     by_task = {row["_ng_task_index"]: row for row in returned}
     assert by_task[0] == successes[0]
     assert by_task[1]["reward"] == 1.0 and by_task[1]["response"] == generated_response
     assert set(by_task) == {0, 1}
     assert [call.kwargs["url_path"] for call in client.post.await_args_list].count("/run") == 3
     assert [call.kwargs["url_path"] for call in client.post.await_args_list].count("/verify") == 1
+    if append:
+        from nemo_gym.rollout_store import RolloutStore
+
+        recovered = RolloutStore.read(output)
+        assert recovered.selected("success") == returned
+        assert by_task[1]["_ng_attempt_index"] == 1
+        assert recovered.coverage()["attempts"] == 4
+        with pytest.warns(UserWarning, match="without a saved response"):
+            assert await reverification.RolloutReverificationHelper().run_from_config(config) == returned
+        assert [call.kwargs["url_path"] for call in client.post.await_args_list].count("/verify") == 1
+
+
+async def test_runner_accepts_nested_hydra_overrides_and_unused_unresolved_server(runner_config, monkeypatch):
+    global_config = {
+        "unused": {"responses_api_models": {"openai_model": {"model": "${oc.env:NG_MISSING_REVIEW_TEST}"}}}
+    }
+    monkeypatch.delenv("NG_MISSING_REVIEW_TEST", raising=False)
+    monkeypatch.setattr(collection, "get_global_config_dict", lambda: global_config)
+    runner_config.responses_create_params = {"metadata": OmegaConf.create({"nested": {"values": [1, 2]}})}
+    client = install_fake_server_client(
+        monkeypatch, AsyncMock(return_value=FakeResponse(200, {"reward": 0, "response": {}}))
+    )
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    assert client.post.await_count == 3
+    for call in client.post.await_args_list:
+        assert call.kwargs["json"]["responses_create_params"]["metadata"] == {"nested": {"values": [1, 2]}}
+    runner_config.resume_from_cache = True
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    assert client.post.await_count == 3
+
+
+def test_identity_resolves_reachable_servers_but_ignores_operational_fields(saved_manifest, monkeypatch):
+    source, rows, _, config, _, _, _ = saved_manifest
+    rows = [rows[0] | {"agent_ref": {"name": "agent"}}]
+    servers = {
+        "policy_api_key": "old-secret",
+        "policy_base_url": "http://old",
+        "policy_name": "model-A",
+        "agent": {
+            "responses_api_agents": {
+                "simple_agent": {
+                    "model_server": {"name": "policy"},
+                    "resources_server": {"name": "resources"},
+                }
+            }
+        },
+        "policy": {
+            "responses_api_models": {
+                "openai_model": {
+                    "model": "${policy_name}",
+                    "openai_api_key": "${policy_api_key}",
+                    "openai_base_url": "${policy_base_url}",
+                    "model_call_capture_dir": "/old/captures",
+                }
+            }
+        },
+        "resources": {
+            "resources_servers": {"example": {"dataset_path": "/tasks/a", "prompt": "${oc.env:NG_REVIEW_PROMPT}"}}
+        },
+        "unused": {"responses_api_models": {"openai_model": {"model": "${oc.env:NG_MISSING_REVIEW_TEST}"}}},
+    }
+    monkeypatch.setenv("NG_REVIEW_PROMPT", "prompt-A")
+    monkeypatch.delenv("NG_MISSING_REVIEW_TEST", raising=False)
+    before = RunManifest.create(source, rows, config, servers).config_digest
+    servers.update(policy_api_key="new-secret", policy_base_url="http://new", model_call_capture_dir="/new/captures")
+    servers["policy"]["responses_api_models"]["openai_model"]["model_call_capture_dir"] = "/another/capture"
+    assert RunManifest.create(source, rows, config, servers).config_digest == before
+    monkeypatch.setenv("NG_REVIEW_PROMPT", "prompt-B")
+    assert RunManifest.create(source, rows, config, servers).config_digest != before
+    monkeypatch.setenv("NG_REVIEW_PROMPT", "prompt-A")
+    servers["resources"]["resources_servers"]["example"]["dataset_path"] = "/tasks/b"
+    assert RunManifest.create(source, rows, config, servers).config_digest != before
+
+
+def test_capture_directory_changes_preserve_identity_but_behavior_changes_do_not(saved_manifest):
+    source, rows, _, config, servers, _, _ = saved_manifest
+    servers["token_id_capture"] = {"dir": "/old", "rebuild_response": True}
+    model = servers["policy"]["responses_api_models"]["vllm_model"]
+    model["token_id_capture"] = {"dir": "/old", "rebuild_response": True}
+    before = RunManifest.create(source, rows, config, servers).config_digest
+    for settings in (servers["token_id_capture"], model["token_id_capture"]):
+        settings["dir"] = "/new"
+    assert RunManifest.create(source, rows, config, servers).config_digest == before
+    servers["token_id_capture"]["rebuild_response"] = False
+    assert RunManifest.create(source, rows, config, servers).config_digest != before
+
+
+@pytest.mark.parametrize(
+    "repeats,fan_out,expected",
+    [(1, None, 1), (3, None, 3), (1, {"my_agent": ["a", "b"]}, 2), (2, {"my_agent": ["a", "b"]}, 4)],
+)
+def test_explicit_ids_expand_deterministically(runner_config, repeats, fan_out, expected):
+    runner_config.num_repeats = repeats
+    runner_config.fan_out = fan_out
+    example = failing_row() | {"_ng_rollout_id": "explicit-task"}
+    helper = RolloutCollectionHelper()
+    rows = helper.preprocess_examples([example], num_repeats=repeats, fan_out=fan_out)
+    assert len(rows) == expected
+    assert len({logical_rollout_id(row) for row in rows}) == expected
+    assert helper.preprocess_examples([example], num_repeats=repeats, fan_out=fan_out) == rows
+    Path(runner_config.input_jsonl_fpath).write_text(json.dumps(example) + "\n")
+    assert helper._preprocess_rows_from_config(runner_config) == rows
+    assert example["_ng_rollout_id"] == "explicit-task"
+    if expected == 1:
+        assert rows[0]["_ng_rollout_id"] == "explicit-task"
+
+
+@pytest.mark.parametrize("identity", [[], "../bad", ""])
+def test_invalid_explicit_identity_is_a_configuration_error(identity):
+    with pytest.raises(ConfigError, match="Invalid rollout identity"):
+        logical_rollout_id(failing_row() | {"_ng_rollout_id": identity})
+
+
+@pytest.mark.parametrize("route_failures", [False, True])
+async def test_failure_sidecar_retains_observations_and_captured_model_calls(
+    runner_config, monkeypatch, route_failures
+):
+    from nemo_gym.base_responses_api_model import CaptureStore
+
+    runner_config.route_failures_to_sidecar = route_failures
+    capture_dir = Path(runner_config.output_jsonl_fpath).parent / "captures"
+    captures = CaptureStore(capture_dir)
+    monkeypatch.setattr(
+        collection,
+        "get_global_config_dict",
+        lambda: {
+            "observability_enabled": True,
+            "model_call_capture_dir": str(capture_dir),
+        },
+    )
+    observations = {"source": "test", "records": [{"kind": "agent_invocation", "invocation_id": "root"}]}
+
+    async def post(**kwargs):
+        row = kwargs["json"]
+        captures.record(
+            logical_rollout_id(row),
+            {
+                "model_call_id": "call-1",
+                "dialect": "responses",
+                "request": {"input": []},
+                "response": {"id": "resp-1"},
+            },
+        )
+        return FakeResponse(
+            200,
+            {
+                "_ng_failure_class": "agent_run_error",
+                "reward": 0,
+                "response": {},
+                "ng_agent_observations": observations,
+                "_ng_failure_judge_error": "diagnostic detail",
+            },
+        )
+
+    install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    with pytest.raises(RuntimeError, match="None of the 3 dispatched"):
+        await RolloutCollectionHelper().run_from_config(runner_config)
+    output = Path(runner_config.output_jsonl_fpath)
+    assert list(read_records(output)) == []
+    failures = list(read_records(collection.failures_path_for(output)))
+    assert len(failures) == 3
+    for row in failures:
+        assert row["ng_agent_observations"]["source"] == observations["source"]
+        assert row["ng_agent_observations"]["records"][0]["invocation_id"] == "root"
+        assert row["_ng_failure_judge_error"] == "diagnostic detail"
+        assert row["ng_trajectory"]["invocations"][0]["invocation_id"] == "root"
+        assert row["ng_trajectory"]["model_calls"][0]["response"] == {"id": "resp-1"}
+        assert "reward" not in row and "response" not in row
+        assert "ng_trajectory" not in row["_ng_failure_record"]
+
+
+async def test_terminal_skips_can_be_explicitly_scored_as_zero(runner_config, monkeypatch):
+    runner_config.disable_aggregation = False
+    runner_config.count_failure_classes_as_zero = ["skipped"]
+    aggregate = AsyncMock(return_value=None)
+    monkeypatch.setattr(RolloutCollectionHelper, "_call_aggregate_metrics", aggregate)
+
+    async def post(**kwargs):
+        result = (
+            {"reward": 0, "response": {}}
+            if kwargs["json"]["task"] == 0
+            else {
+                "_ng_failure_class": "skipped",
+                "_ng_failure_terminal": True,
+            }
+        )
+        return FakeResponse(200, result)
+
+    client = install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    assert len(aggregate.await_args.args[0]) == 3
+    assert all(row["reward"] == 0 for row in aggregate.await_args.args[0])
+    output = Path(runner_config.output_jsonl_fpath)
+    assert len(list(read_records(output))) == 1
+    report = json.loads(coverage_path_for(output).read_text())
+    assert (report["intentionally_omitted"], report["scored"], report["failures_counted_as_zero"]) == (2, 3, 2)
+    runner_config.resume_from_cache = True
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    assert client.post.await_count == 3
+    await collection.RolloutAggregationHelper().run_from_config(
+        collection.RolloutAggregationConfig(
+            input_glob=str(output),
+            output_jsonl_fpath=str(output.with_name("merged.jsonl")),
+            count_failure_classes_as_zero=["skipped"],
+            disable_health_check=True,
+        )
+    )
+    assert len(aggregate.await_args.args[0]) == 3
+
+
+async def test_reported_kill_shaped_failures_consume_bounded_attempts(runner_config, monkeypatch):
+    monkeypatch.setenv("NEMO_GYM_MAX_ROLLOUT_ATTEMPTS", "2")
+
+    async def post(**kwargs):
+        result = (
+            {"reward": 0, "response": {}}
+            if kwargs["json"]["task"] == 0
+            else {
+                "_ng_failure_class": "kill_shaped",
+                "_ng_no_persist": True,
+                "reward": 0,
+                "response": {},
+            }
+        )
+        return FakeResponse(200, result)
+
+    client = install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    runner_config.resume_from_cache = True
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    assert client.post.await_count == 5
+    output = Path(runner_config.output_jsonl_fpath)
+    failures = list(read_records(collection.failures_path_for(output)))
+    assert len(failures) == 4
+    assert all("reward" not in row and "_ng_no_persist" not in row for row in failures)
+    assert json.loads(coverage_path_for(output).read_text())["attempts"] == 5
+
+
+async def test_cancelled_reverify_append_stops_requests_before_closing_journal(runner_config, monkeypatch):
+    from nemo_gym.rollout_store import RolloutStore
+
+    started, stopped = asyncio.Event(), asyncio.Event()
+    verify_requests = []
+
+    async def post(**kwargs):
+        row = kwargs["json"]
+        if kwargs["url_path"] == "/verify":
+            verify_requests.append(row)
+            started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                stopped.set()
+        result = {"reward": 0, "response": {}}
+        if row["task"] != 0:
+            result["_ng_failure_class"] = "judge_failed"
+        return FakeResponse(200, result)
+
+    client = install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    monkeypatch.setattr(reverification, "setup_server_client", lambda: client)
+    monkeypatch.setattr(reverification, "_build_agent_to_resources_server_mapping", lambda _: {"my_agent": "rs"})
+    monkeypatch.setattr(reverification, "raise_for_status", collection.raise_for_status)
+    monkeypatch.setattr(reverification, "get_response_json", collection.get_response_json)
+    config = reverification.RolloutReverificationConfig(
+        materialized_inputs_jsonl_fpath=str(runner_config.materialized_jsonl_fpath),
+        rollouts_jsonl_fpath=runner_config.output_jsonl_fpath,
+        output_jsonl_fpath=runner_config.output_jsonl_fpath,
+        judge_failed_only=True,
+        append=True,
+        num_samples_in_parallel=1,
+        disable_aggregation=True,
+    )
+    task = asyncio.create_task(reverification.RolloutReverificationHelper().run_from_config(config))
+    await asyncio.wait_for(started.wait(), timeout=10)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert stopped.is_set() and len(verify_requests) == 1
+    coverage = RolloutStore.read(Path(runner_config.output_jsonl_fpath)).coverage()
+    assert (coverage["attempts"], coverage["successful"], coverage["failed"], coverage["unknown"]) == (4, 1, 1, 1)
 
 
 @pytest.mark.parametrize("count_failures_as_zero", [False, True])

--- a/tests/unit_tests/test_rollout_recovery.py
+++ b/tests/unit_tests/test_rollout_recovery.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral checks for structured outcomes and resuming an interrupted collector."""
+
+import asyncio
+import json
+import multiprocessing
+import pickle
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+import nemo_gym.rollout_collection as collection
+from nemo_gym.config_types import ConfigError
+from nemo_gym.rollout_collection import RolloutCollectionConfig, RolloutCollectionHelper, _CompletedRollout
+from nemo_gym.rollout_journal import RolloutJournal, coverage_path_for, journal_path_for, read_records
+from nemo_gym.rollout_outcomes import RolloutFailure
+from nemo_gym.rollout_recovery import RunManifest, manifest_path_for, validate_resume
+from tests.unit_tests.test_rollout_collection import FakeResponse, failing_row, http_error, install_fake_server_client
+
+
+def echo_failure(connection, failure):
+    """Exercise the spawn/pickle boundary used by process-based callers."""
+    connection.send(failure)
+    connection.close()
+
+
+def test_failure_has_no_generation_fields_and_round_trips():
+    failure = RolloutFailure(
+        rollout_id="task-42",
+        attempt_index=2,
+        failure_kind="agent_request_failed",
+        stage="request",
+        failure_reason="x" * 9000,
+        response_body="y" * 9000,
+    )
+    assert failure.attempt_id == "task-42-a2"
+    assert len(failure.failure_reason) == len(failure.response_body) == 2000
+    assert RolloutFailure.model_validate_json(failure.model_dump_json()) == failure
+    assert pickle.loads(pickle.dumps(failure)) == failure
+    for field in ("reward", "response", "messages", "tokens"):
+        with pytest.raises(ValidationError):
+            RolloutFailure.model_validate(failure.model_dump() | {field: 0})
+
+
+def test_failure_survives_spawned_process():
+    failure = RolloutFailure(
+        rollout_id="task-42",
+        failure_kind="transport_timeout",
+        stage="request",
+        failure_reason="Timed out",
+    )
+    context = multiprocessing.get_context("spawn")
+    parent, child = context.Pipe()
+    process = context.Process(target=echo_failure, args=(child, failure))
+    process.start()
+    child.close()
+    try:
+        assert parent.poll(30), "Child did not return its failure record"
+        assert parent.recv() == failure
+        process.join(10)
+        assert process.exitcode == 0
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join()
+        parent.close()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {},
+        {"reward": 0},
+        {"reward": float("nan"), "response": {}},
+        {"reward": True, "response": {}},
+        {"_ng_failure_class": []},
+        {"type": "failure", "reward": 0},
+    ],
+)
+async def test_malformed_results_become_associated_failures(payload, monkeypatch):
+    install_fake_server_client(monkeypatch, AsyncMock(return_value=FakeResponse(200, payload)))
+    row = failing_row()
+    original, outcome = await next(RolloutCollectionHelper().run_outcomes([row]))
+    assert original is row
+    assert isinstance(outcome, RolloutFailure)
+    assert outcome.stage == "result"
+    assert outcome.exception_type == "InvalidRolloutResult"
+    assert outcome.rollout_id
+    assert "reward" not in outcome.model_dump()
+
+
+async def test_valid_zero_and_masked_completed_results_remain_results(monkeypatch):
+    for masked in (False, True):
+        result = {"reward": 0.0, "response": {}, "mask_sample": masked}
+        install_fake_server_client(monkeypatch, AsyncMock(return_value=FakeResponse(200, result)))
+        _, outcome = await next(RolloutCollectionHelper().run_outcomes([failing_row()]))
+        assert outcome is result
+
+
+@pytest.mark.parametrize("wrong_identity", [None, "rollout_id", "attempt_index", "run_id"])
+async def test_agent_can_return_a_failure_for_its_dispatched_attempt(monkeypatch, wrong_identity):
+    row = failing_row() | {"_ng_rollout_id": "stable-task", "_ng_attempt_index": 2}
+    failure = RolloutFailure(
+        rollout_id="stable-task",
+        attempt_index=2,
+        failure_kind="judge_failed",
+        stage="verifier",
+        failure_reason="Judge unavailable",
+    )
+    payload = failure.model_dump()
+    if wrong_identity == "rollout_id":
+        payload["rollout_id"] = "another-task"
+    elif wrong_identity == "attempt_index":
+        payload["attempt_index"] = 1
+    elif wrong_identity == "run_id":
+        payload["run_id"] = "another-run"
+    install_fake_server_client(monkeypatch, AsyncMock(return_value=FakeResponse(200, payload)))
+    original, outcome = await next(RolloutCollectionHelper().run_outcomes([row]))
+    assert original is row
+    if wrong_identity is None:
+        assert outcome == failure
+    else:
+        assert outcome.rollout_id == failure.rollout_id
+        assert outcome.attempt_index == failure.attempt_index
+        assert outcome.exception_type == "InvalidRolloutResult"
+        assert outcome.stage == "result"
+
+
+async def test_legacy_judge_placeholder_is_converted_only_for_typed_callers(monkeypatch):
+    legacy = {
+        "reward": 0.0,
+        "response": {"output": []},
+        "_ng_failure_class": "judge_failed",
+        "failure_reason": "Judge unavailable",
+    }
+    install_fake_server_client(monkeypatch, AsyncMock(return_value=FakeResponse(200, legacy)))
+    _, raw = await next(RolloutCollectionHelper().run_examples([failing_row()]))
+    assert raw is legacy
+    _, outcome = await next(RolloutCollectionHelper().run_outcomes([failing_row()]))
+    assert isinstance(outcome, RolloutFailure)
+    assert outcome.failure_kind == "judge_failed"
+    assert "response" not in outcome.model_dump()
+
+
+async def test_expected_failure_does_not_stop_independent_work(monkeypatch):
+    rows = [failing_row(), failing_row() | {"_ng_task_index": 99}]
+
+    async def post(**kwargs):
+        if kwargs["json"]["_ng_task_index"] == rows[0]["_ng_task_index"]:
+            raise http_error(503)
+        return FakeResponse(200, {"reward": 0.0, "response": {}})
+
+    install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    outcomes = [await future for future in RolloutCollectionHelper().run_outcomes(rows)]
+    assert sum(isinstance(result, RolloutFailure) for _, result in outcomes) == 1
+    assert [result["reward"] for _, result in outcomes if isinstance(result, dict)] == [0.0]
+
+
+@pytest.mark.parametrize("error", [RuntimeError("programming error"), asyncio.CancelledError()])
+async def test_typed_api_preserves_programming_errors_and_cancellation(error, monkeypatch):
+    install_fake_server_client(monkeypatch, AsyncMock(side_effect=error))
+    with pytest.raises(type(error)):
+        await next(RolloutCollectionHelper().run_outcomes([failing_row()]))
+
+
+def test_typed_api_requires_identity():
+    with pytest.raises(ValueError, match="preprocess_examples"):
+        RolloutCollectionHelper().run_outcomes([{"agent_ref": {"name": "agent"}}])
+
+
+@pytest.fixture
+def saved_manifest(tmp_path):
+    source = tmp_path / "source.jsonl"
+    source.write_text('{"question":"A"}\n')
+    rows = [{"_ng_task_index": 0, "_ng_rollout_index": 0, "question": "A"}]
+    materialized = tmp_path / "materialized.jsonl"
+    materialized.write_text(json.dumps(rows[0]) + "\n")
+    configuration = {"limit": 1, "responses_create_params": {"temperature": 0.3}}
+    servers = {
+        "policy": {
+            "responses_api_models": {
+                "vllm_model": {
+                    "model": "model-A",
+                    "host": "host-A",
+                    "port": 100,
+                    "api_key": "credential",
+                }
+            }
+        }
+    }
+    manifest = RunManifest.create(source, rows, configuration, servers)
+    path = tmp_path / "manifest.json"
+    manifest.write(path)
+    return source, rows, materialized, configuration, servers, manifest, path
+
+
+def test_resume_allows_new_server_addresses_and_operational_options(saved_manifest):
+    source, rows, materialized, config, servers, saved, path = saved_manifest
+    config = config | {"resume_from_cache": True, "num_samples_in_parallel": 10}
+    servers["policy"]["responses_api_models"]["vllm_model"].update(host="host-B", port=200, api_key="new")
+    current = RunManifest.create(source, rows, config, servers)
+    assert validate_resume(path, current, materialized).run_id == saved.run_id
+    assert "credential" not in path.read_text()
+    assert "model-A" not in path.read_text()
+
+
+@pytest.mark.parametrize("changed", ["source", "materialized", "sampling", "model", "tool_schema"])
+def test_resume_rejects_changed_identity(saved_manifest, changed):
+    source, rows, materialized, config, servers, saved, path = saved_manifest
+    if changed == "source":
+        source.write_text('{"question":"B"}\n')
+    elif changed == "materialized":
+        materialized.write_text('{"question":"corrupted"}\n')
+    elif changed == "sampling":
+        config["responses_create_params"]["temperature"] = 0.8
+    elif changed == "model":
+        servers["policy"]["responses_api_models"]["vllm_model"]["model"] = "model-B"
+    else:
+        servers["policy"]["responses_api_models"]["vllm_model"]["tools"] = {"properties": {"port": {"type": "string"}}}
+    current = RunManifest.create(source, rows, config, servers)
+    with pytest.raises(ConfigError, match="incompatible"):
+        validate_resume(path, current, materialized)
+    assert RunManifest.model_validate_json(path.read_bytes()) == saved
+
+
+def test_legacy_resume_requires_explicit_override(tmp_path):
+    path = tmp_path / "missing.json"
+    with pytest.raises(ConfigError, match="no run manifest"):
+        validate_resume(path, None, tmp_path / "input.jsonl")
+    with pytest.warns(UserWarning, match="allow_unsafe_resume"):
+        assert validate_resume(path, None, tmp_path / "input.jsonl", allow_unsafe=True) is None
+
+
+def test_unknown_manifest_version_is_rejected_even_with_override(saved_manifest):
+    _, _, materialized, _, _, saved, path = saved_manifest
+    path.write_text(json.dumps(saved.model_dump() | {"schema_version": 99}))
+    with pytest.raises(ConfigError, match="Cannot read"):
+        validate_resume(path, None, materialized, allow_unsafe=True)
+
+
+@pytest.mark.parametrize("interruption", [asyncio.CancelledError, RuntimeError])
+async def test_interrupted_runner_closes_files_and_reuses_saved_zero(tmp_path, monkeypatch, interruption):
+    monkeypatch.setattr(collection, "get_global_config_dict", lambda: {})
+    source = tmp_path / "input.jsonl"
+    source.write_text(
+        "".join(
+            json.dumps(
+                {
+                    "responses_create_params": {"input": []},
+                    "agent_ref": {"name": "agent"},
+                    "task": task,
+                }
+            )
+            + "\n"
+            for task in range(3)
+        )
+    )
+    config = RolloutCollectionConfig(
+        input_jsonl_fpath=str(source),
+        output_jsonl_fpath=str(tmp_path / "out.jsonl"),
+        disable_aggregation=True,
+        disable_health_check=True,
+    )
+    opened = []
+    original_open = Path.open
+
+    def track_open(path, *args, **kwargs):
+        file = original_open(path, *args, **kwargs)
+        if args and args[0] == "ab":
+            opened.append(file)
+        return file
+
+    monkeypatch.setattr(Path, "open", track_open)
+    dispatched = []
+    interrupt = True
+
+    class Helper(RolloutCollectionHelper):
+        def _run_examples_with_metadata(self, examples, **kwargs):
+            # Yield lazily to interrupt deterministically after the first flushed result.
+            for row in examples:
+
+                async def complete(row=row):
+                    kwargs["on_dispatch"](row)
+                    dispatched.append(row["task"])
+                    if interrupt and row["task"] == 1:
+                        raise interruption()
+                    return _CompletedRollout(row=row, result={"reward": 0.0, "response": {}}, rollout_latency_ms=None)
+
+                yield complete()
+
+    helper = Helper()
+    with pytest.raises(interruption):
+        await helper.run_from_config(config)
+    assert opened and all(file.closed for file in opened)
+    before = Path(config.output_jsonl_fpath).read_bytes()
+    assert len(before.splitlines()) == 1
+    run_id = RunManifest.model_validate_json(manifest_path_for(Path(config.output_jsonl_fpath)).read_bytes()).run_id
+    interrupt = False
+    dispatched.clear()
+    config.resume_from_cache = True
+    await helper.run_from_config(config)
+    assert dispatched == [1, 2]
+    assert all(file.closed for file in opened)
+    after = Path(config.output_jsonl_fpath).read_bytes()
+    assert after.startswith(before)
+    assert len(after.splitlines()) == 3
+    resumed = [json.loads(line) for line in after.splitlines()]
+    assert resumed[1]["_ng_attempt_index"] == 1
+    assert resumed[2].get("_ng_attempt_index", 0) == 0
+    assert (
+        RunManifest.model_validate_json(manifest_path_for(Path(config.output_jsonl_fpath)).read_bytes()).run_id
+        == run_id
+    )
+    dispatched.clear()
+    await helper.run_from_config(config)
+    assert dispatched == []
+
+
+async def test_runner_rejects_changed_inputs_before_dispatch_or_output_mutation(tmp_path, monkeypatch):
+    monkeypatch.setattr(collection, "get_global_config_dict", lambda: {})
+    source = tmp_path / "input.jsonl"
+    source.write_text(json.dumps({"responses_create_params": {"input": []}, "agent_ref": {"name": "agent"}}) + "\n")
+    config = RolloutCollectionConfig(
+        input_jsonl_fpath=str(source),
+        output_jsonl_fpath=str(tmp_path / "out.jsonl"),
+        disable_aggregation=True,
+        disable_health_check=True,
+    )
+    calls = []
+
+    class Helper(RolloutCollectionHelper):
+        def _run_examples_with_metadata(self, examples, **kwargs):
+            for row in examples:
+
+                async def complete(row=row):
+                    calls.append(row)
+                    return _CompletedRollout(row=row, result={"reward": 0.0, "response": {}}, rollout_latency_ms=None)
+
+                yield complete()
+
+    helper = Helper()
+    await helper.run_from_config(config)
+    output = Path(config.output_jsonl_fpath)
+    original = output.read_bytes()
+    source.write_text(source.read_text().replace('"input": []', '"input": "changed"'))
+    config.resume_from_cache = True
+    with pytest.raises(ConfigError, match="incompatible"):
+        await helper.run_from_config(config)
+    assert len(calls) == 1
+    assert output.read_bytes() == original
+
+
+def test_identity_override_remains_visible_on_future_resumes(saved_manifest):
+    source, rows, materialized, config, servers, saved, path = saved_manifest
+    changed = RunManifest.create(source, rows, config | {"limit": 2}, servers)
+    with pytest.warns(UserWarning, match="allow_unsafe_resume"):
+        overridden = validate_resume(path, changed, materialized, allow_unsafe=True)
+    assert overridden.identity_overridden and overridden.run_id == saved.run_id
+    overridden.write(path)
+    with pytest.raises(ConfigError, match="previously overridden"):
+        validate_resume(path, saved, materialized)
+
+
+@pytest.fixture
+def runner_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(collection, "get_global_config_dict", lambda: {})
+    source = tmp_path / "input.jsonl"
+    source.write_text("".join(json.dumps(failing_row(task) | {"task": task}) + "\n" for task in range(3)))
+    return RolloutCollectionConfig(
+        input_jsonl_fpath=str(source),
+        output_jsonl_fpath=str(tmp_path / "out.jsonl"),
+        route_failures_to_sidecar=True,
+        disable_aggregation=True,
+        disable_health_check=True,
+        num_samples_in_parallel=1,
+    )
+
+
+async def test_runner_journals_before_request_and_resumes_only_failed_work(runner_config, monkeypatch):
+    output = Path(runner_config.output_jsonl_fpath)
+    calls = []
+
+    async def post(**kwargs):
+        row = kwargs["json"]
+        calls.append(row)
+        history = RolloutJournal.load(output, RunManifest.model_validate_json(manifest_path_for(output).read_bytes()))
+        identity = collection.logical_rollout_id(row)
+        assert history.latest[identity] == row.get("_ng_attempt_index", 0)
+        assert history.disposition(identity) == "unknown"
+        if row["task"] == 1 and row.get("_ng_attempt_index", 0) == 0:
+            raise http_error(503)
+        if row["task"] == 2:
+            return FakeResponse(
+                200,
+                {"_ng_failure_class": "skipped", "_ng_failure_terminal": True, "reward": 0, "response": {}},
+            )
+        return FakeResponse(200, {"reward": 0.0, "response": {}, "mask_sample": True})
+
+    install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    helper = RolloutCollectionHelper()
+    await helper.run_from_config(runner_config)
+    report = json.loads(coverage_path_for(output).read_text())
+    assert [report[key] for key in ("successful", "failed", "intentionally_omitted", "unknown")] == [1, 1, 1, 0]
+    assert not report["complete"] and report["reconciled"]
+    failures = list(read_records(collection.failures_path_for(output)))
+    assert len(failures) == 2
+    assert all("reward" not in row and "response" not in row for row in failures)
+    assert all(row["_ng_failure_record"]["run_id"] == report["run_id"] for row in failures)
+    original_history = journal_path_for(output).read_bytes()
+    runner_config.resume_from_cache = True
+    calls.clear()
+    await helper.run_from_config(runner_config)
+    assert [(row["task"], row["_ng_attempt_index"]) for row in calls] == [(1, 1)]
+    assert journal_path_for(output).read_bytes().startswith(original_history)
+    report = json.loads(coverage_path_for(output).read_text())
+    assert [report[key] for key in ("successful", "failed", "intentionally_omitted", "unknown")] == [2, 0, 1, 0]
+    assert len(list(read_records(collection.failures_path_for(output)))) == 2
+
+
+async def test_runner_cancellation_closes_requests_before_return(runner_config, monkeypatch):
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    requests = []
+
+    async def post(**kwargs):
+        requests.append(kwargs["json"])
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            stopped.set()
+
+    install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    task = asyncio.create_task(RolloutCollectionHelper().run_from_config(runner_config))
+    await asyncio.wait_for(started.wait(), timeout=10)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert stopped.is_set() and len(requests) == 1
+    output = Path(runner_config.output_jsonl_fpath)
+    report = json.loads(coverage_path_for(output).read_text())
+    assert (report["attempts"], report["unknown"], report["never_dispatched"]) == (1, 3, 2)
+    assert output.read_bytes() == collection.failures_path_for(output).read_bytes() == b""
+
+
+@pytest.mark.parametrize("route_failures", [False, True])
+async def test_runner_accepts_explicit_failures_independently_of_exception_policy(
+    runner_config, monkeypatch, route_failures
+):
+    runner_config.route_failures_to_sidecar = route_failures
+
+    async def post(**kwargs):
+        row = kwargs["json"]
+        if row["task"] == 0:
+            return FakeResponse(200, {"reward": 0, "response": {}})
+        return FakeResponse(
+            200,
+            RolloutFailure(
+                rollout_id=collection.logical_rollout_id(row),
+                failure_kind="judge_failed",
+                stage="verifier",
+                failure_reason="Judge unavailable",
+            ).model_dump(),
+        )
+
+    install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    output = Path(runner_config.output_jsonl_fpath)
+    assert len(list(read_records(output))) == 1
+    failures = list(read_records(collection.failures_path_for(output)))
+    assert len(failures) == 2 and all("reward" not in row for row in failures)

--- a/tests/unit_tests/test_rollout_recovery.py
+++ b/tests/unit_tests/test_rollout_recovery.py
@@ -114,12 +114,19 @@ async def test_malformed_results_become_associated_failures(payload, monkeypatch
     assert "reward" not in outcome.model_dump()
 
 
-async def test_valid_zero_and_masked_completed_results_remain_results(monkeypatch):
-    for masked in (False, True):
-        result = {"reward": 0.0, "response": {}, "mask_sample": masked}
-        install_fake_server_client(monkeypatch, AsyncMock(return_value=FakeResponse(200, result)))
-        _, outcome = await next(RolloutCollectionHelper().run_outcomes([failing_row()]))
-        assert outcome is result
+@pytest.mark.parametrize("masked", [False, True])
+@pytest.mark.parametrize("failure_kind", [None, "verifier_error"])
+async def test_valid_zero_and_masked_completed_results_remain_results(monkeypatch, masked, failure_kind):
+    result = {
+        "reward": 0.0,
+        "response": {},
+        "mask_sample": masked,
+        "failure_kind": failure_kind,
+        "failure_reason": "Verifier degraded" if failure_kind else None,
+    }
+    install_fake_server_client(monkeypatch, AsyncMock(return_value=FakeResponse(200, result)))
+    _, outcome = await next(RolloutCollectionHelper().run_outcomes([failing_row()]))
+    assert outcome is result
 
 
 @pytest.mark.parametrize("wrong_identity", [None, "rollout_id", "attempt_index", "run_id"])
@@ -475,9 +482,19 @@ async def test_collected_judge_failure_can_be_reverified_without_inference(runne
     assert [call.kwargs["url_path"] for call in client.post.await_args_list].count("/verify") == 1
 
 
-async def test_runner_journals_before_request_and_resumes_only_failed_work(runner_config, monkeypatch):
+@pytest.mark.parametrize("count_failures_as_zero", [False, True])
+async def test_runner_journals_before_request_and_resumes_only_failed_work(
+    runner_config, monkeypatch, count_failures_as_zero
+):
     output = Path(runner_config.output_jsonl_fpath)
     calls = []
+    exported = []
+    runner_config.disable_aggregation = False
+    runner_config.upload_rollouts = False
+    runner_config.count_failure_classes_as_zero = ["agent_request_failed"] if count_failures_as_zero else []
+    monkeypatch.setattr(RolloutCollectionHelper, "_call_aggregate_metrics", AsyncMock(return_value=None))
+    monkeypatch.setattr(collection, "get_exporters", lambda: True)
+    monkeypatch.setattr(collection, "export_metrics", lambda metrics, **kwargs: exported.append(metrics))
 
     async def post(**kwargs):
         row = kwargs["json"]
@@ -493,13 +510,29 @@ async def test_runner_journals_before_request_and_resumes_only_failed_work(runne
                 200,
                 {"_ng_failure_class": "skipped", "_ng_failure_terminal": True, "reward": 0, "response": {}},
             )
-        return FakeResponse(200, {"reward": 0.0, "response": {}, "mask_sample": True})
+        return FakeResponse(
+            200,
+            {"reward": 0.0, "response": {}, "mask_sample": row["task"] == 0, "failure_kind": "verifier_error"},
+        )
 
     install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
     helper = RolloutCollectionHelper()
     await helper.run_from_config(runner_config)
     report = json.loads(coverage_path_for(output).read_text())
     assert [report[key] for key in ("successful", "failed", "intentionally_omitted", "unknown")] == [1, 1, 1, 0]
+    assert (report["measured"], report["masked"]) == (0, 1)
+    assert report["scored"] == 1 + int(count_failures_as_zero)
+    assert report["failures_counted_as_zero"] == int(count_failures_as_zero)
+    assert exported[-1] == {
+        "coverage/expected": 3,
+        "coverage/scored": report["scored"],
+        "coverage/missing": 3 - report["scored"],
+        "coverage/measured": 0,
+        "coverage/masked": 1,
+        "coverage/failed": 1,
+        "coverage/omitted": 1,
+        "coverage/unknown": 0,
+    }
     assert not report["complete"] and report["reconciled"]
     failures = list(read_records(collection.failures_path_for(output)))
     assert len(failures) == 2
@@ -513,6 +546,10 @@ async def test_runner_journals_before_request_and_resumes_only_failed_work(runne
     assert journal_path_for(output).read_bytes().startswith(original_history)
     report = json.loads(coverage_path_for(output).read_text())
     assert [report[key] for key in ("successful", "failed", "intentionally_omitted", "unknown")] == [2, 0, 1, 0]
+    assert (report["measured"], report["masked"], report["scored"], report["failures_counted_as_zero"]) == (1, 1, 2, 0)
+    assert sum(report[key] for key in ("measured", "masked", "failed", "intentionally_omitted", "unknown")) == 3
+    assert exported[-1]["coverage/measured"] == 1 and exported[-1]["coverage/masked"] == 1
+    assert exported[-1]["coverage/failed"] == 0
     assert len(list(read_records(collection.failures_path_for(output)))) == 2
 
 

--- a/tests/unit_tests/test_rollout_recovery.py
+++ b/tests/unit_tests/test_rollout_recovery.py
@@ -26,9 +26,16 @@ import pytest
 from pydantic import ValidationError
 
 import nemo_gym.rollout_collection as collection
+import nemo_gym.rollout_reverification as reverification
 from nemo_gym.config_types import ConfigError
 from nemo_gym.rollout_collection import RolloutCollectionConfig, RolloutCollectionHelper, _CompletedRollout
-from nemo_gym.rollout_journal import RolloutJournal, coverage_path_for, journal_path_for, read_records
+from nemo_gym.rollout_journal import (
+    RolloutJournal,
+    coverage_path_for,
+    journal_path_for,
+    logical_rollout_id,
+    read_records,
+)
 from nemo_gym.rollout_outcomes import RolloutFailure
 from nemo_gym.rollout_recovery import RunManifest, manifest_path_for, validate_resume
 from tests.unit_tests.test_rollout_collection import FakeResponse, failing_row, http_error, install_fake_server_client
@@ -256,6 +263,20 @@ def test_unknown_manifest_version_is_rejected_even_with_override(saved_manifest)
         validate_resume(path, None, materialized, allow_unsafe=True)
 
 
+def test_older_manifest_defaults_to_existing_attempt_selection_policy(saved_manifest):
+    _, _, _, _, _, saved, _ = saved_manifest
+    payload = saved.model_dump()
+    del payload["selection_policy"]
+    assert RunManifest.model_validate(payload).selection_policy == "latest_dispatched"
+
+
+def test_unknown_selection_policy_is_rejected_even_with_override(saved_manifest):
+    _, _, materialized, _, _, saved, path = saved_manifest
+    path.write_text(json.dumps(saved.model_dump() | {"selection_policy": "any_success"}))
+    with pytest.raises(ConfigError, match="Cannot read"):
+        validate_resume(path, None, materialized, allow_unsafe=True)
+
+
 @pytest.mark.parametrize("interruption", [asyncio.CancelledError, RuntimeError])
 async def test_interrupted_runner_closes_files_and_reuses_saved_zero(tmp_path, monkeypatch, interruption):
     monkeypatch.setattr(collection, "get_global_config_dict", lambda: {})
@@ -394,6 +415,66 @@ def runner_config(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.parametrize("route_failures", [False, True])
+async def test_collected_judge_failure_can_be_reverified_without_inference(runner_config, monkeypatch, route_failures):
+    runner_config.route_failures_to_sidecar = route_failures
+    generated_response = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "42"}]}]}
+
+    async def post(**kwargs):
+        row = kwargs["json"]
+        if kwargs["url_path"] == "/verify":
+            assert row["task"] == 1 and row["response"] == generated_response
+            return FakeResponse(200, {"reward": 1.0, "response": row["response"]})
+        assert kwargs["url_path"] == "/run"
+        if row["task"] == 1:
+            return FakeResponse(
+                200,
+                {
+                    "_ng_failure_class": "judge_failed",
+                    "failure_reason": "Judge unavailable",
+                    "reward": 0.0,
+                    "response": generated_response,
+                },
+            )
+        if row["task"] == 2:
+            return FakeResponse(200, {"_ng_failure_class": "agent_request_failed", "reward": 0, "response": {}})
+        return FakeResponse(200, {"reward": 0.0, "response": {"output": []}})
+
+    client = install_fake_server_client(monkeypatch, AsyncMock(side_effect=post))
+    await RolloutCollectionHelper().run_from_config(runner_config)
+    output = Path(runner_config.output_jsonl_fpath)
+    successes = list(read_records(output))
+    failures = {row["_ng_task_index"]: row for row in read_records(collection.failures_path_for(output))}
+    assert failures[1]["response"] == generated_response
+    assert "reward" not in failures[1]
+    assert "response" not in failures[2]
+    for row in failures.values():
+        failure = RolloutFailure.model_validate(row["_ng_failure_record"])
+        assert "response" not in failure.model_dump() and "reward" not in failure.model_dump()
+
+    # Exercise the real sidecar reader, materialized-input join, payload builder,
+    # verifier dispatch, and output writer; only the HTTP boundary is replaced.
+    monkeypatch.setattr(reverification, "setup_server_client", lambda: client)
+    monkeypatch.setattr(reverification, "_build_agent_to_resources_server_mapping", lambda _: {"my_agent": "rs"})
+    monkeypatch.setattr(reverification, "raise_for_status", collection.raise_for_status)
+    monkeypatch.setattr(reverification, "get_response_json", collection.get_response_json)
+    monkeypatch.setattr(reverification, "get_exporters", list)
+    config = reverification.RolloutReverificationConfig(
+        materialized_inputs_jsonl_fpath=str(runner_config.materialized_jsonl_fpath),
+        rollouts_jsonl_fpath=str(output),
+        output_jsonl_fpath=str(output.with_name("reverified.jsonl")),
+        judge_failed_only=True,
+        disable_aggregation=True,
+    )
+    returned = await reverification.RolloutReverificationHelper().run_from_config(config)
+    by_task = {row["_ng_task_index"]: row for row in returned}
+    assert by_task[0] == successes[0]
+    assert by_task[1]["reward"] == 1.0 and by_task[1]["response"] == generated_response
+    assert set(by_task) == {0, 1}
+    assert [call.kwargs["url_path"] for call in client.post.await_args_list].count("/run") == 3
+    assert [call.kwargs["url_path"] for call in client.post.await_args_list].count("/verify") == 1
+
+
 async def test_runner_journals_before_request_and_resumes_only_failed_work(runner_config, monkeypatch):
     output = Path(runner_config.output_jsonl_fpath)
     calls = []
@@ -402,7 +483,7 @@ async def test_runner_journals_before_request_and_resumes_only_failed_work(runne
         row = kwargs["json"]
         calls.append(row)
         history = RolloutJournal.load(output, RunManifest.model_validate_json(manifest_path_for(output).read_bytes()))
-        identity = collection.logical_rollout_id(row)
+        identity = logical_rollout_id(row)
         assert history.latest[identity] == row.get("_ng_attempt_index", 0)
         assert history.disposition(identity) == "unknown"
         if row["task"] == 1 and row.get("_ng_attempt_index", 0) == 0:
@@ -474,7 +555,7 @@ async def test_runner_accepts_explicit_failures_independently_of_exception_polic
         return FakeResponse(
             200,
             RolloutFailure(
-                rollout_id=collection.logical_rollout_id(row),
+                rollout_id=logical_rollout_id(row),
                 failure_kind="judge_failed",
                 stage="verifier",
                 failure_reason="Judge unavailable",

--- a/tests/unit_tests/test_rollout_recovery.py
+++ b/tests/unit_tests/test_rollout_recovery.py
@@ -580,8 +580,9 @@ async def test_runner_cancellation_closes_requests_before_return(runner_config, 
 
 
 @pytest.mark.parametrize("route_failures", [False, True])
+@pytest.mark.parametrize("legacy", [False, True])
 async def test_runner_accepts_explicit_failures_independently_of_exception_policy(
-    runner_config, monkeypatch, route_failures
+    runner_config, monkeypatch, route_failures, legacy
 ):
     runner_config.route_failures_to_sidecar = route_failures
 
@@ -589,6 +590,8 @@ async def test_runner_accepts_explicit_failures_independently_of_exception_polic
         row = kwargs["json"]
         if row["task"] == 0:
             return FakeResponse(200, {"reward": 0, "response": {}})
+        if legacy:
+            return FakeResponse(200, {"_ng_failure_class": "judge_failed", "error": "Judge unavailable"})
         return FakeResponse(
             200,
             RolloutFailure(
@@ -605,3 +608,6 @@ async def test_runner_accepts_explicit_failures_independently_of_exception_polic
     assert len(list(read_records(output))) == 1
     failures = list(read_records(collection.failures_path_for(output)))
     assert len(failures) == 2 and all("reward" not in row for row in failures)
+    for row in failures:
+        assert row["error"] == "Judge unavailable"
+        assert row["_ng_failure_message"] == row["_ng_failure_record"]["failure_reason"] == row["error"]

--- a/tests/unit_tests/test_rollout_store.py
+++ b/tests/unit_tests/test_rollout_store.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise artifact ownership and interruption at persistence boundaries."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import orjson
+import pytest
+
+import nemo_gym.rollout_store as persistence
+from nemo_gym.config_types import ConfigError
+from nemo_gym.path_utils import failures_path_for
+from nemo_gym.rollout_journal import RolloutJournal, journal_path_for, materialized_path_for, read_records
+from nemo_gym.rollout_recovery import RunManifest, manifest_path_for
+from nemo_gym.rollout_store import RolloutStore
+
+
+@pytest.fixture
+def prepared_run(tmp_path):
+    rows = [{"_ng_task_index": i, "_ng_rollout_index": 0, "agent_ref": {"name": "agent"}} for i in range(2)]
+    source = tmp_path / "source.jsonl"
+    source.write_bytes(b"".join(orjson.dumps(row) + b"\n" for row in rows))
+    prepare = Mock(side_effect=lambda: (rows, RunManifest.create(source, rows, {}, {})))
+    return tmp_path / "rollouts.jsonl", prepare
+
+
+def snapshot(output):
+    return {path.name: path.read_bytes() for path in output.parent.iterdir() if path.is_file()}
+
+
+@pytest.mark.parametrize("interruption", ["outcome_event", "fsync"])
+def test_flushed_payload_survives_interrupted_commit(prepared_run, monkeypatch, interruption):
+    output, prepare = prepared_run
+    store = RolloutStore.start_or_resume(output, prepare, resume=False)
+    original_event = RolloutJournal._event
+
+    def event(state, key, status, reason=None):
+        if status == "success":
+            # The payload must be visible even though its outcome event fails.
+            assert list(read_records(output)) == [result]
+            raise OSError("interrupted outcome event")
+        return original_event(state, key, status, reason)
+
+    def fsync(fd):
+        assert list(read_records(output)) == [result]
+        assert [row["status"] for row in read_records(journal_path_for(output))] == ["dispatched"]
+        raise OSError("interrupted fsync")
+
+    monkeypatch.setattr(RolloutJournal, "_event", event)
+    if interruption == "fsync":
+        monkeypatch.setattr(persistence, "os", SimpleNamespace(fsync=fsync))
+    with pytest.raises(OSError, match="interrupted"):
+        with store:
+            row = store.pending(3)[0]
+            store.record_dispatch(row)
+            result = row | {"reward": 0.0, "response": {}}
+            store.record_outcome(result, sync=interruption == "fsync")
+    before = snapshot(output)
+    recovered = RolloutStore.read(output)
+    assert recovered.selected("success") == [result]
+    assert [row["_ng_task_index"] for row in recovered.pending(3)] == [1]
+    assert recovered.coverage()["successful"] == 1
+    assert snapshot(output) == before
+
+
+def test_invalid_outcomes_are_rejected_before_appending_bytes(prepared_run):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False) as store:
+        row, undispatched = store.pending(3)
+        store.record_dispatch(row)
+        result = row | {"reward": 0.0, "response": {}}
+        store.record_outcome(result)
+        before = snapshot(output)
+        for invalid in (result | {"reward": 1.0}, undispatched | {"reward": 0.0, "response": {}}):
+            with pytest.raises(ConfigError, match="Conflicting outcomes|no dispatch"):
+                store.record_outcome(invalid)
+            assert snapshot(output) == before
+    assert RolloutStore.read(output).selected("success") == [result]
+
+
+def test_partial_open_failure_closes_files_and_allows_retry(prepared_run, monkeypatch):
+    output, prepare = prepared_run
+    store = RolloutStore.start_or_resume(output, prepare, resume=False)
+    original_open = Path.open
+    opened = []
+
+    def failing_open(path, *args, **kwargs):
+        if args and args[0] == "ab":
+            if path == failures_path_for(output):
+                raise OSError("cannot open sidecar")
+            file = original_open(path, *args, **kwargs)
+            opened.append(file)
+            return file
+        return original_open(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "open", failing_open)
+        with pytest.raises(OSError, match="cannot open sidecar"):
+            with store:
+                pytest.fail("The store must not open partially")
+    assert len(opened) == 2 and all(file.closed for file in opened)
+    with store:
+        row = store.pending(3)[0]
+        store.record_dispatch(row)
+        store.record_outcome(row | {"reward": 0.0, "response": {}})
+    assert RolloutStore.read(output).coverage()["successful"] == 1
+
+
+def test_store_requires_write_context_and_offline_reads_never_open_writers(prepared_run):
+    output, prepare = prepared_run
+    store = RolloutStore.start_or_resume(output, prepare, resume=False)
+    row = store.pending(3)[0]
+    with pytest.raises(RuntimeError, match="open store context"):
+        store.record_dispatch(row)
+    with store:
+        with pytest.raises(RuntimeError, match="already open"):
+            with store:
+                pytest.fail("Cannot open the same store twice")
+        store.record_dispatch(row)
+    before = snapshot(output)
+    reader = RolloutStore.read(output)
+    with pytest.raises(RuntimeError, match="read-only"):
+        with reader:
+            pytest.fail("Cannot write through an offline reader")
+    assert snapshot(output) == before
+    with pytest.raises(RuntimeError, match="open store context"):
+        store.record_outcome(row | {"reward": 0.0, "response": {}})
+
+
+def test_recovery_and_offline_selection_use_the_newest_dispatch(prepared_run):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False) as store:
+        original = store.pending(3)[0]
+        store.record_dispatch(original)
+        store.record_dispatch(original | {"_ng_attempt_index": 1})
+        store.record_outcome(original | {"reward": 1.0, "response": {}})
+        assert store.selected("success") == []
+    before = snapshot(output)
+    offline = RolloutStore.read(output)
+    assert offline.selected("success") == []
+    assert offline.coverage()["selection_policy"] == "latest_dispatched"
+    assert snapshot(output) == before
+    with RolloutStore.start_or_resume(output, prepare, resume=True) as resumed:
+        assert resumed.coverage() == offline.coverage()
+        assert resumed.pending(3) == offline.pending(3)
+        assert resumed.pending(3)[0]["_ng_attempt_index"] == 2
+        retry = resumed.pending(3)[0]
+        resumed.record_dispatch(retry)
+        resumed.record_outcome(retry | {"reward": 0.0, "response": {}})
+    assert [row["reward"] for row in RolloutStore.read(output).selected("success")] == [0.0]
+    assert len(list(read_records(output))) == 2
+
+
+def test_legacy_import_preserves_artifacts_and_does_not_require_original_source(prepared_run):
+    output, prepare = prepared_run
+    rows, _ = prepare()
+    materialized_path_for(output).write_bytes(b"".join(orjson.dumps(row) + b"\n" for row in rows))
+    old_result = rows[0] | {"reward": 0.0, "response": {}}
+    output.write_bytes(orjson.dumps(old_result) + b"\n")
+    prepare.reset_mock()
+    prepare.side_effect = AssertionError("Original dataset no longer exists")
+    original = output.read_bytes()
+    before = snapshot(output)
+    assert RolloutStore.read(output).coverage()["successful"] == 1
+    assert snapshot(output) == before
+    with pytest.warns(UserWarning, match="allow_unsafe_resume"):
+        store = RolloutStore.start_or_resume(output, prepare, resume=True, allow_unsafe=True)
+    prepare.assert_not_called()
+    with store:
+        assert [row["_ng_task_index"] for row in store.pending(3)] == [1]
+        assert not store.coverage()["identity_verified"]
+        row = store.pending(3)[0]
+        store.record_dispatch(row)
+        store.record_outcome(row | {"reward": 1.0, "response": {}})
+    assert output.read_bytes().startswith(original)
+    assert RolloutStore.read(output).coverage()["complete"]
+    assert RunManifest.model_validate_json(manifest_path_for(output).read_bytes()).legacy_import
+
+
+def test_legacy_file_without_inventory_has_unknown_coverage(tmp_path):
+    output = tmp_path / "legacy.jsonl"
+    output.write_bytes(b'{"reward":0.0,"response":{}}\n')
+    assert RolloutStore.read(output) is None
+
+
+@pytest.mark.parametrize("missing", ["output", "materialized", "journal"])
+def test_resume_rejects_missing_artifacts_before_changing_saved_work(prepared_run, missing):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False) as store:
+        row = store.pending(3)[0]
+        store.record_dispatch(row)
+        store.record_outcome(row | {"reward": 0.0, "response": {}})
+    paths = {"output": output, "materialized": materialized_path_for(output), "journal": journal_path_for(output)}
+    paths[missing].unlink()
+    before = snapshot(output)
+    with pytest.raises(ConfigError, match="missing|without attempt history"):
+        RolloutStore.start_or_resume(output, prepare, resume=True)
+    assert snapshot(output) == before
+
+
+def test_missing_current_source_requires_visible_identity_override(prepared_run):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False) as store:
+        row = store.pending(3)[0]
+        store.record_dispatch(row)
+        result = row | {"reward": 0.0, "response": {}}
+        store.record_outcome(result)
+    before = snapshot(output)
+    prepare.side_effect = FileNotFoundError("Original source was removed")
+    with pytest.raises(FileNotFoundError, match="Original source was removed"):
+        RolloutStore.start_or_resume(output, prepare, resume=True)
+    assert snapshot(output) == before
+    with pytest.warns(UserWarning, match="allow_unsafe_resume"):
+        resumed = RolloutStore.start_or_resume(output, prepare, resume=True, allow_unsafe=True)
+    assert resumed.selected("success") == [result]
+    assert not resumed.coverage()["identity_verified"]
+    assert resumed.manifest.run_id == store.manifest.run_id
+    saved = RunManifest.model_validate_json(manifest_path_for(output).read_bytes())
+    assert saved.identity_overridden

--- a/tests/unit_tests/test_rollout_store.py
+++ b/tests/unit_tests/test_rollout_store.py
@@ -26,7 +26,7 @@ import nemo_gym.rollout_store as persistence
 from nemo_gym.config_types import ConfigError
 from nemo_gym.path_utils import failures_path_for
 from nemo_gym.rollout_journal import RolloutJournal, journal_path_for, materialized_path_for, read_records
-from nemo_gym.rollout_recovery import RunManifest, manifest_path_for
+from nemo_gym.rollout_recovery import RunManifest, atomic_write_json, manifest_path_for
 from nemo_gym.rollout_store import RolloutStore
 
 
@@ -196,6 +196,134 @@ def test_legacy_file_without_inventory_has_unknown_coverage(tmp_path):
     output = tmp_path / "legacy.jsonl"
     output.write_bytes(b'{"reward":0.0,"response":{}}\n')
     assert RolloutStore.read(output) is None
+
+
+def test_prepared_but_never_opened_run_can_resume(prepared_run):
+    output, prepare = prepared_run
+    abandoned = RolloutStore.start_or_resume(output, prepare, resume=False)
+    with RolloutStore.start_or_resume(output, prepare, resume=True) as resumed:
+        assert resumed.manifest.run_id == abandoned.manifest.run_id
+        assert resumed.pending(3) == abandoned.pending(3)
+        assert resumed.coverage()["attempts"] == 0
+        for row in resumed.pending(3):
+            resumed.record_dispatch(row)
+            resumed.record_outcome(row | {"reward": 0.0, "response": {}})
+    assert RolloutStore.read(output).coverage()["complete"]
+
+
+@pytest.mark.parametrize("missing", [("journal",), ("manifest",), ("manifest", "journal")])
+def test_unsafe_recovery_rebuilds_own_artifacts_without_relabeling(prepared_run, missing):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False) as original:
+        row = original.pending(3)[0]
+        original.record_dispatch(row)
+        result = row | {"reward": 0.0, "response": {}}
+        original.record_outcome(result)
+    paths = {"journal": journal_path_for(output), "manifest": manifest_path_for(output)}
+    for name in missing:
+        paths[name].unlink()
+    saved_output = output.read_bytes()
+    with pytest.raises(ConfigError):
+        RolloutStore.start_or_resume(output, prepare, resume=True)
+    with pytest.warns(UserWarning, match="allow_unsafe_resume"):
+        resumed = RolloutStore.start_or_resume(output, prepare, resume=True, allow_unsafe=True)
+    with resumed:
+        assert resumed.manifest.run_id == original.manifest.run_id
+        assert resumed.selected("success") == [result]
+        assert [row["_ng_task_index"] for row in resumed.pending(3)] == [1]
+        assert not resumed.coverage()["identity_verified"]
+        pending = resumed.pending(3)[0]
+        resumed.record_dispatch(pending)
+        resumed.record_outcome(pending | {"reward": 1.0, "response": {}})
+    assert output.read_bytes().startswith(saved_output)
+    assert RolloutStore.read(output).coverage()["complete"]
+
+
+@pytest.mark.parametrize("remove_manifest", [False, True])
+def test_unsafe_import_rejects_foreign_run_mixtures(prepared_run, remove_manifest):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False) as store:
+        for row in store.pending(3):
+            store.record_dispatch(row)
+            store.record_outcome(row | {"reward": 0.0, "response": {}})
+    records = list(read_records(output))
+    records[1]["_ng_run_id"] = "foreign"
+    output.write_bytes(b"".join(orjson.dumps(row) + b"\n" for row in records))
+    journal_path_for(output).unlink()
+    if remove_manifest:
+        manifest_path_for(output).unlink()
+    before = snapshot(output)
+    with pytest.raises(ConfigError, match="different run"):
+        RolloutStore.start_or_resume(output, prepare, resume=True, allow_unsafe=True)
+    assert snapshot(output) == before
+
+
+def test_legacy_conflicting_attempts_and_failure_in_main_remain_readable(prepared_run):
+    output, prepare = prepared_run
+    rows, _ = prepare()
+    materialized_path_for(output).write_bytes(b"".join(orjson.dumps(row) + b"\n" for row in rows))
+    failure = rows[0] | {"_ng_attempt_index": 0, "_ng_failure_class": "judge_failed"}
+    result = rows[0] | {"_ng_attempt_index": 0, "reward": 1.0, "response": {}}
+    output.write_bytes(orjson.dumps(failure) + b"\n" + orjson.dumps(result) + b"\n")
+    before = snapshot(output)
+    store = RolloutStore.read(output)
+    assert store.selected("success") == [result | {"_ng_attempt_index": 1}]
+    assert store.coverage()["attempts"] == 2
+    assert snapshot(output) == before
+
+
+def test_atomic_metadata_preserves_sharing_permissions(tmp_path):
+    ordinary = tmp_path / "ordinary.json"
+    ordinary.write_text("{}")
+    output = tmp_path / "metadata.json"
+    atomic_write_json(output, {"generation": 1})
+    assert output.stat().st_mode & 0o777 == ordinary.stat().st_mode & 0o777
+    output.chmod(0o640)
+    atomic_write_json(output, {"generation": 2})
+    assert output.stat().st_mode & 0o777 == 0o640
+    assert orjson.loads(output.read_bytes()) == {"generation": 2}
+
+
+def test_failed_atomic_publication_keeps_prior_metadata(tmp_path, monkeypatch):
+    output = tmp_path / "metadata.json"
+    atomic_write_json(output, {"generation": 1})
+    before = output.read_bytes()
+
+    def interrupted_replace(*args):
+        raise OSError("interrupted publication")
+
+    monkeypatch.setattr(Path, "replace", interrupted_replace)
+    with pytest.raises(OSError, match="interrupted publication"):
+        atomic_write_json(output, {"generation": 2})
+    assert output.read_bytes() == before
+    assert list(tmp_path.iterdir()) == [output]
+
+
+def test_reverification_rejects_changed_inputs_before_dispatch(prepared_run):
+    output, prepare = prepared_run
+    with RolloutStore.start_or_resume(output, prepare, resume=False):
+        pass
+    writer = RolloutStore.append_existing(output)
+    before = snapshot(output)
+    rows, _ = prepare()
+    for invalid in (rows[0] | {"_ng_task_index": 999}, rows[0] | {"agent_ref": {"name": "other"}}):
+        with pytest.raises(ConfigError, match="Reverification input"):
+            writer.for_reverification([invalid | {"response": {}}])
+    assert snapshot(output) == before
+    journal_path_for(output).unlink()
+    with pytest.raises(ConfigError, match="without attempt history"):
+        RolloutStore.append_existing(output)
+
+
+def test_reverification_overwrite_preserves_existing_run(prepared_run):
+    from nemo_gym.rollout_reverification import _prepare_output_fpaths
+
+    output, prepare = prepared_run
+    RolloutStore.start_or_resume(output, prepare, resume=False)
+    before = snapshot(output)
+    with pytest.raises(ConfigError, match="Cannot overwrite a journal-backed run"):
+        _prepare_output_fpaths("", str(output), False, True, False)
+    assert snapshot(output) == before
 
 
 @pytest.mark.parametrize("missing", ["output", "materialized", "journal"])


### PR DESCRIPTION
## What does this PR do?

Adds typed rollout failures and resumable evaluation attempts in Gym's evaluation runner, addressing the failure-recording and evaluation-recovery parts of #2135. After an interruption, completed rollouts are retained and eligible unfinished work is retried from its original input. If generation succeeded but judging failed, judge-only reverification can reuse the saved answer without another policy call.

- **Failure contract and compatibility:** Add serializable `RolloutFailure` outcomes through opt-in `run_outcomes()`, preserving the existing `run_examples()` interface and completed-result dictionaries. Failures have no fabricated rewards or generation placeholders; sidecars retain diagnostic trajectories, capture evidence, and legacy aliases.
- **Durable recovery:** `RolloutStore` owns manifests, input identity, dispatch/outcome journals, legacy import, and interrupted-write recovery. Dispatch events are flushed before requests and payloads before outcome events. Each retry gets a new attempt index; late results from older attempts cannot supersede newer work. Resume validates task/configuration identity while excluding known operational credentials and endpoints.
- **Bounded retries:** Collection and appended reverification respect terminal failures and attempt budgets. Exhausted counts, the current cap, attempt numbers, and diagnostic artifact paths are visible in coverage and logs. Reported `kill_shaped` failures consume attempts, including when a legacy producer requests suppression.
- **Consistent coverage and aggregation:** Online collection and offline aggregation select the same attempts and distinguish measured, masked, failed, omitted, and unknown work. Masked results remain completed for resume; explicit failure-as-zero scoring stays separate from completion coverage. Equivalent paths and symlinks are deduplicated.
- **Judge-only recovery:** Reverification uses saved responses from the selected attempts, reports/skips failures without an answer, and journals new attempts when appending to the original run. Saved answers can retain reconstructed token IDs while remaining rewardless until judging succeeds.

### Boundaries and compatibility

Recovery restarts a rollout from its input; it does not restore a conversation or remote sandbox state. Each output path has one writer. Disabling failure routing retains fail-fast behavior, and invalid rollout identity is rejected before dispatch.

Legacy append/reverify artifacts remain readable line by line when no manifest or journal exists, including inventories with repeated explicit rollout IDs. Partial legacy caches restart from current inputs only when no manifest or journal exists; journal-backed runs retain strict validation. Explicit unsafe recovery can reconstruct missing dispatch history from saved outcomes while still rejecting foreign-run records, conflicts, and corruption. Dispatches lost without saved payloads cannot be reconstructed, so recovered attempt counts are lower bounds. Separate legacy files with identical inventories remain distinct; callers must exclude copied legacy runs stored at different locations. Operational identity exclusions cover known fields and authentication headers, not arbitrary custom configuration names.

Builds on merged #3213 and includes main through `dbd26a976`, including the completed-result schema/quality policy from #2611 and the equivalence-judge failure handling from #3538. Producer migration (#3180), automatic group recovery, remote cleanup, and transport replay policy remain separate work.

The review follow-up incorporates Giulio's regression tests from #3522. Collection, merged/non-merged aggregation, and standalone health checks now inspect the store's selected completed attempts; superseded successes do not appear in health reports. Judge-only reverification retains the saved canonical trajectory and its health findings. The merge with main preserves the separate ATIF validation and failure-persistence behavior introduced by #2737.

The merge with #2611 preserves its masked/unmasked progress metrics and uses the store’s persisted dispositions for failure/omission counts. Terminal skips remain omissions; kill-shaped outcomes remain bounded failures. Agents with no successful outcomes still publish failure counts. Both parents’ collection tests are retained.

## Validation

- Final head `0322683aa` includes main through `dbd26a976`. Merge-specific regression checks: **7 passed, 87 deselected in 20.40s**. These exercise the collector, saved coverage, and exported progress for masked results, typed/legacy failures, terminal skips, kill-shaped failures, and suppressed results.
- Focused recovery, journal/store, collection, health, ATIF/reverification, CLI, masking/aggregation, OpenAI-client, and judge suites: **1380 passed, 107 warnings in 101.01s (0:01:41)**.
- Equivalence-judge and OpenAI-model server tests: **65 passed, 1 warning in 12.73s**. This includes the upstream #3538 behavior alongside the merged recovery code.
- Full local core selection (`tests/unit_tests/ -m 'not sandbox'`): **3 failed, 4769 passed, 102 skipped, 654 deselected, 113 warnings, 184 subtests passed in 207.62s (0:03:27)**. The three failures remain the previously reproduced local Python 3.14.5 / hydra-core 1.3.6 CLI-help issue (`LazyCompletionHelp` / `badly formed help string`); they are not failures in the merged recovery/masking paths. Validation ran on a four-CPU, 24-GiB allocation; no GPU/model serving was required for these checks.
- All-files pre-commit and `git diff --check` passed on the final files. The merge commit has DCO sign-off.
- CI for this new head is pending. [The preceding head `f5b388bea` passed core tests and all eight server shards](https://github.com/NVIDIA-NeMo/Gym/actions/runs/35355227790); that run does not validate the new merge.
- Real-model recovery validation was performed on earlier head `67aa8fc7c`, using Qwen2.5-0.5B-Instruct Q4_K_M with llama.cpp on CPU and the FrontierScience example. Killing the collector after two saved successes resumed to 10/10 results. A judge HTTP outage preserved five answers; reverification recovered all five with zero additional policy calls and was idempotent. Online/offline metrics matched. No real-model rerun in this follow-up: this conflict resolution changes collector telemetry and preserves the upstream verifier implementation; the affected paths are covered by the integration tests above. The earlier run did not validate judge accuracy, Hydra CLI parsing, or Ray/server-launch orchestration.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; related follow-up work is identified above.
- [x] Tests added or updated: all focused and affected server checks pass; the broader local environment limitation is documented above.
- [ ] Applicable unit/server validation passes in CI on the current head (new run pending).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`).
- [x] All commits have DCO sign-off (`git commit -s`).
