### PR TITLE
fix(genrm_compare): surface GenRM output-budget exhaustion (empty verdict) instead of a generic parse failure

### DIFF
--- a/resources_servers/genrm_compare/app.py
+++ b/resources_servers/genrm_compare/app.py
@@ -61,6 +61,26 @@ from resources_servers.genrm_compare.utils import (
 
 logger = logging.getLogger(__name__)
 
+
+def _is_output_budget_exhausted(raw_response: Dict[str, Any]) -> bool:
+    """True if a Responses API object was cut off by max_output_tokens.
+
+    Gym's chat->Responses conversion sets status="incomplete" with
+    incomplete_details.reason="max_output_tokens" when the model returned finish_reason="length".
+    """
+    if not isinstance(raw_response, dict) or raw_response.get("status") != "incomplete":
+        return False
+    details = raw_response.get("incomplete_details") or {}
+    return isinstance(details, dict) and details.get("reason") == "max_output_tokens"
+
+
+def _escalate_output_budget(current: Optional[int], multiplier: float, cap: int) -> Optional[int]:
+    """Next max_output_tokens to try after a budget-exhausted response (never above cap)."""
+    if current is None or multiplier <= 1.0 or current >= cap:
+        return current
+    return min(int(current * multiplier), cap)
+
+
 # Cohort state for verify(): buffer by prompt_key until num_rollouts_per_prompt received (Difference 1)
 _cohort_lock: asyncio.Lock = asyncio.Lock()
 _cohort_buffers: Dict[str, List[Tuple[Any, asyncio.Future]]] = defaultdict(list)
@@ -87,6 +107,12 @@ class GenRMCompareConfig(BaseResourcesServerConfig):
         debug_logging: Enable verbose logging for debugging
         genrm_parse_retries: Number of retries on parse failures
         genrm_parse_retry_sleep_s: Sleep duration between parse retries
+        genrm_budget_exhausted_retry_multiplier: When the GenRM response is `incomplete` because
+            `max_output_tokens` was reached (reasoning consumed the whole budget and no verdict was
+            emitted), multiply max_output_tokens by this factor on each retry. Default 1.0 = off:
+            measured against a hosted GenRM, runaway reasoning did not converge even at 3x the
+            budget, so escalation mostly burns engine time. Enable only if your prompts converge.
+        genrm_max_output_tokens_cap: Upper bound for the escalated max_output_tokens
         use_principle: Enable principle-based comparison
         default_principle: Default principle when none provided in request
     """
@@ -142,6 +168,8 @@ class GenRMCompareConfig(BaseResourcesServerConfig):
     # Retry config for parse failures
     genrm_parse_retries: int = 3
     genrm_parse_retry_sleep_s: float = 0.2
+    genrm_budget_exhausted_retry_multiplier: float = 1.0
+    genrm_max_output_tokens_cap: int = 65536
 
 
 class GenRMCompareVerifyRequest(BaseVerifyRequest):
@@ -490,6 +518,7 @@ class GenRMCompareResourcesServer(SimpleResourcesServer):
 
                 # Extract output_text from GenRM response (skip reasoning, only parse the final JSON scores)
                 genrm_answer = extract_output_text(raw_response)
+                budget_exhausted = _is_output_budget_exhausted(raw_response)
 
                 try:
                     score_1, score_2, ranking = parse_genrm_output(
@@ -501,13 +530,38 @@ class GenRMCompareResourcesServer(SimpleResourcesServer):
                     return score_1, score_2, ranking
 
                 except GenRMOutputParseError:
+                    current_budget = responses_create_params.max_output_tokens
+                    if budget_exhausted:
+                        # The model hit max_output_tokens before writing the verdict (typically the
+                        # reasoning consumed the whole budget). Retrying with the same budget mostly
+                        # reproduces the same outcome, so escalate it.
+                        logger.warning(
+                            f"[GenRM] Output budget exhausted for pair {pair_idx} "
+                            f"(attempt {attempt_idx + 1}/{max_attempts}, max_output_tokens={current_budget}): "
+                            f"response is incomplete (reason=max_output_tokens) and contains no verdict."
+                        )
+                        if attempt_idx < max_attempts - 1:
+                            escalated = _escalate_output_budget(
+                                current_budget,
+                                cfg.genrm_budget_exhausted_retry_multiplier,
+                                cfg.genrm_max_output_tokens_cap,
+                            )
+                            if escalated != current_budget:
+                                logger.info(f"[GenRM] Retrying pair {pair_idx} with max_output_tokens={escalated}")
+                                responses_create_params.max_output_tokens = escalated
+
                     if attempt_idx < max_attempts - 1:
                         await asyncio.sleep(float(cfg.genrm_parse_retry_sleep_s))
                         continue
 
                     # Give up: fall back to defaults
+                    cause = (
+                        f"output budget exhausted at max_output_tokens={current_budget}"
+                        if budget_exhausted
+                        else "output could not be parsed"
+                    )
                     logger.warning(
-                        f"[GenRM] Parse failed for pair {pair_idx} after {max_attempts} attempts; "
+                        f"[GenRM] Parse failed for pair {pair_idx} after {max_attempts} attempts ({cause}); "
                         f"falling back to defaults."
                     )
                     return cfg.default_score, cfg.default_score, cfg.default_ranking

--- a/resources_servers/genrm_compare/tests/test_app.py
+++ b/resources_servers/genrm_compare/tests/test_app.py
@@ -405,6 +405,108 @@ class TestRunSingleComparison:
         call_kwargs = mock_server_client.post.call_args.kwargs
         return call_kwargs["json"]
 
+    @staticmethod
+    def _incomplete_response(reasoning_only: bool = True):
+        """A Responses API object cut off by max_output_tokens: reasoning present, no verdict text."""
+        output = [{"type": "reasoning", "summary": [], "content": [{"type": "reasoning_text", "text": "thinking..."}]}]
+        if not reasoning_only:
+            output.append({"type": "message", "content": [{"type": "output_text", "text": ""}]})
+        return {"status": "incomplete", "incomplete_details": {"reason": "max_output_tokens"}, "output": output}
+
+    @staticmethod
+    def _complete_response(text='{"score_1": 4, "score_2": 2, "ranking": 2}'):
+        return {
+            "status": "completed",
+            "output": [{"type": "message", "content": [{"type": "output_text", "text": text}]}],
+        }
+
+    def test_budget_exhausted_escalates_max_output_tokens_and_recovers(self):
+        """incomplete/max_output_tokens -> retry with a larger budget -> parsed verdict returned."""
+        server, mock_client = self._make_server()
+        server.config.genrm_parse_retries = 2
+        server.config.genrm_parse_retry_sleep_s = 0.0
+        server.config.genrm_budget_exhausted_retry_multiplier = 2.0
+        server.config.genrm_max_output_tokens_cap = 65536
+        bodies = [self._incomplete_response(), self._incomplete_response(), self._complete_response()]
+        budgets = []
+
+        async def fake_post(**kwargs):
+            budgets.append(kwargs["json"].max_output_tokens)  # capture at call time; the params object is mutated
+            resp = AsyncMock()
+            resp.json = AsyncMock(return_value=bodies[len(budgets) - 1])
+            return resp
+
+        mock_client.post = AsyncMock(side_effect=fake_post)
+
+        result = asyncio.run(
+            server._run_single_comparison(
+                [{"role": "user", "content": "q"}], self._make_response_obj("a"), self._make_response_obj("b")
+            )
+        )
+
+        assert result == (4.0, 2.0, 2.0)
+        assert budgets == [1024, 2048, 4096]
+
+    def test_budget_escalation_respects_cap(self):
+        server, mock_client = self._make_server()
+        server.config.genrm_parse_retries = 3
+        server.config.genrm_parse_retry_sleep_s = 0.0
+        server.config.genrm_budget_exhausted_retry_multiplier = 4.0
+        server.config.genrm_max_output_tokens_cap = 3000
+        budgets = []
+
+        async def fake_post(**kwargs):
+            budgets.append(kwargs["json"].max_output_tokens)
+            resp = AsyncMock()
+            resp.json = AsyncMock(return_value=self._incomplete_response())
+            return resp
+
+        mock_client.post = AsyncMock(side_effect=fake_post)
+
+        result = asyncio.run(
+            server._run_single_comparison(
+                [{"role": "user", "content": "q"}], self._make_response_obj("a"), self._make_response_obj("b")
+            )
+        )
+
+        # every attempt exhausted -> defaults; budget escalated once to the cap and then held there
+        assert result == (server.config.default_score, server.config.default_score, server.config.default_ranking)
+        assert budgets == [1024, 3000, 3000, 3000]
+
+    def test_plain_parse_failure_does_not_escalate_budget(self):
+        """A completed-but-unparseable response keeps the original budget on retry."""
+        server, mock_client = self._make_server()
+        server.config.genrm_parse_retries = 1
+        server.config.genrm_parse_retry_sleep_s = 0.0
+        mock_http_response = AsyncMock()
+        mock_http_response.json = AsyncMock(return_value=self._complete_response(text="no json here"))
+        mock_client.post = AsyncMock(return_value=mock_http_response)
+
+        asyncio.run(
+            server._run_single_comparison(
+                [{"role": "user", "content": "q"}], self._make_response_obj("a"), self._make_response_obj("b")
+            )
+        )
+        budgets = [call.kwargs["json"].max_output_tokens for call in mock_client.post.call_args_list]
+        assert budgets == [1024, 1024]
+
+    def test_escalation_off_by_default(self):
+        """Default multiplier is 1.0: budget exhaustion is logged but the budget is not raised."""
+        server, mock_client = self._make_server()
+        assert server.config.genrm_budget_exhausted_retry_multiplier == 1.0
+        server.config.genrm_parse_retries = 1
+        server.config.genrm_parse_retry_sleep_s = 0.0
+        mock_http_response = AsyncMock()
+        mock_http_response.json = AsyncMock(return_value=self._incomplete_response())
+        mock_client.post = AsyncMock(return_value=mock_http_response)
+        asyncio.run(
+            server._run_single_comparison(
+                [{"role": "user", "content": "q"}], self._make_response_obj("a"), self._make_response_obj("b")
+            )
+        )
+        budgets = [call.kwargs["json"].max_output_tokens for call in mock_client.post.call_args_list]
+        assert budgets == [1024, 1024]
+
     def test_responses_passed_via_metadata_not_input(self):
         """response_1 and response_2 are sent in metadata, not appended to input."""
         server, mock_client = self._make_server(use_principle=False)


### PR DESCRIPTION
## What does this PR do?

Makes GenRM output-budget exhaustion visible and distinguishable from a real parse failure in `resources_servers/genrm_compare`. Default behaviour is unchanged apart from the log lines.

## Why

When the GenRM model spends its whole `max_output_tokens` on reasoning, the model server returns **HTTP 200 with a complete envelope and an empty final message**: `status: "incomplete"`, `incomplete_details.reason: "max_output_tokens"`. There is no verdict JSON, so `parse_genrm_output` fails, the server retries with the same budget, and after `genrm_parse_retries` attempts it silently assigns `default_score` / `default_ranking`. The only trace is a generic `[GenRM] Parse failed ... falling back to defaults` warning, which hides the cause.

Measured against a hosted GenRM endpoint with the candidates delivered as `response_1`/`response_2` roles (the same request shape the `genrm_model` server produces), temperature 0.6, same input each time:

| `max_output_tokens` | runs | verdict (`status: completed`) | exhausted (`status: incomplete`, `reason: max_output_tokens`, empty message) |
|---|---|---|---|
| 16,384 | 5 | 2 | 3 |
| 24,576 | 4 | 2 | 2 |

The exhausted responses look like this (reasoning omitted):

```json
{"status": "incomplete", "incomplete_details": {"reason": "max_output_tokens"},
 "usage": {"output_tokens": 16384},
 "output": [{"type": "message", "status": "incomplete", "content": []}]}
```

The outcome is bimodal: the same input either converges at roughly 8 to 10k output tokens or runs away and consumes whatever budget it is given, so a larger budget does not change the odds while a resample often does.

## How

- `_is_output_budget_exhausted(raw_response)`: true when the Responses object is `incomplete` with reason `max_output_tokens`.
- On a parse failure for such a response, log `[GenRM] Output budget exhausted for pair ... (max_output_tokens=N)` per attempt, and name the cause in the final fallback warning.
- Opt-in escalation: `genrm_budget_exhausted_retry_multiplier` (default **1.0 = off**) multiplies `max_output_tokens` on retries after exhaustion, capped by `genrm_max_output_tokens_cap` (65,536). Off by default because exhaustion on these inputs is bimodal at temperature 0.6 (converges at ~8–10k tokens or runs away and consumes any budget: 4/4 still exhausted at 49,152), so the existing same-budget retry is the right handler and a bigger budget mostly adds engine time.
- Tests: recovery via escalation, cap behaviour, no escalation on ordinary parse failures, escalation off by default. `resources_servers/genrm_compare/tests`: 63 passed.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally (`resources_servers/genrm_compare/tests`, 63 passed).
- [x] Pre-commit checks pass locally (`pre-commit run --files ...`: all Passed).
- [x] All commits have DCO sign-off (`git commit -s`).

