### PR TITLE
Track SciCode token usage per problem and subproblem

### DIFF
--- a/resources_servers/scicode/app.py
+++ b/resources_servers/scicode/app.py
@@ -65,6 +65,10 @@ class ScicodeVerifyRequest(ScicodeRunRequest, BaseVerifyRequest):
 
 
 class ScicodeVerifyResponse(BaseVerifyResponse):
+    # Retain the agent's compact accounting records through verification. None
+    # distinguishes historical final-step-only rollouts from whole-problem usage.
+    token_usage_version: Optional[str] = None
+    step_usage: Optional[List[dict]] = None
     # Declared so it survives into the rollout output (identifies the problem); the request's
     # sub_steps/solutions are intentionally not carried through to keep rollout rows small.
     problem_id: str = ""

--- a/resources_servers/scicode/app.py
+++ b/resources_servers/scicode/app.py
@@ -67,7 +67,7 @@ class ScicodeVerifyRequest(ScicodeRunRequest, BaseVerifyRequest):
 class ScicodeVerifyResponse(BaseVerifyResponse):
     # Retain the agent's compact accounting records through verification. None
     # distinguishes historical final-step-only rollouts from whole-problem usage.
-    token_usage_version: Optional[str] = None
+    token_usage_version: Optional[int] = None
     step_usage: Optional[List[dict]] = None
     # Declared so it survives into the rollout output (identifies the problem); the request's
     # sub_steps/solutions are intentionally not carried through to keep rollout rows small.

--- a/resources_servers/scicode/tests/test_app.py
+++ b/resources_servers/scicode/tests/test_app.py
@@ -110,6 +110,25 @@ def test_run_substep_timeout():
 # server
 # ----------------------------
 class TestApp:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("has_solution", [False, True])
+    async def test_verify_preserves_step_usage(self, has_solution):
+        request_json = _request(solutions={"1.1": "a"} if has_solution else None).model_dump()
+        request_json["token_usage_version"] = "scicode-v1"
+        request_json["step_usage"] = [
+            {
+                "step_number": "1.1",
+                "status": "generated" if has_solution else "skipped",
+                "usage": None,
+            }
+        ]
+        request = ScicodeVerifyRequest.model_validate(request_json)
+        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_substep(passed=True):
+            result = (await _server(h5.name).verify(request)).model_dump()
+        assert result["token_usage_version"] == "scicode-v1"
+        assert result["step_usage"] == request_json["step_usage"]
+        assert result["reward"] == float(has_solution)
+
     def test_sanity(self):
         _server()
 

--- a/resources_servers/scicode/tests/test_app.py
+++ b/resources_servers/scicode/tests/test_app.py
@@ -114,7 +114,7 @@ class TestApp:
     @pytest.mark.parametrize("has_solution", [False, True])
     async def test_verify_preserves_step_usage(self, has_solution):
         request_json = _request(solutions={"1.1": "a"} if has_solution else None).model_dump()
-        request_json["token_usage_version"] = "scicode-v1"
+        request_json["token_usage_version"] = 1
         request_json["step_usage"] = [
             {
                 "step_number": "1.1",
@@ -125,7 +125,7 @@ class TestApp:
         request = ScicodeVerifyRequest.model_validate(request_json)
         with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_substep(passed=True):
             result = (await _server(h5.name).verify(request)).model_dump()
-        assert result["token_usage_version"] == "scicode-v1"
+        assert result["token_usage_version"] == 1
         assert result["step_usage"] == request_json["step_usage"]
         assert result["reward"] == float(has_solution)
 

--- a/responses_api_agents/scicode_agent/README.md
+++ b/responses_api_agents/scicode_agent/README.md
@@ -11,70 +11,36 @@ rollouts) via `compute_metrics` / `get_key_metrics` — these live on the agent 
 
 ## Token statistics
 
-Each rollout records `response.usage` summed across all generated sub-steps in that
-problem attempt. Output tokens include the provider's reported reasoning tokens;
-input tokens include prior-step code sent again as context. The response text remains
-the final step's generation.
+`response.usage` sums usage across the problem's sub-steps; response text remains
+the final generation. Output includes reported reasoning tokens, and input includes
+prior-step code sent again as context.
 
-The agent exposes six headline metrics in `key_metrics`:
+For each of `input`, `output`, and `total`, `key_metrics` exposes:
 
 | Metric | Definition |
 | --- | --- |
-| `mean/input_tokens_per_problem` | Total input tokens / problem attempts (also `mean/input_tokens`) |
-| `mean/output_tokens_per_problem` | Total output tokens / problem attempts (also `mean/output_tokens`) |
-| `mean/total_tokens_per_problem` | Total input + output tokens / problem attempts (also `mean/total_tokens`) |
-| `mean/input_tokens_per_subproblem` | Total input tokens / benchmark sub-step count across attempts, excluding prefilled steps |
-| `mean/output_tokens_per_subproblem` | Total output tokens / benchmark sub-step count across attempts, excluding prefilled steps |
-| `mean/total_tokens_per_subproblem` | Total input + output tokens / benchmark sub-step count across attempts, excluding prefilled steps |
+| `mean/<type>_tokens_per_problem` | Token sum / problem attempts; also `mean/<type>_tokens` |
+| `mean/<type>_tokens_per_subproblem` | Token sum / non-prefilled benchmark sub-steps across all attempts |
 
-Repeats count as separate attempts. Sub-step usage is pooled across problems, so
-problems with more steps contribute more observations to the subproblem mean.
-The subproblem denominator is fixed by the benchmark, including the final step,
-context-rejected steps, and skipped remaining steps. Only prefilled reference-code
-steps are excluded. A problem that generates no steps uses zero tokens; a
-collection with no non-prefilled subproblems has a null subproblem mean.
-`generation_coverage` reports generated steps / non-prefilled benchmark steps.
-Report it alongside accuracy and token means: early stopping reduces cost but
-also reduces coverage. For three subproblems, generating only one 1,000-token
-response gives 1,000 output tokens per problem, 333.33 per subproblem, and 1/3
-generation coverage.
+Repeats count separately. The subproblem denominator includes final, rejected, and
+skipped steps; only prefilled steps are excluded. `generation_coverage` is generated
+steps / non-prefilled steps. With no eligible sub-steps, the subproblem mean is null.
 
-Generations that reach an output or context limit **are counted**, including all
-reported tokens and the attempt in the subproblem denominator. A pre-generation
-context-window rejection records zero input, output, and total tokens, as do
-prefilled and skipped steps. Prior generations' usage is still counted.
-If a model adapter turns a rejection into an empty response without usage, that
-response is treated as having unknown usage, rather than assuming zero tokens.
+- Count all reported usage, including incorrect or invalid code and generations
+  that hit a token limit. Incorrect or invalid code does not stop later steps.
+- Pre-generation context rejections, prefilled steps, and skipped steps use zero
+  tokens. Earlier generations still count. Aborted rollouts are excluded from
+  completed-rollout metrics.
+- If any generated response lacks usage, suppress all aggregate token statistics,
+  set the named token means to null, and report `token_usage_complete: false`.
+  Accuracy, coverage, and raw rollout records remain available. Missing optional
+  reasoning/cache breakdowns do not invalidate known input/output/total usage.
 
-Correctness does not filter token usage. The agent generates all sub-steps before
-verification, using its prior generated code even if that code is incorrect.
-For example, two models that each generate three 1,000-output-token sub-steps
-both use 3,000 output tokens per problem and 1,000 per subproblem, whether they
-solve one sub-step correctly or all three. These metrics measure tokens per attempted solution,
-not tokens per correct solution.
+`step_usage` records each step's number, status, and usage. Coverage counts are
+`num_subproblems`, `num_generated_steps`, and `num_steps_with_usage`.
 
-Code extraction does not validate Python syntax: it takes the first code block,
-or the raw response if there is no code fence. Empty or invalid code still counts
-as a generated attempt, with all reported tokens, and does not stop later steps.
-An unexpected exception that aborts the rollout is a run failure; its partial
-usage is not represented in completed-rollout metrics.
-
-Compact `step_usage` records retain each `step_number`, its status (`generated`,
-`prefilled`, `context_window_exceeded`, or `skipped`), and its provider usage. A
-generated step with missing usage has `usage: null` and makes its problem's total
-usage unknown. If even one generated response lacks usage, the aggregate endpoint
-suppresses all generic token statistics (including per-task and per-repeat
-statistics), sets the six named token means to null, and reports
-`token_usage_complete: false`. It preserves raw rollout records for diagnosis;
-accuracy and coverage remain available. `num_subproblems`, `num_generated_steps`,
-and `num_steps_with_usage` expose the counts. Missing reasoning/cache breakdowns
-alone do not invalidate known input/output/total usage.
-
-New rollouts and aggregates carry `token_usage_version: scicode-v1`. Older rollouts
-have no version and their `mean/output_tokens` covers only the final step; they
-cannot be backfilled from rollout files alone. Aggregating legacy-only rollouts
-preserves their existing metrics without adding the six new metrics. Mixing old
-and new accounting versions raises an error to prevent misleading comparisons.
+New records carry `token_usage_version: scicode-v1`. Legacy records contain only
+final-step usage and retain their old metrics. Mixing accounting versions is rejected.
 
 ## Configuration
 

--- a/responses_api_agents/scicode_agent/README.md
+++ b/responses_api_agents/scicode_agent/README.md
@@ -39,8 +39,8 @@ steps / non-prefilled steps. With no eligible sub-steps, the subproblem mean is 
 `step_usage` records each step's number, status, and usage. Coverage counts are
 `num_subproblems`, `num_generated_steps`, and `num_steps_with_usage`.
 
-Rollouts carry `token_usage_version: scicode-v1`; aggregates use numeric version `1`
-for evaluator export. Legacy records retain final-step metrics. Mixing versions is rejected.
+Rollouts and aggregates use `token_usage_version: 1`. Legacy records retain
+final-step metrics. Mixing versions is rejected.
 
 ## Configuration
 

--- a/responses_api_agents/scicode_agent/README.md
+++ b/responses_api_agents/scicode_agent/README.md
@@ -24,7 +24,7 @@ For each of `input`, `output`, and `total`, `key_metrics` exposes:
 
 Repeats count separately. The subproblem denominator includes final, rejected, and
 skipped steps; only prefilled steps are excluded. `generation_coverage` is generated
-steps / non-prefilled steps. With no eligible sub-steps, the subproblem mean is null.
+steps / non-prefilled steps. With no eligible sub-steps, the subproblem mean is omitted.
 
 - Count all reported usage, including incorrect or invalid code and generations
   that hit a token limit. Incorrect or invalid code does not stop later steps.
@@ -32,15 +32,15 @@ steps / non-prefilled steps. With no eligible sub-steps, the subproblem mean is 
   tokens. Earlier generations still count. Aborted rollouts are excluded from
   completed-rollout metrics.
 - If any generated response lacks usage, suppress all aggregate token statistics,
-  set the named token means to null, and report `token_usage_complete: false`.
+  omit the token means, and report `token_usage_complete: false`.
   Accuracy, coverage, and raw rollout records remain available. Missing optional
   reasoning/cache breakdowns do not invalidate known input/output/total usage.
 
 `step_usage` records each step's number, status, and usage. Coverage counts are
 `num_subproblems`, `num_generated_steps`, and `num_steps_with_usage`.
 
-New records carry `token_usage_version: scicode-v1`. Legacy records contain only
-final-step usage and retain their old metrics. Mixing accounting versions is rejected.
+Rollouts carry `token_usage_version: scicode-v1`; aggregates use numeric version `1`
+for evaluator export. Legacy records retain final-step metrics. Mixing versions is rejected.
 
 ## Configuration
 

--- a/responses_api_agents/scicode_agent/README.md
+++ b/responses_api_agents/scicode_agent/README.md
@@ -9,6 +9,73 @@ It also reports the headline `subtask_accuracy` metric (total sub-steps passed /
 rollouts) via `compute_metrics` / `get_key_metrics` — these live on the agent because
 `/aggregate_metrics` runs on the agent server.
 
+## Token statistics
+
+Each rollout records `response.usage` summed across all generated sub-steps in that
+problem attempt. Output tokens include the provider's reported reasoning tokens;
+input tokens include prior-step code sent again as context. The response text remains
+the final step's generation.
+
+The agent exposes six headline metrics in `key_metrics`:
+
+| Metric | Definition |
+| --- | --- |
+| `mean/input_tokens_per_problem` | Total input tokens / problem attempts (also `mean/input_tokens`) |
+| `mean/output_tokens_per_problem` | Total output tokens / problem attempts (also `mean/output_tokens`) |
+| `mean/total_tokens_per_problem` | Total input + output tokens / problem attempts (also `mean/total_tokens`) |
+| `mean/input_tokens_per_subproblem` | Total input tokens / benchmark sub-step count across attempts, excluding prefilled steps |
+| `mean/output_tokens_per_subproblem` | Total output tokens / benchmark sub-step count across attempts, excluding prefilled steps |
+| `mean/total_tokens_per_subproblem` | Total input + output tokens / benchmark sub-step count across attempts, excluding prefilled steps |
+
+Repeats count as separate attempts. Sub-step usage is pooled across problems, so
+problems with more steps contribute more observations to the subproblem mean.
+The subproblem denominator is fixed by the benchmark, including the final step,
+context-rejected steps, and skipped remaining steps. Only prefilled reference-code
+steps are excluded. A problem that generates no steps uses zero tokens; a
+collection with no non-prefilled subproblems has a null subproblem mean.
+`generation_coverage` reports generated steps / non-prefilled benchmark steps.
+Report it alongside accuracy and token means: early stopping reduces cost but
+also reduces coverage. For three subproblems, generating only one 1,000-token
+response gives 1,000 output tokens per problem, 333.33 per subproblem, and 1/3
+generation coverage.
+
+Generations that reach an output or context limit **are counted**, including all
+reported tokens and the attempt in the subproblem denominator. A pre-generation
+context-window rejection records zero input, output, and total tokens, as do
+prefilled and skipped steps. Prior generations' usage is still counted.
+If a model adapter turns a rejection into an empty response without usage, that
+response is treated as having unknown usage, rather than assuming zero tokens.
+
+Correctness does not filter token usage. The agent generates all sub-steps before
+verification, using its prior generated code even if that code is incorrect.
+For example, two models that each generate three 1,000-output-token sub-steps
+both use 3,000 output tokens per problem and 1,000 per subproblem, whether they
+solve one sub-step correctly or all three. These metrics measure tokens per attempted solution,
+not tokens per correct solution.
+
+Code extraction does not validate Python syntax: it takes the first code block,
+or the raw response if there is no code fence. Empty or invalid code still counts
+as a generated attempt, with all reported tokens, and does not stop later steps.
+An unexpected exception that aborts the rollout is a run failure; its partial
+usage is not represented in completed-rollout metrics.
+
+Compact `step_usage` records retain each `step_number`, its status (`generated`,
+`prefilled`, `context_window_exceeded`, or `skipped`), and its provider usage. A
+generated step with missing usage has `usage: null` and makes its problem's total
+usage unknown. If even one generated response lacks usage, the aggregate endpoint
+suppresses all generic token statistics (including per-task and per-repeat
+statistics), sets the six named token means to null, and reports
+`token_usage_complete: false`. It preserves raw rollout records for diagnosis;
+accuracy and coverage remain available. `num_subproblems`, `num_generated_steps`,
+and `num_steps_with_usage` expose the counts. Missing reasoning/cache breakdowns
+alone do not invalidate known input/output/total usage.
+
+New rollouts and aggregates carry `token_usage_version: scicode-v1`. Older rollouts
+have no version and their `mean/output_tokens` covers only the final step; they
+cannot be backfilled from rollout files alone. Aggregating legacy-only rollouts
+preserves their existing metrics without adding the six new metrics. Mixing old
+and new accounting versions raises an error to prevent misleading comparisons.
+
 ## Configuration
 
 - `resources_server`: the SciCode resources server instance to verify against

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -41,7 +41,7 @@ from step_utils import (
     process_problem_steps,
 )
 
-from nemo_gym.base_resources_server import BaseRunRequest
+from nemo_gym.base_resources_server import AggregateMetrics, AggregateMetricsRequest, BaseRunRequest
 from nemo_gym.base_responses_api_agent import (
     BaseResponsesAPIAgentConfig,
     Body,
@@ -53,12 +53,15 @@ from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseUsage,
+    accumulate_response_usage,
 )
 from nemo_gym.prompt import PromptConfig, load_prompt_config
 from nemo_gym.server_utils import raise_for_status
 
 
 LOG = logging.getLogger(__name__)
+TOKEN_USAGE_VERSION = "scicode-v1"
 
 
 class ScicodeAgentConfig(BaseResponsesAPIAgentConfig):
@@ -131,6 +134,37 @@ def _across_run_stats(tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
     return metrics
 
 
+def _token_metrics(tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
+    """Pool generated steps across attempts, rather than averaging per-problem ratios."""
+    rows = [r for task in tasks for r in task]
+    versions = {r.get("token_usage_version") for r in rows}
+    if not rows or versions == {None}:
+        # Historical rollouts contain only the last step's usage.
+        return {}
+    if versions != {TOKEN_USAGE_VERSION}:
+        raise ValueError("Cannot aggregate SciCode rollouts with different token accounting versions")
+
+    steps = [step for r in rows for step in r["step_usage"] if step["status"] != "prefilled"]
+    generated = [step for step in steps if step["status"] == "generated"]
+    metrics = {
+        "token_usage_version": TOKEN_USAGE_VERSION,
+        "num_subproblems": len(steps),
+        "num_generated_steps": len(generated),
+        "num_steps_with_usage": sum(step["usage"] is not None for step in generated),
+        "generation_coverage": len(generated) / len(steps) if steps else None,
+    }
+    complete = metrics["num_steps_with_usage"] == len(generated)
+    metrics["token_usage_complete"] = complete
+    # Override the generic means too: pandas would otherwise silently average only
+    # the rollouts with known usage, presenting a partial measurement as a full one.
+    for name in ("input_tokens", "output_tokens", "total_tokens"):
+        total = sum(step["usage"][name] for step in steps) if complete else None
+        metrics[f"mean/{name}"] = total / len(rows) if total is not None else None
+        metrics[f"mean/{name}_per_problem"] = metrics[f"mean/{name}"]
+        metrics[f"mean/{name}_per_subproblem"] = total / len(steps) if complete and steps else None
+    return metrics
+
+
 class ScicodeAgent(SimpleResponsesAPIAgent):
     """Agent that drives the SciCode per-sub-step generation + code-accumulation loop."""
 
@@ -173,13 +207,24 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         solutions: Dict[str, str] = {}
         out_of_context = False
         last_response_json = None
+        zero_usage = NeMoGymResponseUsage.sum_from_list([])
+        usage = zero_usage
+        usage_complete = True
+        step_usage = []
         response_create_params = body.responses_create_params.model_dump(exclude_unset=True, exclude_none=True)
         response_create_params.pop("input", None)
 
         for cur_step in range(total):
+            step_record = {
+                "step_number": sub_steps[cur_step]["step_number"],
+                "status": "skipped",
+                "usage": zero_usage.model_dump(),
+            }
+            step_usage.append(step_record)
             # Prefilled steps provide context for later steps but are not scored (no solution entry).
             if (body.problem_id, cur_step) in PREFILLED_STEPS_CODE:
                 previous_llm_code[cur_step] = PREFILLED_STEPS_CODE[(body.problem_id, cur_step)]
+                step_record["status"] = "prefilled"
                 continue
             if out_of_context:
                 solutions[f"{body.problem_id}.{cur_step + 1}"] = OUT_OF_CONTEXT
@@ -209,13 +254,19 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
                 if is_context_window_error(error):
                     LOG.warning("SciCode step %s: context window exceeded; failing remaining steps.", cur_step)
                     out_of_context = True
+                    step_record["status"] = "context_window_exceeded"
                     solutions[f"{body.problem_id}.{cur_step + 1}"] = OUT_OF_CONTEXT
                     continue
                 raise
 
             cookies = gen_response.cookies
             last_response_json = await gen_response.json()
-            generation = NeMoGymResponse.model_validate(last_response_json).output_text
+            model_response = NeMoGymResponse.model_validate(last_response_json)
+            step_record["status"] = "generated"
+            step_record["usage"] = model_response.usage.model_dump() if model_response.usage is not None else None
+            usage_complete = usage_complete and model_response.usage is not None
+            usage = accumulate_response_usage(usage, model_response.usage)
+            generation = model_response.output_text
             extracted = extract_python_script(generation)
             previous_llm_code[cur_step] = extracted
             solutions[f"{body.problem_id}.{cur_step + 1}"] = f"{previous_code}\n{extracted}"
@@ -224,6 +275,10 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         verify_request_data["solutions"] = solutions
         # /verify requires a response; record the last sub-step's generation (empty if none ran).
         verify_request_data["response"] = last_response_json if last_response_json is not None else _empty_response()
+        # Keep the final generation for inspection, but account for the whole problem.
+        verify_request_data["response"]["usage"] = usage.model_dump() if usage_complete else None
+        verify_request_data["token_usage_version"] = TOKEN_USAGE_VERSION
+        verify_request_data["step_usage"] = step_usage
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
@@ -233,16 +288,41 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         await raise_for_status(verify_response)
         return await verify_response.json()
 
+    async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:
+        if any(
+            step["status"] == "generated" and step["usage"] is None
+            for row in body.verify_responses
+            for step in (row.get("step_usage") or [])
+        ):
+            # Suppress generic token statistics at every level (including per-task
+            # and per-repeat). Keep the caller's raw rollout records unchanged.
+            body = body.model_copy(
+                update={
+                    "verify_responses": [
+                        {**row, "response": {**(row.get("response") or {}), "usage": None}}
+                        for row in body.verify_responses
+                    ]
+                }
+            )
+        return await super().aggregate_metrics(body)
+
     def compute_metrics(self, tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Headline SciCode metric: sub-step-weighted accuracy = total passed / total over all rollouts."""
         passed = sum(r.get("num_steps_passed", 0) for task in tasks for r in task)
         total = sum(r.get("num_steps_total", 0) for task in tasks for r in task)
         metrics = {"subtask_accuracy": passed / total if total else 0.0}
         metrics.update(_across_run_stats(tasks))
+        metrics.update(_token_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
-        return {k: v for k, v in agent_metrics.items() if k.startswith("mean/") or k.startswith("subtask_accuracy")}
+        return {
+            k: v
+            for k, v in agent_metrics.items()
+            if k.startswith("mean/")
+            or k.startswith("subtask_accuracy")
+            or k in {"generation_coverage", "token_usage_complete"}
+        }
 
 
 if __name__ == "__main__":

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -61,7 +61,7 @@ from nemo_gym.server_utils import raise_for_status
 
 
 LOG = logging.getLogger(__name__)
-TOKEN_USAGE_VERSION = "scicode-v1"
+TOKEN_USAGE_VERSION = 1
 
 
 class ScicodeAgentConfig(BaseResponsesAPIAgentConfig):
@@ -148,7 +148,7 @@ def _token_metrics(tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
     generated = [step for step in steps if step["status"] == "generated"]
     metrics = {
         # Aggregate values are exported as numeric scores by NeMo Evaluator.
-        "token_usage_version": 1,
+        "token_usage_version": TOKEN_USAGE_VERSION,
         "num_subproblems": len(steps),
         "num_generated_steps": len(generated),
         "num_steps_with_usage": sum(step["usage"] is not None for step in generated),

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -147,7 +147,8 @@ def _token_metrics(tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
     steps = [step for r in rows for step in r["step_usage"] if step["status"] != "prefilled"]
     generated = [step for step in steps if step["status"] == "generated"]
     metrics = {
-        "token_usage_version": TOKEN_USAGE_VERSION,
+        # Aggregate values are exported as numeric scores by NeMo Evaluator.
+        "token_usage_version": 1,
         "num_subproblems": len(steps),
         "num_generated_steps": len(generated),
         "num_steps_with_usage": sum(step["usage"] is not None for step in generated),
@@ -304,7 +305,12 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
                     ]
                 }
             )
-        return await super().aggregate_metrics(body)
+        metrics = await super().aggregate_metrics(body)
+        # NeMo Evaluator requires numeric scores. Omit unavailable values rather
+        # than exporting nulls or inventing zero consumption.
+        metrics.agent_metrics = {k: v for k, v in metrics.agent_metrics.items() if v is not None}
+        metrics.key_metrics = {k: v for k, v in metrics.key_metrics.items() if v is not None}
+        return metrics
 
     def compute_metrics(self, tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Headline SciCode metric: sub-step-weighted accuracy = total passed / total over all rollouts."""

--- a/responses_api_agents/scicode_agent/tests/test_app.py
+++ b/responses_api_agents/scicode_agent/tests/test_app.py
@@ -432,7 +432,8 @@ class TestTokenAccounting:
         assert result.agent_metrics["num_steps_with_usage"] == 8
         assert result.key_metrics["generation_coverage"] == 1.0
         assert result.key_metrics["token_usage_complete"] is True
-        assert result.agent_metrics["token_usage_version"] == TOKEN_USAGE_VERSION
+        assert result.agent_metrics["token_usage_version"] == 1
+        assert all(isinstance(value, (int, float)) for value in result.agent_metrics.values())
         assert [g["mean/output_tokens"] for g in result.group_level_metrics] == [150, 1650]
 
     @pytest.mark.asyncio
@@ -489,8 +490,10 @@ class TestTokenAccounting:
         assert body.model_dump() == original
         assert result.key_metrics["token_usage_complete"] is not missing_usage
         assert result.key_metrics["generation_coverage"] == 1.0
+        for section in (result.agent_metrics, result.key_metrics):
+            assert all(value is not None and not isinstance(value, str) for value in section.values())
         if missing_usage:
-            assert result.key_metrics["mean/output_tokens_per_problem"] is None
+            assert "mean/output_tokens_per_problem" not in result.key_metrics
 
             def check_no_numeric_tokens(value):
                 if isinstance(value, dict):

--- a/responses_api_agents/scicode_agent/tests/test_app.py
+++ b/responses_api_agents/scicode_agent/tests/test_app.py
@@ -19,9 +19,12 @@ import pytest
 from fastapi import Response
 
 import responses_api_agents.scicode_agent.app as app
+from nemo_gym.base_resources_server import AggregateMetricsRequest
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.reward_profile import compute_aggregate_metrics
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.scicode_agent.app import (
+    TOKEN_USAGE_VERSION,
     ModelServerRef,
     ResourcesServerRef,
     ScicodeAgent,
@@ -360,3 +363,223 @@ class TestAcrossRunStats:
         assert "mean/problem_accuracy/std_dev_across_runs" in key
         assert "subtask_accuracy/std_dev_across_runs" in key
         assert "std/reward" not in key
+
+
+def _usage(output_tokens, input_tokens=10, cached_tokens=2, reasoning_tokens=3):
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "input_tokens_details": {"cached_tokens": cached_tokens},
+        "output_tokens_details": {"reasoning_tokens": reasoning_tokens},
+    }
+
+
+async def _collect_usage(usages, problem_id="1", n_steps=None, response_overrides=None):
+    """Exercise the step loop and capture the payload sent to verification."""
+    agent = _agent()
+    responses = iter(usages)
+
+    def _post(server_name, url_path, json, cookies):
+        if url_path == "/v1/responses":
+            usage = next(responses)
+            if isinstance(usage, Exception):
+                raise usage
+            return _Resp({**_model_json("x = 1"), "usage": usage, **(response_overrides or {})})
+        return _Resp({**json, "reward": 0.0})
+
+    agent.server_client.post = AsyncMock(side_effect=_post)
+    with patch.object(app, "raise_for_status", AsyncMock()):
+        return await agent.run(
+            _FakeRequest(), _run_request(problem_id=problem_id, n_steps=len(usages) if n_steps is None else n_steps)
+        )
+
+
+def _aggregate(rows):
+    agent = _agent()
+    rows = [{"_ng_task_index": i, "_ng_rollout_index": 0, **row} for i, row in enumerate(rows)]
+    return compute_aggregate_metrics(rows, agent.compute_metrics, agent.get_key_metrics)
+
+
+class TestTokenAccounting:
+    @pytest.mark.asyncio
+    async def test_usage_sent_to_verifier_sums_all_steps_and_details(self):
+        row = await _collect_usage([_usage(100), _usage(300, input_tokens=20)])
+        assert row["token_usage_version"] == TOKEN_USAGE_VERSION
+        assert row["response"]["usage"] == _usage(400, input_tokens=30, cached_tokens=4, reasoning_tokens=6)
+        assert row["step_usage"] == [
+            {"step_number": "1.1", "status": "generated", "usage": _usage(100)},
+            {"step_number": "1.2", "status": "generated", "usage": _usage(300, input_tokens=20)},
+        ]
+        assert row["response"]["output"][0]["content"][0]["text"] == "```python\nx = 1\n```"
+
+    @pytest.mark.asyncio
+    async def test_unequal_step_counts_and_repeats_are_pooled(self):
+        # Two attempts each: one-step problem (100, 200), three-step problem
+        # (300+400+500, 600+700+800). Total 3600 / 4 problems / 8 steps.
+        rows = []
+        for task_idx, attempts in enumerate(([[100], [200]], [[300, 400, 500], [600, 700, 800]])):
+            for repeat_idx, tokens in enumerate(attempts):
+                row = await _collect_usage([_usage(t) for t in tokens])
+                rows.append({**row, "_ng_task_index": task_idx, "_ng_rollout_index": repeat_idx})
+        result = _aggregate(rows)
+        for name, per_problem, per_subproblem in (("input", 20, 10), ("output", 900, 450), ("total", 920, 460)):
+            assert result.key_metrics[f"mean/{name}_tokens_per_problem"] == per_problem
+            assert result.key_metrics[f"mean/{name}_tokens_per_subproblem"] == per_subproblem
+            assert result.key_metrics[f"mean/{name}_tokens"] == per_problem
+        assert result.agent_metrics["num_generated_steps"] == 8
+        assert result.agent_metrics["num_subproblems"] == 8
+        assert result.agent_metrics["num_steps_with_usage"] == 8
+        assert result.key_metrics["generation_coverage"] == 1.0
+        assert result.key_metrics["token_usage_complete"] is True
+        assert result.agent_metrics["token_usage_version"] == TOKEN_USAGE_VERSION
+        assert [g["mean/output_tokens"] for g in result.group_level_metrics] == [150, 1650]
+
+    @pytest.mark.asyncio
+    async def test_prefilled_and_context_skipped_steps_are_not_generated(self):
+        row = await _collect_usage(
+            [_usage(100), RuntimeError("exceeds maximum input length")], problem_id="62", n_steps=4
+        )
+        assert [s["status"] for s in row["step_usage"]] == [
+            "prefilled",
+            "generated",
+            "context_window_exceeded",
+            "skipped",
+        ]
+        assert row["response"]["usage"]["output_tokens"] == 100
+        for i in (0, 2, 3):
+            assert row["step_usage"][i]["usage"] == _usage(0, input_tokens=0, cached_tokens=0, reasoning_tokens=0)
+        result = _aggregate([row])
+        metrics = result.key_metrics
+        assert metrics["mean/output_tokens_per_problem"] == 100
+        assert metrics["mean/output_tokens_per_subproblem"] == pytest.approx(100 / 3)
+        assert metrics["generation_coverage"] == 1 / 3
+        assert metrics["token_usage_complete"] is True
+        assert result.agent_metrics["num_subproblems"] == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("missing_index", [0, 1])
+    async def test_missing_usage_stays_unknown_in_rollout_and_collection(self, missing_index):
+        usages = [_usage(100), _usage(300)]
+        usages[missing_index] = None
+        unknown = await _collect_usage(usages)
+        known = await _collect_usage([_usage(200)])
+        assert unknown["response"]["usage"] is None
+        assert unknown["step_usage"][missing_index]["usage"] is None
+        result = _aggregate([unknown, {**known, "_ng_task_index": 1}])
+        for name in ("input", "output", "total"):
+            for suffix in ("", "_per_problem", "_per_subproblem"):
+                assert result.key_metrics[f"mean/{name}_tokens{suffix}"] is None
+        assert result.agent_metrics["num_generated_steps"] == 3
+        assert result.agent_metrics["num_steps_with_usage"] == 2
+        assert result.key_metrics["token_usage_complete"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("missing_usage", [False, True])
+    async def test_aggregate_endpoint_suppresses_all_partial_token_statistics(self, missing_usage):
+        rows = []
+        for task_idx in range(2):
+            for repeat_idx in range(2):
+                usage = None if missing_usage and task_idx == repeat_idx == 0 else _usage(100)
+                row = await _collect_usage([usage])
+                rows.append({**row, "_ng_task_index": task_idx, "_ng_rollout_index": repeat_idx})
+        body = AggregateMetricsRequest(verify_responses=rows)
+        original = body.model_dump()
+        result = await _agent().aggregate_metrics(body)
+        assert body.model_dump() == original
+        assert result.key_metrics["token_usage_complete"] is not missing_usage
+        assert result.key_metrics["generation_coverage"] == 1.0
+        if missing_usage:
+            assert result.key_metrics["mean/output_tokens_per_problem"] is None
+
+            def check_no_numeric_tokens(value):
+                if isinstance(value, dict):
+                    for key, item in value.items():
+                        if "tokens" in key:
+                            assert not isinstance(item, (int, float)), (key, item)
+                        check_no_numeric_tokens(item)
+                elif isinstance(value, list):
+                    for item in value:
+                        check_no_numeric_tokens(item)
+
+            check_no_numeric_tokens(result.model_dump())
+        else:
+            assert result.key_metrics["mean/output_tokens_per_problem"] == 100
+            assert result.agent_metrics["max/output_tokens"] == 100
+            assert all(group["mean/output_tokens"] == 100 for group in result.group_level_metrics)
+
+    @pytest.mark.asyncio
+    async def test_unknown_reasoning_details_do_not_poison_known_output_count(self):
+        row = await _collect_usage([_usage(100, reasoning_tokens=None), _usage(200)])
+        assert row["response"]["usage"]["output_tokens"] == 300
+        assert row["response"]["usage"]["output_tokens_details"]["reasoning_tokens"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", ["empty", "prefilled", "context"])
+    async def test_no_generations_zero_usage_with_fixed_subproblem_denominator(self, kind):
+        if kind == "prefilled":
+            row = await _collect_usage([], problem_id="62", n_steps=1)
+        elif kind == "context":
+            row = await _collect_usage([RuntimeError("exceeds maximum input length")], n_steps=2)
+        else:
+            row = await _collect_usage([])
+        assert row["response"]["usage"]["output_tokens"] == 0
+        assert all(step["usage"]["total_tokens"] == 0 for step in row["step_usage"])
+        metrics = _aggregate([row]).key_metrics
+        for name in ("input", "output", "total"):
+            assert metrics[f"mean/{name}_tokens_per_problem"] == 0
+            assert metrics[f"mean/{name}_tokens_per_subproblem"] == (0 if kind == "context" else None)
+        assert metrics["generation_coverage"] == (0 if kind == "context" else None)
+
+    @pytest.mark.asyncio
+    async def test_truncated_generation_counts_all_usage(self):
+        row = await _collect_usage(
+            [_usage(262000, input_tokens=144)],
+            response_overrides={"status": "incomplete", "incomplete_details": {"reason": "max_output_tokens"}},
+        )
+        assert row["response"]["incomplete_details"] == {"reason": "max_output_tokens"}
+        assert row["step_usage"][0]["status"] == "generated"
+        metrics = _aggregate([row]).key_metrics
+        for scope in ("problem", "subproblem"):
+            assert metrics[f"mean/input_tokens_per_{scope}"] == 144
+            assert metrics[f"mean/output_tokens_per_{scope}"] == 262000
+            assert metrics[f"mean/total_tokens_per_{scope}"] == 262144
+
+    @pytest.mark.asyncio
+    async def test_correctness_does_not_filter_token_usage(self):
+        row = await _collect_usage([_usage(1000)] * 3)
+        one_correct = {**row, "step_results": [True, False, False], "num_steps_passed": 1, "num_steps_total": 3}
+        two_correct = {**row, "step_results": [True, True, False], "num_steps_passed": 2, "num_steps_total": 3}
+        first = _aggregate([one_correct]).key_metrics
+        second = _aggregate([two_correct]).key_metrics
+        assert first["subtask_accuracy"] == 1 / 3
+        assert second["subtask_accuracy"] == 2 / 3
+        assert first["mean/output_tokens_per_problem"] == second["mean/output_tokens_per_problem"] == 3000
+        assert first["mean/output_tokens_per_subproblem"] == second["mean/output_tokens_per_subproblem"] == 1000
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("text", ["not Python code", "```python\nthis is ! invalid\n```", "```python\n", ""])
+    async def test_unusable_code_does_not_stop_later_steps_or_drop_usage(self, text):
+        output = _model_json("ignored")["output"]
+        output[0]["content"][0]["text"] = text
+        row = await _collect_usage([_usage(100), _usage(200)], response_overrides={"output": output})
+        assert set(row["solutions"]) == {"1.1", "1.2"}
+        assert [step["status"] for step in row["step_usage"]] == ["generated", "generated"]
+        assert row["response"]["usage"]["output_tokens"] == 300
+        metrics = _aggregate([row]).key_metrics
+        assert metrics["mean/output_tokens_per_problem"] == 300
+        assert metrics["mean/output_tokens_per_subproblem"] == 150
+
+    def test_legacy_rollouts_do_not_gain_whole_problem_metrics(self):
+        row = {"reward": 0.0, "response": {"usage": _usage(100)}}
+        metrics = _aggregate([row]).key_metrics
+        assert metrics["mean/output_tokens"] == 100
+        assert "mean/output_tokens_per_problem" not in metrics
+        assert "mean/output_tokens_per_subproblem" not in metrics
+
+    @pytest.mark.asyncio
+    async def test_mixed_accounting_versions_rejected(self):
+        row = await _collect_usage([_usage(100)])
+        old_row = {"reward": 0.0, "response": {"usage": _usage(200)}}
+        with pytest.raises(ValueError, match="different token accounting versions"):
+            _aggregate([row, old_row])


### PR DESCRIPTION
## What does this PR do?

SciCode rollouts currently report only the final step's token usage. Sum usage across all generated steps and expose input, output, and total token averages per problem and per subproblem, with per-step usage records and generation coverage.

Count incorrect and truncated generations. Pre-generation context rejections and skipped steps contribute zero; prefilled steps are excluded from the subproblem denominator. If any generated response lacks usage, omit aggregate token statistics while retaining accuracy and coverage. Keep legacy accounting distinguishable and aggregate values compatible with NeMo Evaluator's numeric score parser.

Validation: 520 problem attempts / 2,304 generated steps completed, and all usage records matched the independent request cache exactly. Replaying aggregation and the actual evaluator parser passed complete-usage, missing-usage, and empty-denominator cases. SciCode agent/resource tests and all-file pre-commit checks pass.

## Checklist

- [x] I have read the contributing guidelines.
- [x] The change is focused; no unrelated edits.
- [x] Tests added or updated and pass locally.
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`).
- [x] All commits have DCO sign-off (`git commit -s`).
