### PR TITLE
fix(server-utils): disable uvicorn proxy headers by default

### DIFF
--- a/fern/versions/latest/pages/reference/configuration.mdx
+++ b/fern/versions/latest/pages/reference/configuration.mdx
@@ -93,6 +93,31 @@ server_id:                    # Your unique name for this server
       # ... additional fields vary by server type
 ```
 
+### Reverse Proxy Headers
+
+Gym disables Uvicorn proxy-header processing by default. Direct Gym traffic does not pass through a reverse proxy, so
+the network peer address and request scheme are authoritative without interpreting `X-Forwarded-For` or
+`X-Forwarded-Proto`.
+
+Deployments behind a reverse proxy must opt in with top-level configuration and list the proxy addresses or CIDRs that
+are allowed to supply forwarded headers:
+
+```yaml
+uvicorn_proxy_headers: true
+uvicorn_forwarded_allow_ips:
+  - 10.0.0.5
+  - 10.20.0.0/24
+```
+
+Both settings apply to the Gym head server and the Agent, Model, and Resources servers. Enabling proxy headers without
+a non-empty allowlist fails at startup. Wildcards and all-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected.
+
+<Warning>
+Only list reverse proxies you control. Trusting a loopback address such as `127.0.0.1` trusts every local process, not
+only a proxy running on that address. Deployments that previously relied on Uvicorn's implicit loopback trust must set
+these options explicitly.
+</Warning>
+
 ### Model Server Fields
 
 ```yaml

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -646,6 +646,10 @@ class UvicornLoggingConfig(BaseModel):
     uvicorn_logging_show_200_ok: bool = False
 
 
+# Every IPv4 address as it appears on a dual-stack socket.
+_ALL_V4_MAPPED = ip_network("::ffff:0:0/96")
+
+
 class UvicornProxyHeadersConfig(BaseModel):
     # Gym servers call each other directly, so proxy headers stay off: uvicorn would otherwise let
     # any caller rewrite its own client host and URL scheme through X-Forwarded-*.
@@ -666,11 +670,18 @@ class UvicornProxyHeadersConfig(BaseModel):
         for address in allow_ips:
             try:
                 network = ip_network(address)
-            except ValueError:
-                continue
-            if network.prefixlen == 0:
+            except ValueError as exc:
+                # Anything uvicorn cannot parse as an address is kept as a literal it will never
+                # match against a TCP peer, so the entry would silently trust nothing.
                 raise ValueError(
-                    "uvicorn_forwarded_allow_ips must not contain an all-address CIDR: "
+                    f"uvicorn_forwarded_allow_ips entry {address!r} is not a valid IP address or CIDR range: {exc}"
+                ) from exc
+            # prefixlen 0 covers a whole family; an IPv6 supernet of ::ffff:0:0/96 covers all of
+            # IPv4 once peers arrive IPv4-mapped on a dual-stack socket.
+            covers_all_v4_mapped = network.version == 6 and network.supernet_of(_ALL_V4_MAPPED)
+            if network.prefixlen == 0 or covers_all_v4_mapped:
+                raise ValueError(
+                    f"uvicorn_forwarded_allow_ips entry {address!r} covers every address: "
                     "it trusts forwarded headers from any peer."
                 )
 
@@ -1166,7 +1177,7 @@ class HeadServer(BaseServer):
         self._cached_yaml = None
 
     @classmethod
-    def run_webserver(cls) -> Tuple[uvicorn.Server, Thread, "HeadServer"]:  # pragma: no cover
+    def run_webserver(cls) -> Tuple[uvicorn.Server, Thread, "HeadServer"]:
         config = ServerClient.load_head_server_config()
         server = cls(config=config)
         uvicorn_proxy_cfg = UvicornProxyHeadersConfig.model_validate(get_global_config_dict())

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -51,7 +51,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from multidict import CIMultiDict
 from omegaconf import DictConfig, OmegaConf, open_dict
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 from requests.exceptions import ConnectionError
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -645,6 +645,28 @@ class UvicornLoggingConfig(BaseModel):
     uvicorn_logging_show_200_ok: bool = False
 
 
+class UvicornProxyHeadersConfig(BaseModel):
+    # Gym servers call each other directly, so proxy headers stay off: uvicorn would otherwise let
+    # any caller rewrite its own client host and URL scheme through X-Forwarded-*.
+    uvicorn_proxy_headers: bool = False
+    # Trusted proxy addresses. Required when uvicorn_proxy_headers is enabled.
+    uvicorn_forwarded_allow_ips: Optional[List[str]] = None
+
+    @model_validator(mode="after")
+    def _require_trusted_proxy_allowlist(self) -> "UvicornProxyHeadersConfig":
+        if not self.uvicorn_proxy_headers:
+            return self
+
+        allow_ips = [ip.strip() for ip in (self.uvicorn_forwarded_allow_ips or []) if ip.strip()]
+        if not allow_ips:
+            raise ValueError("uvicorn_proxy_headers=True requires a non-empty uvicorn_forwarded_allow_ips allowlist.")
+        if "*" in allow_ips:
+            raise ValueError("uvicorn_forwarded_allow_ips must not be '*': it trusts forwarded headers from any peer.")
+
+        self.uvicorn_forwarded_allow_ips = allow_ips
+        return self
+
+
 _NEMO_GYM_STARTED_RAY_CLUSTER: bool = False
 
 
@@ -1050,6 +1072,7 @@ Full body: {json.dumps(exc.body, indent=4)}
             server.setup_profiling(app, profiling_config)
 
         uvicorn_logging_cfg = UvicornLoggingConfig.model_validate(global_config_dict)
+        uvicorn_proxy_cfg = UvicornProxyHeadersConfig.model_validate(global_config_dict)
         if not uvicorn_logging_cfg.uvicorn_logging_show_200_ok and is_main_fastapi_proc:
             print(
                 "Disabling a uvicorn access logging so that the logs aren't spammed with 200 OK messages. This is to help errors pop up better and filter out noise."
@@ -1069,6 +1092,10 @@ Full body: {json.dumps(exc.body, indent=4)}
             # A missing or incompatible httptools wheel now fails during startup.
             http="httptools",
             access_log=uvicorn_logging_cfg.uvicorn_logging_show_200_ok,
+            # Internal-only by default. Enabling this requires an explicit trusted-proxy allowlist,
+            # so forwarded headers are never honored from an arbitrary peer.
+            proxy_headers=uvicorn_proxy_cfg.uvicorn_proxy_headers,
+            forwarded_allow_ips=uvicorn_proxy_cfg.uvicorn_forwarded_allow_ips or [],
         )
 
         if server.config.num_workers and server.config.num_workers > 1:

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -22,6 +22,7 @@ import time
 from abc import abstractmethod
 from asyncio.exceptions import CancelledError
 from contextlib import asynccontextmanager
+from ipaddress import ip_network
 from os import environ, getenv
 from pathlib import Path
 from threading import Thread
@@ -662,6 +663,16 @@ class UvicornProxyHeadersConfig(BaseModel):
             raise ValueError("uvicorn_proxy_headers=True requires a non-empty uvicorn_forwarded_allow_ips allowlist.")
         if "*" in allow_ips:
             raise ValueError("uvicorn_forwarded_allow_ips must not be '*': it trusts forwarded headers from any peer.")
+        for address in allow_ips:
+            try:
+                network = ip_network(address)
+            except ValueError:
+                continue
+            if network.prefixlen == 0:
+                raise ValueError(
+                    "uvicorn_forwarded_allow_ips must not contain an all-address CIDR: "
+                    "it trusts forwarded headers from any peer."
+                )
 
         self.uvicorn_forwarded_allow_ips = allow_ips
         return self
@@ -1158,6 +1169,7 @@ class HeadServer(BaseServer):
     def run_webserver(cls) -> Tuple[uvicorn.Server, Thread, "HeadServer"]:  # pragma: no cover
         config = ServerClient.load_head_server_config()
         server = cls(config=config)
+        uvicorn_proxy_cfg = UvicornProxyHeadersConfig.model_validate(get_global_config_dict())
 
         app = server.setup_webserver()
 
@@ -1165,6 +1177,8 @@ class HeadServer(BaseServer):
             app,
             host=server.config.host,
             port=server.config.port,
+            proxy_headers=uvicorn_proxy_cfg.uvicorn_proxy_headers,
+            forwarded_allow_ips=uvicorn_proxy_cfg.uvicorn_forwarded_allow_ips or [],
         )
         uvicorn_server = uvicorn.Server(config=config)
 

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -892,6 +892,13 @@ class TestUvicornProxyHeadersConfig:
                 {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.0.1", "*"]}
             )
 
+    def test_all_address_networks_are_rejected(self) -> None:
+        for network in ("0.0.0.0/0", "::/0"):
+            with raises(ValidationError, match="must not contain an all-address CIDR"):
+                UvicornProxyHeadersConfig.model_validate(
+                    {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [network]}
+                )
+
     def test_allowlist_is_normalized(self) -> None:
         config = UvicornProxyHeadersConfig.model_validate(
             {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [" 10.0.0.1 ", "", "10.0.0.2"]}
@@ -1026,3 +1033,48 @@ class TestRunWebserverProxyKwargs:
     def test_enabling_without_allowlist_fails_startup(self, monkeypatch: MonkeyPatch) -> None:
         with raises(ValidationError, match="requires a non-empty uvicorn_forwarded_allow_ips"):
             self._capture_uvicorn_kwargs(monkeypatch, {"uvicorn_proxy_headers": True}, num_workers=1)
+
+
+class TestHeadServerProxyKwargs:
+    """The independently launched head server must use the same proxy-header policy."""
+
+    @staticmethod
+    def _capture_uvicorn_kwargs(monkeypatch: MonkeyPatch, config_dict: dict) -> dict:
+        monkeypatch.setattr(
+            ServerClient,
+            "load_head_server_config",
+            MagicMock(return_value=BaseServerConfig(host="127.0.0.1", port=11000)),
+        )
+        monkeypatch.setattr(
+            nemo_gym.server_utils,
+            "get_global_config_dict",
+            MagicMock(return_value=DictConfig(config_dict)),
+        )
+
+        captured: dict = {}
+
+        def capture_config(app, **kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(nemo_gym.server_utils.uvicorn, "Config", capture_config)
+        monkeypatch.setattr(nemo_gym.server_utils.uvicorn, "Server", MagicMock(return_value=MagicMock()))
+        monkeypatch.setattr(nemo_gym.server_utils, "Thread", MagicMock(return_value=MagicMock()))
+
+        HeadServer.run_webserver()
+        return captured
+
+    def test_proxy_headers_are_disabled_by_default(self, monkeypatch: MonkeyPatch) -> None:
+        kwargs = self._capture_uvicorn_kwargs(monkeypatch, {})
+
+        assert kwargs["proxy_headers"] is False
+        assert kwargs["forwarded_allow_ips"] == []
+
+    def test_trusted_proxy_opt_in_is_forwarded(self, monkeypatch: MonkeyPatch) -> None:
+        kwargs = self._capture_uvicorn_kwargs(
+            monkeypatch,
+            {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.0.1"]},
+        )
+
+        assert kwargs["proxy_headers"] is True
+        assert kwargs["forwarded_allow_ips"] == ["10.0.0.1"]

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -18,9 +18,11 @@ import socket
 from concurrent.futures import ProcessPoolExecutor
 from unittest.mock import AsyncMock, MagicMock
 
+import uvicorn
 from aiohttp import ClientOSError, ClientResponseError, RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
 from omegaconf import OmegaConf
+from pydantic import ValidationError
 from pytest import CaptureFixture, MonkeyPatch, raises
 from yarl import URL
 
@@ -28,6 +30,7 @@ import nemo_gym.global_config
 import nemo_gym.server_utils
 from nemo_gym.config_types import BaseRunServerInstanceConfig
 from nemo_gym.global_config import (
+    DRY_RUN_KEY_NAME,
     NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
 )
@@ -43,6 +46,7 @@ from nemo_gym.server_utils import (
     HeadServer,
     ServerClient,
     SimpleServer,
+    UvicornProxyHeadersConfig,
     _format_upstream_error_log,
     _make_keepalive_socket_factory,
     initialize_ray,
@@ -811,3 +815,214 @@ class TestServerUtils:
         response = await nemo_gym.server_utils.request("POST", "http://flaky-host:1/v1")
         assert response is client.success_response
         assert client.request.await_count == 5
+
+
+_SPOOFED_HOST = "203.0.113.99"
+_LOOPBACK = "127.0.0.1"
+
+
+async def _scope_seen_by_app(*, proxy_headers: bool, allow_ips: list[str] | None, peer: str, forwarded: bool) -> dict:
+    """Drive uvicorn's loaded app with one request and return the scope the inner app observed."""
+    seen: dict = {}
+
+    async def recorder(scope, receive, send) -> None:
+        seen["client"] = scope.get("client")
+        seen["scheme"] = scope["scheme"]
+
+    config = uvicorn.Config(
+        app=recorder,
+        proxy_headers=proxy_headers,
+        forwarded_allow_ips=allow_ips or [],
+    )
+    config.load()
+
+    headers = []
+    if forwarded:
+        headers = [(b"x-forwarded-for", _SPOOFED_HOST.encode()), (b"x-forwarded-proto", b"https")]
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "scheme": "http",
+        "headers": headers,
+        "client": (peer, 54321),
+        "server": (_LOOPBACK, 8000),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message) -> None:
+        return None
+
+    await config.loaded_app(scope, receive, send)
+    return seen
+
+
+class TestUvicornProxyHeadersConfig:
+    def test_disabled_by_default(self) -> None:
+        config = UvicornProxyHeadersConfig.model_validate({})
+
+        assert config.uvicorn_proxy_headers is False
+        assert config.uvicorn_forwarded_allow_ips is None
+
+    def test_unrelated_config_keys_are_ignored(self) -> None:
+        config = UvicornProxyHeadersConfig.model_validate({"uvicorn_logging_show_200_ok": True, "port": 1234})
+
+        assert config.uvicorn_proxy_headers is False
+
+    def test_enabling_without_allowlist_is_rejected(self) -> None:
+        with raises(ValidationError, match="requires a non-empty uvicorn_forwarded_allow_ips"):
+            UvicornProxyHeadersConfig.model_validate({"uvicorn_proxy_headers": True})
+
+    def test_enabling_with_empty_allowlist_is_rejected(self) -> None:
+        with raises(ValidationError, match="requires a non-empty uvicorn_forwarded_allow_ips"):
+            UvicornProxyHeadersConfig.model_validate(
+                {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["  "]}
+            )
+
+    def test_wildcard_allowlist_is_rejected(self) -> None:
+        with raises(ValidationError, match="must not be"):
+            UvicornProxyHeadersConfig.model_validate(
+                {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.0.1", "*"]}
+            )
+
+    def test_allowlist_is_normalized(self) -> None:
+        config = UvicornProxyHeadersConfig.model_validate(
+            {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [" 10.0.0.1 ", "", "10.0.0.2"]}
+        )
+
+        assert ["10.0.0.1", "10.0.0.2"] == config.uvicorn_forwarded_allow_ips
+
+
+class TestUvicornProxyHeadersBehavior:
+    async def test_forwarded_headers_ignored_when_disabled(self) -> None:
+        """The documented internal-only default: the real peer and scheme survive a forged header."""
+        seen = await _scope_seen_by_app(proxy_headers=False, allow_ips=None, peer=_LOOPBACK, forwarded=True)
+
+        assert (_LOOPBACK, 54321) == seen["client"]
+        assert "http" == seen["scheme"]
+
+    async def test_real_peer_reported_when_disabled_without_forwarded_headers(self) -> None:
+        seen = await _scope_seen_by_app(proxy_headers=False, allow_ips=None, peer=_LOOPBACK, forwarded=False)
+
+        assert (_LOOPBACK, 54321) == seen["client"]
+        assert "http" == seen["scheme"]
+
+    async def test_forwarded_headers_honored_for_trusted_proxy(self) -> None:
+        seen = await _scope_seen_by_app(proxy_headers=True, allow_ips=[_LOOPBACK], peer=_LOOPBACK, forwarded=True)
+
+        assert (_SPOOFED_HOST, 0) == seen["client"]
+        assert "https" == seen["scheme"]
+
+    async def test_forwarded_headers_ignored_from_untrusted_peer(self) -> None:
+        """Enabled, but the caller is not on the allowlist, so its forwarded claims are discarded."""
+        seen = await _scope_seen_by_app(proxy_headers=True, allow_ips=["10.0.0.1"], peer=_LOOPBACK, forwarded=True)
+
+        assert (_LOOPBACK, 54321) == seen["client"]
+        assert "http" == seen["scheme"]
+
+    def test_proxy_middleware_absent_for_single_and_multi_worker(self) -> None:
+        """run_webserver builds one kwargs dict for both launch paths, so the setting must hold for each."""
+        from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+        for workers in (1, 4):
+            config = uvicorn.Config(
+                app=lambda scope, receive, send: None,
+                workers=workers,
+                proxy_headers=False,
+                forwarded_allow_ips=[],
+            )
+            config.load()
+
+            assert not isinstance(config.loaded_app, ProxyHeadersMiddleware), workers
+
+
+class TestRunWebserverProxyKwargs:
+    """run_webserver must forward the proxy config into uvicorn on both launch paths."""
+
+    def _capture_uvicorn_kwargs(self, monkeypatch: MonkeyPatch, config_dict: dict, num_workers: int) -> dict:
+        from fastapi import FastAPI
+
+        global_config = DictConfig({DRY_RUN_KEY_NAME: False, "my_server": {"a": {"b": {}}}, **config_dict})
+        monkeypatch.setattr(nemo_gym.server_utils.ray, "is_initialized", MagicMock(return_value=True))
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", MagicMock(return_value=global_config))
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="", port=0), global_config_dict=DictConfig({})
+        )
+        server_client_mock = MagicMock(return_value=server_client)
+        server_client_mock.load_head_server_config = MagicMock(return_value=BaseServerConfig(host="", port=0))
+        monkeypatch.setattr(nemo_gym.server_utils, "ServerClient", server_client_mock)
+        monkeypatch.setattr(nemo_gym.server_utils, "is_nemo_gym_fastapi_worker", MagicMock(return_value=False))
+
+        captured: dict = {}
+        monkeypatch.setattr(nemo_gym.server_utils.uvicorn, "run", lambda **kwargs: captured.update(kwargs))
+
+        server_config = BaseRunServerInstanceConfig(
+            name="my_server", host="127.0.0.1", port=8000, entrypoint="app.py", num_workers=num_workers
+        )
+
+        class TestSimpleServer(SimpleServer):
+            @classmethod
+            def load_config_from_global_config(cls):
+                return server_config
+
+            def setup_webserver(self) -> FastAPI:
+                return FastAPI()
+
+            def setup_telemetry(self) -> None: ...
+            def set_ulimit(self) -> None: ...
+            def prefix_server_logs(self) -> None: ...
+            def setup_exception_middleware(self, app) -> None: ...
+            def setup_cancellation_middleware(self, app) -> None: ...
+            def instrument_app_for_telemetry(self, app) -> None: ...
+
+        TestSimpleServer.run_webserver()
+        return captured
+
+    def test_proxy_headers_disabled_by_default_single_worker(self, monkeypatch: MonkeyPatch) -> None:
+        kwargs = self._capture_uvicorn_kwargs(monkeypatch, {}, num_workers=1)
+
+        assert kwargs["proxy_headers"] is False
+        assert [] == kwargs["forwarded_allow_ips"]
+        # A single worker passes the app object itself rather than an import string.
+        assert not isinstance(kwargs["app"], str)
+        assert "workers" not in kwargs
+
+    def test_proxy_headers_disabled_by_default_multi_worker(self, monkeypatch: MonkeyPatch) -> None:
+        kwargs = self._capture_uvicorn_kwargs(monkeypatch, {}, num_workers=4)
+
+        # Multi-worker launches re-import the app, so uvicorn receives an import string.
+        assert isinstance(kwargs["app"], str)
+        assert kwargs["app"].endswith(":app")
+        assert 4 == kwargs["workers"]
+        assert kwargs["proxy_headers"] is False
+        assert [] == kwargs["forwarded_allow_ips"]
+
+    def test_unrelated_uvicorn_settings_are_unchanged(self, monkeypatch: MonkeyPatch) -> None:
+        """The issue calls out parser, keepalive, access-log, and graceful-shutdown as must-not-change."""
+        kwargs = self._capture_uvicorn_kwargs(monkeypatch, {}, num_workers=1)
+
+        assert "httptools" == kwargs["http"]
+        assert 30 == kwargs["timeout_keep_alive"]
+        assert kwargs["access_log"] is False
+        assert 0.5 == kwargs["timeout_graceful_shutdown"]
+
+    def test_trusted_proxy_opt_in_is_forwarded_to_uvicorn(self, monkeypatch: MonkeyPatch) -> None:
+        kwargs = self._capture_uvicorn_kwargs(
+            monkeypatch,
+            {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.0.1"]},
+            num_workers=1,
+        )
+
+        assert kwargs["proxy_headers"] is True
+        assert ["10.0.0.1"] == kwargs["forwarded_allow_ips"]
+
+    def test_enabling_without_allowlist_fails_startup(self, monkeypatch: MonkeyPatch) -> None:
+        with raises(ValidationError, match="requires a non-empty uvicorn_forwarded_allow_ips"):
+            self._capture_uvicorn_kwargs(monkeypatch, {"uvicorn_proxy_headers": True}, num_workers=1)

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -821,7 +821,7 @@ _SPOOFED_HOST = "203.0.113.99"
 _LOOPBACK = "127.0.0.1"
 
 
-async def _scope_seen_by_app(*, proxy_headers: bool, allow_ips: list[str] | None, peer: str, forwarded: bool) -> dict:
+async def _scope_seen_by_app(*, uvicorn_kwargs: dict, peer: str, forwarded: bool) -> dict:
     """Drive uvicorn's loaded app with one request and return the scope the inner app observed."""
     seen: dict = {}
 
@@ -829,10 +829,12 @@ async def _scope_seen_by_app(*, proxy_headers: bool, allow_ips: list[str] | None
         seen["client"] = scope.get("client")
         seen["scheme"] = scope["scheme"]
 
+    # Take the proxy settings straight from what run_webserver produced, so this exercises
+    # Gym's wiring rather than restating uvicorn's defaults.
     config = uvicorn.Config(
         app=recorder,
-        proxy_headers=proxy_headers,
-        forwarded_allow_ips=allow_ips or [],
+        proxy_headers=uvicorn_kwargs["proxy_headers"],
+        forwarded_allow_ips=uvicorn_kwargs["forwarded_allow_ips"],
     )
     config.load()
 
@@ -894,10 +896,34 @@ class TestUvicornProxyHeadersConfig:
 
     def test_all_address_networks_are_rejected(self) -> None:
         for network in ("0.0.0.0/0", "::/0"):
-            with raises(ValidationError, match="must not contain an all-address CIDR"):
+            with raises(ValidationError, match="covers every address"):
                 UvicornProxyHeadersConfig.model_validate(
                     {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [network]}
                 )
+
+    def test_unparseable_allowlist_entries_are_rejected(self) -> None:
+        """uvicorn keeps an unparseable entry as a literal that never matches a TCP peer, so the
+        allowlist would look populated while trusting nobody."""
+        for bad in ("10.0.0.5/24", "proxy.internal", "not an ip", "0/0"):
+            with raises(ValidationError, match="is not a valid IP address or CIDR range"):
+                UvicornProxyHeadersConfig.model_validate(
+                    {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [bad]}
+                )
+
+    def test_ipv4_mapped_all_address_network_is_rejected(self) -> None:
+        """::ffff:0:0/96 has prefixlen 96 but trusts every IPv4 peer on a dual-stack socket."""
+        for bad in ("::ffff:0:0/96", "::ffff:0.0.0.0/96"):
+            with raises(ValidationError, match="covers every address"):
+                UvicornProxyHeadersConfig.model_validate(
+                    {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [bad]}
+                )
+
+    def test_valid_cidr_ranges_are_accepted(self) -> None:
+        config = UvicornProxyHeadersConfig.model_validate(
+            {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.1.0/24", "10.0.0.1"]}
+        )
+
+        assert ["10.0.1.0/24", "10.0.0.1"] == config.uvicorn_forwarded_allow_ips
 
     def test_allowlist_is_normalized(self) -> None:
         config = UvicornProxyHeadersConfig.model_validate(
@@ -908,46 +934,51 @@ class TestUvicornProxyHeadersConfig:
 
 
 class TestUvicornProxyHeadersBehavior:
-    async def test_forwarded_headers_ignored_when_disabled(self) -> None:
-        """The documented internal-only default: the real peer and scheme survive a forged header."""
-        seen = await _scope_seen_by_app(proxy_headers=False, allow_ips=None, peer=_LOOPBACK, forwarded=True)
+    """End-to-end: the kwargs run_webserver builds are fed to uvicorn and the resulting
+    middleware stack is driven with a real request."""
+
+    def _kwargs(self, monkeypatch: MonkeyPatch, config_dict: dict) -> dict:
+        return TestRunWebserverProxyKwargs()._capture_uvicorn_kwargs(monkeypatch, config_dict, num_workers=1)
+
+    async def test_forwarded_headers_ignored_on_the_default_internal_path(self, monkeypatch: MonkeyPatch) -> None:
+        """Gym's default config must leave the real peer and scheme intact despite forged headers."""
+        seen = await _scope_seen_by_app(uvicorn_kwargs=self._kwargs(monkeypatch, {}), peer=_LOOPBACK, forwarded=True)
 
         assert (_LOOPBACK, 54321) == seen["client"]
         assert "http" == seen["scheme"]
 
-    async def test_real_peer_reported_when_disabled_without_forwarded_headers(self) -> None:
-        seen = await _scope_seen_by_app(proxy_headers=False, allow_ips=None, peer=_LOOPBACK, forwarded=False)
+    async def test_real_peer_reported_when_no_forwarded_headers_are_sent(self, monkeypatch: MonkeyPatch) -> None:
+        seen = await _scope_seen_by_app(uvicorn_kwargs=self._kwargs(monkeypatch, {}), peer=_LOOPBACK, forwarded=False)
 
         assert (_LOOPBACK, 54321) == seen["client"]
         assert "http" == seen["scheme"]
 
-    async def test_forwarded_headers_honored_for_trusted_proxy(self) -> None:
-        seen = await _scope_seen_by_app(proxy_headers=True, allow_ips=[_LOOPBACK], peer=_LOOPBACK, forwarded=True)
+    async def test_forwarded_headers_honored_for_trusted_proxy(self, monkeypatch: MonkeyPatch) -> None:
+        kwargs = self._kwargs(monkeypatch, {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": [_LOOPBACK]})
+        seen = await _scope_seen_by_app(uvicorn_kwargs=kwargs, peer=_LOOPBACK, forwarded=True)
 
         assert (_SPOOFED_HOST, 0) == seen["client"]
         assert "https" == seen["scheme"]
 
-    async def test_forwarded_headers_ignored_from_untrusted_peer(self) -> None:
-        """Enabled, but the caller is not on the allowlist, so its forwarded claims are discarded."""
-        seen = await _scope_seen_by_app(proxy_headers=True, allow_ips=["10.0.0.1"], peer=_LOOPBACK, forwarded=True)
+    async def test_forwarded_headers_honored_for_trusted_cidr_range(self, monkeypatch: MonkeyPatch) -> None:
+        """A CIDR allowlist entry, as the configuration docs advertise, must actually match."""
+        kwargs = self._kwargs(
+            monkeypatch, {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.1.0/24"]}
+        )
+        seen = await _scope_seen_by_app(uvicorn_kwargs=kwargs, peer="10.0.1.55", forwarded=True)
+
+        assert (_SPOOFED_HOST, 0) == seen["client"]
+        assert "https" == seen["scheme"]
+
+    async def test_forwarded_headers_ignored_from_untrusted_peer(self, monkeypatch: MonkeyPatch) -> None:
+        """Opt-in enabled, but the caller is not on the allowlist, so its claims are discarded."""
+        kwargs = self._kwargs(
+            monkeypatch, {"uvicorn_proxy_headers": True, "uvicorn_forwarded_allow_ips": ["10.0.0.1"]}
+        )
+        seen = await _scope_seen_by_app(uvicorn_kwargs=kwargs, peer=_LOOPBACK, forwarded=True)
 
         assert (_LOOPBACK, 54321) == seen["client"]
         assert "http" == seen["scheme"]
-
-    def test_proxy_middleware_absent_for_single_and_multi_worker(self) -> None:
-        """run_webserver builds one kwargs dict for both launch paths, so the setting must hold for each."""
-        from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
-
-        for workers in (1, 4):
-            config = uvicorn.Config(
-                app=lambda scope, receive, send: None,
-                workers=workers,
-                proxy_headers=False,
-                forwarded_allow_ips=[],
-            )
-            config.load()
-
-            assert not isinstance(config.loaded_app, ProxyHeadersMiddleware), workers
 
 
 class TestRunWebserverProxyKwargs:


### PR DESCRIPTION
## What does this PR do?

Disables uvicorn's proxy-header middleware by default, and adds an explicit trusted-proxy opt-in for deployments behind a reverse proxy.

Gym builds its uvicorn arguments without setting `proxy_headers` or `forwarded_allow_ips`, so uvicorn's defaults stay active: every server is wrapped in `ProxyHeadersMiddleware` trusting `127.0.0.1`. Since Gym servers call each other over loopback, that trusted peer is the actual peer — any local caller can rewrite its own client address and URL scheme by setting `X-Forwarded-For` / `X-Forwarded-Proto`.

Two new top-level config keys:

| Key | Default | Description |
|-----|---------|-------------|
| `uvicorn_proxy_headers` | `false` | Honor `X-Forwarded-*` headers |
| `uvicorn_forwarded_allow_ips` | `null` | Addresses/CIDRs whose forwarded headers are trusted; required when enabled |

The allowlist is validated at startup. Rejected: an empty list, `*`, any entry covering every address (`0.0.0.0/0`, `::/0`, and IPv4-mapped supernets like `::ffff:0:0/96`, which trust every IPv4 peer on a dual-stack socket), and any entry that is not a parseable IP or CIDR. That last case matters because uvicorn keeps an unparseable entry as a literal it can never match against a TCP peer, so a typo such as `10.0.0.5/24` would otherwise leave a populated allowlist that trusts nobody.

Applied to both launch paths. `SimpleServer.run_webserver` builds one `uvicorn_kwargs` dict shared by the single-worker and import-string multi-worker branches, so those stay consistent. `HeadServer.run_webserver` has its own `uvicorn.Config` call and is configured the same way.

Closes #3009

## Validation

Reproduction using the same uvicorn kwargs as `run_webserver`, sending one plain request and one with forged headers:

**Before**
```
plain request   : {"client_host":"127.0.0.1","scheme":"http"}
SPOOFED headers : {"client_host":"203.0.113.99","scheme":"https"}
```

**After**
```
plain request   : {"client_host":"127.0.0.1","scheme":"http"}
SPOOFED headers : {"client_host":"127.0.0.1","scheme":"http"}
```

Also confirmed against a running Gym server via uvicorn access logs, which print the client address per request.

22 tests added across four classes: config validation, middleware behavior, `run_webserver` kwargs for both worker paths, and the head server.

The behavior tests drive uvicorn with the kwargs `run_webserver` actually produced, rather than with literals, so they exercise this repo's wiring instead of restating uvicorn's defaults. Removing the two kwargs lines fails 8 of the 22.

- `pytest tests/unit_tests/test_server_utils.py` — 52 passed
- `pytest tests/unit_tests/` — all unit tests pass
- `ruff check` / `ruff format` — clean
- `pre-commit run --all-files` — clean

## Benchmark

Load generated with bombardier (Go, keep-alive). One uvicorn worker per arm, both using the same kwargs as `run_webserver` (`httptools`, `access_log=False`, keepalive 30s). 3s warmup, 15s measured, 3 repetitions with the arm order alternated, median reported. Latency in microseconds.

Before measuring, the harness confirms each arm is in the state it claims to be, with forged `X-Forwarded-*` headers present on both:

```
arm=off    sees host=127.0.0.1     scheme=http     <- forged headers ignored
arm=optin  sees host=203.0.113.99  scheme=https    <- trusted proxy honored
```

The second line is the opt-in escape hatch working on a live server: a deployment behind a trusted reverse proxy still recovers the original client address and scheme.

Proxy handling off vs. trusted-proxy opt-in, with `X-Forwarded-*` sent to both arms so only server-side handling differs:

| payload | conc | OFF rps | p50 | p95 | p99 | OPT-IN rps | p50 | p95 | p99 | rps diff |
|---|---|---|---|---|---|---|---|---|---|---|
| tiny | 1 | 7461 | 130 | 142 | 149 | 6862 | 142 | 155 | 164 | +8.73% |
| tiny | 32 | 12603 | 2310 | 4531 | 4737 | 10961 | 2657 | 5212 | 5450 | +14.98% |
| 28KB | 1 | 6079 | 161 | 172 | 179 | 5703 | 170 | 187 | 194 | +6.60% |
| 28KB | 32 | 10787 | 3137 | 3857 | 4401 | 9503 | 3555 | 4368 | 5067 | +13.52% |
| 2MB | 1 | 369 | 2569 | 2698 | 2745 | 372 | 2575 | 2671 | 2703 | -1.01% |
| 2MB | 32 | 1241 | 25323 | 27976 | 29758 | 1253 | 24901 | 27584 | 28465 | -0.95% |

The 2 MB control shows no difference, as expected for payload-bound traffic.

Same comparison with no `X-Forwarded-*` headers sent, which is what Gym's internal traffic looks like. This table is really "Gym before this PR vs after", since `proxy_headers: true` was the default on main and internal callers do not send these headers:

| payload | conc | OFF rps | p50 | p95 | p99 | OPT-IN rps | p50 | p95 | p99 | rps diff |
|---|---|---|---|---|---|---|---|---|---|---|
| tiny | 1 | 7544 | 129 | 143 | 150 | 7281 | 133 | 150 | 157 | +3.62% |
| tiny | 32 | 12617 | 2318 | 4530 | 4761 | 11776 | 2482 | 4866 | 5082 | +7.14% |
| 28KB | 1 | 6050 | 162 | 175 | 181 | 5850 | 167 | 181 | 189 | +3.42% |
| 28KB | 32 | 10760 | 3131 | 3972 | 4667 | 10026 | 3367 | 4258 | 5009 | +7.32% |

That works out to about 4.8 microseconds saved per request on header-free internal traffic, and about 11.7 microseconds when forwarded headers are present and get parsed. The middleware is not free even with no headers to apply: it still does the trusted-host lookup and builds a dict of all request headers before finding nothing to use.

As a check on the setup, the OFF arm landed within about 1% across the two independent runs (7461 vs 7544, 12603 vs 12617, 6079 vs 6050, 10787 vs 10760).

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).




