### PR TITLE
test: isolated individual-only suggestion (throwaway, do not merge)

### DIFF
--- a/docker/install_codec_deps.sh
+++ b/docker/install_codec_deps.sh
@@ -37,3 +37,5 @@ uv pip install --no-config \
     "torchaudio==2.11.0"
 
 echo "[codec-deps] Done."
+
+# no-op: isolated test, individual-only suggestion (no team in this diff)


### PR DESCRIPTION
Isolated test PR touching ONLY docker/install_codec_deps.sh, which now
maps to exactly one individual suggestion (@anwithk) via CODEOWNERS,
with no team match anywhere in this diff.

Purpose: confirm whether the bot App token (nemo-automation-bot) can
successfully request an individual reviewer when no team is bundled
in the same batch call -- separate from the confirmed-broken
team-reviewer case.

Throwaway -- will close after checking the result.