### PR TITLE
feat: add Deepseek Harness

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -994,6 +994,9 @@ class NeMoGymChatCompletionAssistantMessageParam(ChatCompletionAssistantMessageP
     # Override the iterable which is annoying to work with.
     content: Union[str, List[ContentArrayOfContentPart], None]
     tool_calls: Optional[NeMoGymChatCompletionMessageToolCallsParam] = None
+    # Thinking-mode harnesses return reasoning alongside tool-call history.
+    reasoning_content: Optional[str]
+    reasoning: Optional[str]
 
 
 class NeMoGymChatCompletionAssistantMessageForTrainingParam(
@@ -1027,6 +1030,10 @@ NeMoGymChatCompletionMessageParam: TypeAlias = Annotated[
 ]
 
 
+class NeMoGymThinkingConfig(TypedDict):
+    type: Literal["enabled", "disabled"]
+
+
 class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1047,7 +1054,8 @@ class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
     presence_penalty: Optional[float] = None
     prompt_cache_key: Optional[str] = None
     prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
-    reasoning_effort: Optional[ReasoningEffort] = None
+    reasoning_effort: Optional[Union[ReasoningEffort, Literal["max"]]] = None
+    thinking: Optional[NeMoGymThinkingConfig] = None
     response_format: Optional[ResponseFormat] = None
     seed: Optional[int] = None
     safety_identifier: Optional[str] = None

--- a/responses_api_agents/deepseek_harness_agent/.gitignore
+++ b/responses_api_agents/deepseek_harness_agent/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/responses_api_agents/deepseek_harness_agent/README.md
+++ b/responses_api_agents/deepseek_harness_agent/README.md
@@ -1,0 +1,123 @@
+# DeepSeek Harness agent
+
+Runs the upstream DeepSeek Harness Python SDK **0.1.5rc1** inside a task sandbox
+through Gym's `AsyncSandbox` API. The resources server prepares the task and
+verifies the resulting workspace. The agent contains no benchmark-specific image,
+path, patch-extraction, or scoring logic.
+
+The default `sdk` profile retains the upstream harness. `sdk-minimal` selects the
+upstream persistent-shell-only profile for connectivity checks; it is a different
+agent configuration and should be reported separately in benchmark results.
+
+## Runtime and sandbox requirements
+
+- A resources server whose `/seed_session` returns `sandbox_descriptor`, accepted
+  by `AsyncSandbox.connect()`, or the existing `sandbox_handle` opaque-id field.
+  The latter is supported by the OpenSandbox execution path used by SWE-bench.
+- A matching, connectable Gym sandbox provider. Direct Sandbox API integration
+  does not imply that every provider implements reconnecting to another server's
+  task sandbox.
+- Linux task images with Python 3.10+, `venv`, and `pip`. The published runtime
+  wheels require glibc 2.28+ on x86-64 or arm64. System Node.js is unnecessary.
+- A Gym model server reachable from inside the sandbox and compatible with
+  DSH's DeepSeek Chat Completions dialect, including SSE and reasoning/tool calls.
+
+Preinstall `deepseek-harness-sdk==0.1.5rc1` into the sandbox image for repeated
+evaluations. Otherwise the runner installs that exact SDK and its matching
+runtime wheel into a per-rollout virtual environment outside the task repository;
+the image then needs package-index access. `python_executable` can select an
+existing Python environment containing the pinned SDK.
+
+Each rollout has its own `DSH_HOME`, session id, and artifacts directory. Gym
+provides task-container isolation; the runner sets `DSH_PERMISSION_MODE` to
+`danger-full-access` **inside that sandbox** to avoid nested kernel sandbox
+requirements and unattended approval prompts.
+
+With `stop_sandbox: true`, the agent closes the sandbox after verification,
+exceptions, or cancellation. Resources may also stop it during verification;
+cleanup failures are logged without replacing the verification result or original
+error. Set it to `false` only when the
+resources server owns cleanup, including failed runs. The SDK closes its runtime
+on normal completion/errors; execution deadlines and process-tree termination
+also depend on the selected sandbox provider.
+
+## Configure and run
+
+Compose `configs/deepseek_harness_agent.yaml` with a model, sandbox provider, and
+resources server. Set `model` to the actual model id, not the Gym server instance
+name. For example, the existing SWE-bench topology can be configured with:
+
+```bash
+gym env start \
+  --config responses_api_models/openai_model/configs/openai_model.yaml \
+  --config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml \
+  --config resources_servers/swebench/configs/swebench.yaml \
+  --config responses_api_agents/deepseek_harness_agent/configs/deepseek_harness_agent.yaml \
+  ++deepseek_harness_agent.responses_api_agents.deepseek_harness_agent.resources_server.name=swebench_resources_server \
+  ++deepseek_harness_agent.responses_api_agents.deepseek_harness_agent.model=YOUR_MODEL_ID \
+  '++swebench_resources_server.resources_servers.swebench.allowed_agents=[deepseek_harness_agent]'
+```
+
+Set `policy_base_url`, `policy_api_key`, and `policy_model_name` in `env.yaml` or
+as CLI overrides, plus the OpenSandbox connection settings as for the existing
+`opencode_sandboxed_agent`. Send a benchmark row to this agent's `/run` endpoint;
+task metadata is forwarded unchanged to `/seed_session` and `/verify`.
+`/responses` is the execution step within that prepared `/run` context.
+
+Use `openai_model` for hosted Chat Completions endpoints to preserve their native
+`reasoning_content` fields through Gym's SSE bridge. The `vllm_model` converter
+wraps reasoning in `<think>` text, which DSH records as assistant text.
+
+Supported input is one text user task (a string or one user message). Conversation
+replay, multimodal input, and caller-supplied tools/instructions are rejected.
+DSH owns its prompts and tool roster. `max_output_tokens` overrides the configured
+per-model-call `max_tokens`; `timeout_s` bounds sandbox runner execution, including
+dependency installation. `max_concurrency` limits active rollouts per server worker.
+
+## Results and validation
+
+The verifier's response/reward is preserved. Additional fields are
+`dsh_finish_reason`, `dsh_error`, and `dsh_artifacts`. A model token-limit outcome
+remains distinct from a runner error. Review these fields alongside reward: a
+partially completed workspace may still receive a verifier score.
+
+The artifact directory contains input configuration, raw SDK notifications in
+`events.jsonl`, the runner's `result.json`, and stdout/stderr when available.
+Notifications are flushed while running, including child sessions and compaction
+events. Artifacts are retrieved before sandbox cleanup, also after execution
+errors. A terminated runner may leave a partial final JSONL record; that is
+reported as an incomplete event log.
+
+Gym's response contains the committed **root-session** reasoning, assistant text,
+tool calls/results, and root usage. Child output does not overwrite the root
+response. Cache reads/writes are included in Gym input-token totals; missing
+detail counts remain unknown. The raw event log is authoritative for context
+injections, compaction, and subagent behavior.
+
+This is an evaluation integration. Training token IDs/logprobs are not synthesized
+from text. Gym currently buffers model completions before emitting SSE; align
+timeouts with the longest model call. Its `external_staging` training-capture path
+rejects streaming requests and needs separate integration work.
+
+```bash
+pytest responses_api_agents/deepseek_harness_agent/tests
+ruff check responses_api_agents/deepseek_harness_agent
+ruff format --check responses_api_agents/deepseek_harness_agent
+```
+
+Install `deepseek-harness-sdk==0.1.5rc1` in the test environment to enable the SDK
+smokes. Those use the real published runtime and real shell tools with a
+deterministic model endpoint, for both profiles. They validate execution and event
+translation, not real-model quality or benchmark/provider compatibility. A real
+rollout with the intended model and sandbox provider is still required before
+claiming benchmark validation.
+
+A real-model smoke on 2026-09-10 passed for both profiles with DeepSeek V4 Flash,
+Gym's `openai_model`, and an Enroot task container: read and repair a Python
+function, execute tool calls, export the trajectory, and pass independent Python
+assertions. This exercises `/responses` on a prepared sandbox; it does not
+validate the resource-server `/run` handoff or a benchmark. Enroot itself does
+not implement the reconnect capability required by `/run`.
+
+Tracking: [#2577](https://github.com/NVIDIA-NeMo/Gym/issues/2577),
+[#2950](https://github.com/NVIDIA-NeMo/Gym/issues/2950).

--- a/responses_api_agents/deepseek_harness_agent/README.md
+++ b/responses_api_agents/deepseek_harness_agent/README.md
@@ -112,12 +112,64 @@ translation, not real-model quality or benchmark/provider compatibility. A real
 rollout with the intended model and sandbox provider is still required before
 claiming benchmark validation.
 
-A real-model smoke on 2026-09-10 passed for both profiles with DeepSeek V4 Flash,
+Tests are passed for both profiles with DeepSeek V4 Flash,
 Gym's `openai_model`, and an Enroot task container: read and repair a Python
 function, execute tool calls, export the trajectory, and pass independent Python
 assertions. This exercises `/responses` on a prepared sandbox; it does not
 validate the resource-server `/run` handoff or a benchmark. Enroot itself does
 not implement the reconnect capability required by `/run`.
+
+### Benchmark pilot
+
+Gym commit `7d1761dc58e9799d8c2762963264b92d612d958f` was evaluated with
+OpenSandbox task containers on an H100 host. All three harnesses used
+`nvidia/deepseek-ai/deepseek-v4-flash` through NVIDIA Inference Hub; inference
+was remote, so these results do not measure local H100 inference performance.
+DSH used SDK `0.1.5rc1`; the reference harness used OpenCode `1.17.11`.
+
+The fixed pilot selected 50 SWE-bench Verified tasks across 12 repositories and
+10 Terminal-Bench 2.1 tasks across 10 categories. Dataset revisions were
+`c104f840cc67f8b6eec6f759ebc8b2693d585d4a` (SWE) and
+`7131e4375048a0e408a8fb404b5f499d726b695b` (Terminal), with selection seed
+`dsh-benchmark-20260910-v1`. Each harness used the same tasks, model, temperature
+(0.6), and externally enforced budgets: 8,192 output tokens per model call,
+65,536 cumulative output tokens and 100 model calls per rollout, with separate
+1,800-second agent and verifier limits. Native harness prompts and tools differed.
+
+| Harness | SWE-bench Verified (50 tasks) | Terminal-Bench 2.1 (10 tasks) |
+| --- | ---: | ---: |
+| DSH `sdk` | 31/50 (62%) | 6/10 (60%) |
+| DSH `sdk-minimal` | 39/50 (78%) | 4/10 (40%) |
+| OpenCode | 32/50 (64%) | 6/10 (60%) |
+
+Scores count tasks resolved by the benchmark verifier. All 120 positive/negative
+verifier calibration controls passed. The final audit found no score or budget
+inconsistencies across 180 retained outcomes and 150 official SWE test reports.
+Verifiers completed for 179/180 outcomes; one `sdk-minimal` Terminal attempt
+damaged its task environment and remained in the denominator with score 0.
+Timeouts and budget stops also remained in the scored cohort.
+
+On this SWE sample, `sdk-minimal` solved seven more tasks than OpenCode while
+using 3.28× the upstream input tokens and 2.30× the output tokens. This is a
+coverage-oriented pilot; the results do not establish full-suite performance
+or a stable ranking between harnesses.
+
+Remaining validation limits:
+
+- Six interrupted SWE attempts and three setup failures before model calls were
+  rerun, with their original records retained. Earlier batches affected by gateway
+  throttling or a test-adapter history-isolation error were quarantined in full.
+  These scores therefore cannot be described as uninterrupted pass@1.
+- Evidence has gaps: 18 OpenCode structured snapshots failed, one model response
+  was truncated, and two SDK final result files were absent after inferred
+  timeouts. Available exports, partial events, usage records and verifier results
+  were retained; complete trajectory capture has not been validated.
+- SDK errors can produce `dsh_finish_reason="error"` with `dsh_error=null` on the
+  tested commit. A separate error-propagation patch passed 37 focused tests and
+  real-model smoke runs for both profiles; it was not part of the scored code.
+
+Full SWE (500 tasks), Terminal (89 tasks), and repeated experiments have not run.
+Expansion is gated on fixing error reporting and the material capture gaps.
 
 Tracking: [#2577](https://github.com/NVIDIA-NeMo/Gym/issues/2577),
 [#2950](https://github.com/NVIDIA-NeMo/Gym/issues/2950).

--- a/responses_api_agents/deepseek_harness_agent/app.py
+++ b/responses_api_agents/deepseek_harness_agent/app.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from shlex import quote
+from time import time
+from typing import Any, Literal
+from uuid import uuid4
+
+from fastapi import HTTPException, Request
+from pydantic import ConfigDict, Field
+
+from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
+from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, SimpleResponsesAPIAgent
+from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.sandbox import AsyncSandbox, create_provider, resolve_provider_config
+from nemo_gym.server_utils import get_response_json, is_nemo_gym_fastapi_entrypoint, raise_for_status
+from responses_api_agents.deepseek_harness_agent.trajectory import convert_events
+
+
+class DeepSeekHarnessAgentConfig(BaseResponsesAPIAgentConfig):
+    resources_server: ResourcesServerRef
+    model_server: ModelServerRef
+    model: str
+    sandbox_provider: str
+    profile: Literal["sdk", "sdk-minimal"] = "sdk"
+    reasoning_effort: str | None = None
+    max_tokens: int = Field(default=32768, gt=0)
+    timeout_s: float = Field(default=1800, gt=0)
+    max_concurrency: int = Field(default=4, gt=0)
+    python_executable: str = "python3"
+    results_dir: Path = Path(__file__).parent / "results"
+    # Also clean up failed runs and resources that delegate sandbox cleanup.
+    stop_sandbox: bool = True
+
+
+class DeepSeekHarnessRunRequest(BaseRunRequest):
+    model_config = ConfigDict(extra="allow")
+
+
+class DeepSeekHarnessVerifyResponse(BaseVerifyResponse):
+    model_config = ConfigDict(extra="allow")
+
+    dsh_finish_reason: str | None
+    dsh_error: str | None = None
+    dsh_artifacts: str
+
+
+def task_text(body: NeMoGymResponseCreateParamsNonStreaming) -> str:
+    if body.instructions or body.tools or body.previous_response_id:
+        raise HTTPException(422, "DSH accepts a fresh text task; configure its instructions and tools in its profile.")
+    if isinstance(body.input, str):
+        prompt = body.input
+    else:
+        if len(body.input) != 1 or getattr(body.input[0], "role", None) != "user":
+            raise HTTPException(422, "DSH requires one user task, without conversation history.")
+        content = body.input[0].content
+        if isinstance(content, str):
+            prompt = content
+        else:
+            if any(part.get("type") != "input_text" for part in content):
+                raise HTTPException(422, "DSH currently supports text tasks only.")
+            prompt = "\n".join(part["text"] for part in content)
+    if not prompt.strip():
+        raise HTTPException(422, "DSH requires a non-empty task.")
+    return prompt
+
+
+class DeepSeekHarnessAgent(SimpleResponsesAPIAgent):
+    config: DeepSeekHarnessAgentConfig
+
+    def model_post_init(self, context: Any, /) -> None:
+        super().model_post_init(context)
+        self._semaphore = asyncio.Semaphore(self.config.max_concurrency)
+
+    async def responses(self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
+        sandbox = getattr(request.state, "dsh_sandbox", None)
+        if sandbox is None:
+            raise HTTPException(400, "Use /run to prepare the task sandbox before running DSH.")
+        session_id = uuid4().hex
+        local_dir = self.config.results_dir / session_id
+        local_dir.mkdir(parents=True)
+        remote_dir = f"/tmp/nemo-gym-dsh-{session_id}"
+        harness_config = {
+            "model": body.model or self.config.model,
+            "profile": self.config.profile,
+            "base_url": self.resolve_model_base_url(self.config.model_server.name, request.state.dsh_rollout_id),
+            "api_key": "EMPTY",
+            # Gym owns container isolation; avoid nested host sandbox/approval dependencies.
+            "env": {"DSH_PERMISSION_MODE": "danger-full-access"},
+            "reasoning_effort": self.config.reasoning_effort,
+            "max_tokens": body.max_output_tokens or self.config.max_tokens,
+            "initialize_timeout_seconds": min(120, self.config.timeout_s),
+            "request_timeout_seconds": self.config.timeout_s,
+        }
+        input_path = local_dir / "input.json"
+        input_path.write_text(
+            json.dumps({"prompt": task_text(body), "session_id": session_id, "harness": harness_config})
+        )
+        result = await sandbox.exec(f"mkdir -m 700 {quote(remote_dir)}")
+        if result.return_code != 0:
+            raise RuntimeError("Could not create the DSH run directory in the task sandbox")
+        await sandbox.upload(Path(__file__).with_name("runner.py"), f"{remote_dir}/runner.py")
+        await sandbox.upload(input_path, f"{remote_dir}/input.json")
+        execution_error = None
+        try:
+            result = await sandbox.exec(
+                f"{quote(self.config.python_executable)} {remote_dir}/runner.py {remote_dir}/input.json",
+                timeout_s=self.config.timeout_s,
+            )
+            (local_dir / "stdout.log").write_text(result.stdout or "")
+            (local_dir / "stderr.log").write_text(result.stderr or "")
+            if result.return_code != 0:
+                execution_error = f"DSH runner exited with code {result.return_code}"
+        except Exception as exc:
+            execution_error = f"{type(exc).__name__}: {exc}"
+        finally:
+            for name in ("events.jsonl", "result.json"):
+                try:
+                    await sandbox.download(f"{remote_dir}/{name}", local_dir / name)
+                except Exception:
+                    logging.getLogger(__name__).warning("Could not retrieve DSH artifact %s", name, exc_info=True)
+        result_path = local_dir / "result.json"
+        try:
+            summary = json.loads(result_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            summary = {"finish_reason": "error", "error": execution_error or "Missing or invalid DSH result"}
+        if summary["error"]:
+            summary["finish_reason"] = "error"
+        notifications = []
+        events_path = local_dir / "events.jsonl"
+        if not events_path.exists():
+            summary.update(finish_reason="error", error=summary.get("error") or "Missing DSH event log")
+        if events_path.exists():
+            for line in events_path.read_text().splitlines():
+                try:
+                    notifications.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # A terminated runner can leave a partial final JSONL record.
+                    summary["error"] = "Incomplete DSH event log"
+                    summary["finish_reason"] = "error"
+        output, usage = convert_events(notifications, session_id)
+        request.state.dsh_result = {
+            "dsh_finish_reason": summary["finish_reason"],
+            "dsh_error": summary["error"],
+            "dsh_artifacts": str(local_dir),
+        }
+        return NeMoGymResponse(
+            id=f"resp_{session_id}",
+            created_at=int(time()),
+            model=harness_config["model"],
+            object="response",
+            output=output,
+            usage=usage,
+            status="completed" if summary["finish_reason"] == "completed" else "incomplete",
+            tool_choice=body.tool_choice,
+            tools=body.tools,
+            parallel_tool_calls=body.parallel_tool_calls,
+        )
+
+    async def run(self, request: Request, body: DeepSeekHarnessRunRequest) -> DeepSeekHarnessVerifyResponse:
+        task_text(body.responses_create_params)
+        async with self._semaphore:
+            seed = await self.server_client.post(
+                self.config.resources_server.name, "/seed_session", json=body.model_dump(), cookies=request.cookies
+            )
+            await raise_for_status(seed)
+            cookies = request.cookies | seed.cookies
+            state = await get_response_json(seed)
+            descriptor = state.get("sandbox_descriptor")
+            if descriptor is None:
+                # The existing sandboxed-agent wire protocol carries an opaque sandbox id.
+                descriptor = {"sandbox_id": state["sandbox_handle"]}
+            provider = create_provider(
+                resolve_provider_config(self.config.sandbox_provider, self.server_client.global_config_dict)
+            )
+            sandbox = None
+            try:
+                sandbox = await AsyncSandbox.connect(descriptor, provider=provider)
+                request.state.dsh_sandbox = sandbox
+                request.state.dsh_rollout_id = self.rollout_id_from_run(body)
+                response = await self.responses(request, body.responses_create_params)
+                verify_body = body.model_dump() | {"response": response.model_dump()}
+                if self.config.skip_verification:
+                    verified = verify_body | {"reward": self.config.skip_verification_reward}
+                else:
+                    verification = await self.server_client.post(
+                        self.config.resources_server.name, "/verify", json=verify_body, cookies=cookies
+                    )
+                    await raise_for_status(verification)
+                    verified = await get_response_json(verification)
+                return DeepSeekHarnessVerifyResponse.model_validate(verified | request.state.dsh_result)
+            finally:
+                request.state.dsh_sandbox = None
+                try:
+                    if sandbox is not None and self.config.stop_sandbox:
+                        await sandbox.stop()
+                    else:
+                        await provider.aclose()
+                except Exception:
+                    logging.getLogger(__name__).warning("Could not clean up DSH sandbox connection", exc_info=True)
+
+
+if __name__ == "__main__":
+    DeepSeekHarnessAgent.run_webserver()
+elif is_nemo_gym_fastapi_entrypoint(__file__):
+    app = DeepSeekHarnessAgent.run_webserver()

--- a/responses_api_agents/deepseek_harness_agent/configs/deepseek_harness_agent.yaml
+++ b/responses_api_agents/deepseek_harness_agent/configs/deepseek_harness_agent.yaml
@@ -1,0 +1,17 @@
+deepseek_harness_agent:
+  responses_api_agents:
+    deepseek_harness_agent:
+      entrypoint: app.py
+      resources_server:
+        type: resources_servers
+        name: ???
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      model: ???
+      sandbox_provider: sandbox
+      profile: sdk
+      max_tokens: 32768
+      timeout_s: 1800
+      max_concurrency: 4
+      datasets: []

--- a/responses_api_agents/deepseek_harness_agent/requirements.txt
+++ b/responses_api_agents/deepseek_harness_agent/requirements.txt
@@ -1,0 +1,1 @@
+-e nemo-gym[dev,sandbox] @ ../../

--- a/responses_api_agents/deepseek_harness_agent/runner.py
+++ b/responses_api_agents/deepseek_harness_agent/runner.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the pinned upstream SDK inside a task sandbox, independently of Gym."""
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+DSH_VERSION = "0.1.5rc1"
+
+
+def ensure_sdk(run_dir: Path) -> None:
+    try:
+        if version("deepseek-harness-sdk") == DSH_VERSION:
+            return
+    except PackageNotFoundError:
+        pass
+    # Keep dependencies out of the task repository and its Python environment.
+    venv = run_dir / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+    python = str(venv / "bin" / "python")
+    subprocess.run(
+        [
+            python,
+            "-m",
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "--disable-pip-version-check",
+            f"deepseek-harness-sdk=={DSH_VERSION}",
+        ],
+        check=True,
+    )
+    os.execv(python, [python, *sys.argv])
+
+
+def run(config_path: Path) -> int:
+    run_dir = config_path.parent
+    result = {"finish_reason": "error", "error": None, "version": DSH_VERSION}
+    try:
+        ensure_sdk(run_dir)
+        from deepseek_harness import DeepSeekHarness
+
+        config = json.loads(config_path.read_text())
+        config["harness"]["env"] = {
+            **config["harness"].get("env", {}),
+            "PKG_NATIVE_CACHE_PATH": str(run_dir / "cache"),
+            "XDG_CACHE_HOME": str(run_dir / "cache"),
+        }
+        with (run_dir / "events.jsonl").open("w", buffering=1) as events:
+            with DeepSeekHarness(
+                dsh_home=str(run_dir / "home"),
+                cwd=os.getcwd(),
+                runtime_cwd=os.getcwd(),
+                **config["harness"],
+            ) as harness:
+                output = harness.run(
+                    config["prompt"],
+                    session_id=config["session_id"],
+                    on_notification=lambda notification: events.write(json.dumps(asdict(notification)) + "\n"),
+                )
+                result["finish_reason"] = output.finish_reason
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        (run_dir / "result.json").write_text(json.dumps(result))
+    return 0 if result["finish_reason"] == "completed" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run(Path(sys.argv[1])))

--- a/responses_api_agents/deepseek_harness_agent/tests/test_app.py
+++ b/responses_api_agents/deepseek_harness_agent/tests/test_app.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import shlex
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from nemo_gym.global_config import OBSERVABILITY_ENABLED_KEY_NAME
+from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.server_utils import ServerClient
+from responses_api_agents.deepseek_harness_agent import app as module
+from responses_api_agents.deepseek_harness_agent.app import (
+    DeepSeekHarnessAgent,
+    DeepSeekHarnessAgentConfig,
+    DeepSeekHarnessRunRequest,
+    task_text,
+)
+from responses_api_agents.deepseek_harness_agent.trajectory import convert_events
+
+
+def event(kind, data, seq=1, session="root"):
+    return {
+        "method": "session.event",
+        "payload": {"sessionId": session, "event": {"type": kind, "data": data, "seq": seq}},
+    }
+
+
+def transcript(session="root"):
+    return [
+        event(
+            "assistant/message",
+            {
+                "message": {
+                    "content": [
+                        {"type": "reasoning", "text": "Inspect the file."},
+                        {"type": "tool-call", "id": "call_1", "name": "bash", "arguments": '{"command":"cat answer"}'},
+                    ]
+                },
+                "usage": {"inputTokens": 20, "cacheReadTokens": 10, "outputTokens": 5},
+            },
+            session=session,
+        ),
+        event("tool/call", {"callId": "call_1", "name": "bash", "arguments": "{}"}, seq=2, session=session),
+        event(
+            "tool/result",
+            {
+                "message": {
+                    "content": [
+                        {"type": "tool-result", "toolCallId": "call_1", "content": [{"type": "text", "text": "42"}]}
+                    ]
+                }
+            },
+            seq=3,
+            session=session,
+        ),
+        event(
+            "assistant/message",
+            {
+                "message": {"content": [{"type": "text", "text": "42"}]},
+                "usage": {"inputTokens": 30, "outputTokens": 2},
+            },
+            seq=4,
+            session=session,
+        ),
+    ]
+
+
+def test_transcript_preserves_call_order_reasoning_and_cached_usage():
+    notifications = transcript() + [
+        event("assistant/message", {"message": {"content": [{"type": "text", "text": "child"}]}}, session="child")
+    ]
+    output, usage = convert_events(notifications, "root")
+    assert [item.type for item in output] == ["reasoning", "function_call", "function_call_output", "message"]
+    assert output[1].call_id == output[2].call_id == "call_1"
+    assert output[2].output == "42"
+    assert output[0].summary[0].text == "Inspect the file."
+    assert (usage.input_tokens, usage.output_tokens, usage.total_tokens) == (60, 7, 67)
+    assert usage.input_tokens_details.cached_tokens is None
+    assert usage.output_tokens_details.reasoning_tokens is None
+
+
+@pytest.mark.parametrize(
+    "block", [{"type": "image"}, {"type": "tool-result", "toolCallId": "x", "content": [{"type": "image"}]}]
+)
+def test_unsupported_output_is_not_silently_discarded(block):
+    with pytest.raises(ValueError):
+        convert_events([event("assistant/message", {"message": {"content": [block]}})], "root")
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    ["hi", [{"role": "user", "content": "hi"}], [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]],
+)
+def test_text_inputs(input_value):
+    assert task_text(NeMoGymResponseCreateParamsNonStreaming(input=input_value)) == "hi"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"input": " "},
+        {"input": []},
+        {"input": [{"role": "system", "content": "hi"}]},
+        {"input": "hi", "instructions": "instruction"},
+        {"input": "hi", "previous_response_id": "old"},
+        {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_image", "image_url": "https://example.com/image.png", "detail": "auto"}
+                    ],
+                }
+            ]
+        },
+    ],
+)
+def test_unsupported_inputs_fail_before_starting_a_sandbox(kwargs):
+    with pytest.raises(HTTPException, match="DSH"):
+        task_text(NeMoGymResponseCreateParamsNonStreaming(**kwargs))
+
+
+@pytest.fixture
+def setup(tmp_path, monkeypatch):
+    config = DeepSeekHarnessAgentConfig(
+        host="127.0.0.1",
+        port=8080,
+        entrypoint="app.py",
+        name="dsh",
+        resources_server={"type": "resources_servers", "name": "tasks"},
+        model_server={"type": "responses_api_models", "name": "policy_model"},
+        model="test-model",
+        sandbox_provider="sandbox",
+        results_dir=tmp_path,
+    )
+    client = MagicMock(spec=ServerClient)
+    client.global_config_dict = {OBSERVABILITY_ENABLED_KEY_NAME: True}
+    agent = DeepSeekHarnessAgent(config=config, server_client=client)
+    monkeypatch.setattr(
+        DeepSeekHarnessAgent, "resolve_model_base_url", lambda self, name, rollout: f"http://model/{rollout}/v1"
+    )
+    monkeypatch.setattr(module, "resolve_provider_config", lambda *args: {})
+    provider = AsyncMock()
+    monkeypatch.setattr(module, "create_provider", lambda *args: provider)
+    monkeypatch.setattr(module, "raise_for_status", AsyncMock())
+    monkeypatch.setattr(module, "get_response_json", lambda response: response.json())
+    files = {}
+    order = []
+    sandbox = AsyncMock()
+    state = SimpleNamespace(
+        agent=agent,
+        sandbox=sandbox,
+        provider=provider,
+        files=files,
+        order=order,
+        mode="completed",
+        seed={"sandbox_handle": "opaque-id"},
+    )
+
+    async def upload(local, remote):
+        files[remote] = Path(local).read_text()
+
+    async def download(remote, local):
+        Path(local).write_text(files[remote])
+        order.append("download")
+
+    async def execute(command, **kwargs):
+        if command.startswith("mkdir"):
+            return SimpleNamespace(return_code=0)
+        assert "user task" not in command
+        input_path = shlex.split(command)[-1]
+        data = json.loads(files[input_path])
+        assert data["harness"]["base_url"] == "http://model/rollout-1/v1"
+        assert data["harness"]["env"]["DSH_PERMISSION_MODE"] == "danger-full-access"
+        root = str(Path(input_path).parent)
+        files[root + "/events.jsonl"] = "\n".join(json.dumps(x) for x in transcript(data["session_id"]))
+        if state.mode == "cancel":
+            raise asyncio.CancelledError()
+        if state.mode == "timeout":
+            raise TimeoutError("runner deadline")
+        files[root + "/result.json"] = json.dumps({"finish_reason": state.mode, "error": None})
+        return SimpleNamespace(return_code=0 if state.mode == "completed" else 1, stdout="", stderr="")
+
+    async def post(server, path, **kwargs):
+        order.append(path)
+        if path == "/seed_session":
+            assert kwargs["json"]["task_metadata"] == {"opaque": "kept"}
+            assert kwargs["cookies"] == {"original": "cookie"}
+            return SimpleNamespace(cookies={"resource": "cookie"}, json=AsyncMock(return_value=state.seed))
+        assert kwargs["cookies"] == {"original": "cookie", "resource": "cookie"}
+        assert kwargs["json"]["task_metadata"] == {"opaque": "kept"}
+        if state.mode == "verifier-error":
+            raise RuntimeError("verifier unavailable")
+        return SimpleNamespace(json=AsyncMock(return_value=kwargs["json"] | {"reward": 1.0}))
+
+    sandbox.upload.side_effect = upload
+    sandbox.download.side_effect = download
+    sandbox.exec.side_effect = execute
+    sandbox.stop.side_effect = lambda: order.append("stop")
+    client.post = AsyncMock(side_effect=post)
+    monkeypatch.setattr(module.AsyncSandbox, "connect", AsyncMock(return_value=sandbox))
+    state.body = DeepSeekHarnessRunRequest(
+        responses_create_params={"input": "user task ' $(false)"},
+        task_metadata={"opaque": "kept"},
+        _ng_rollout_id="rollout-1",
+    )
+    state.request = lambda: Request({"type": "http", "headers": [(b"cookie", b"original=cookie")]})
+    return state
+
+
+@pytest.mark.parametrize("descriptor", [False, True])
+async def test_run_keeps_resources_opaque_and_verifies_before_cleanup(setup, descriptor):
+    if descriptor:
+        setup.seed = {"sandbox_descriptor": {"provider_token": "opaque", "workdir": "/workspace"}}
+    result = await setup.agent.run(setup.request(), setup.body)
+    assert result.reward == 1
+    assert result.dsh_finish_reason == "completed"
+    assert result.dsh_error is None
+    assert Path(result.dsh_artifacts, "events.jsonl").exists()
+    assert setup.order[-2:] == ["/verify", "stop"]
+    expected = setup.seed.get("sandbox_descriptor", {"sandbox_id": "opaque-id"})
+    assert module.AsyncSandbox.connect.await_args.args[0] == expected
+
+
+@pytest.mark.parametrize("mode", ["timeout", "max-tokens"])
+async def test_partial_runs_keep_their_trajectory_and_finish_reason(setup, mode):
+    setup.mode = mode
+    result = await setup.agent.run(setup.request(), setup.body)
+    assert result.response.status == "incomplete"
+    assert result.response.output[-1].content[0].text == "42"
+    assert result.dsh_finish_reason == ("error" if mode == "timeout" else "max-tokens")
+    assert bool(result.dsh_error) == (mode == "timeout")
+    setup.sandbox.stop.assert_awaited_once()
+
+
+@pytest.mark.parametrize("mode,error", [("verifier-error", RuntimeError), ("cancel", asyncio.CancelledError)])
+async def test_failures_release_sandbox_and_capture_partial_events(setup, mode, error):
+    setup.mode = mode
+    with pytest.raises(error):
+        await setup.agent.run(setup.request(), setup.body)
+    setup.sandbox.stop.assert_awaited_once()
+    assert "download" in setup.order
+
+
+async def test_independent_runs_have_independent_homes_and_artifacts(setup):
+    a, b = await asyncio.gather(
+        setup.agent.run(setup.request(), setup.body), setup.agent.run(setup.request(), setup.body)
+    )
+    assert a.dsh_artifacts != b.dsh_artifacts
+    inputs = [json.loads(value) for name, value in setup.files.items() if name.endswith("input.json")]
+    assert len({item["session_id"] for item in inputs}) == 2
+
+
+async def test_resources_can_retain_sandbox_ownership_and_skip_verification(setup):
+    setup.agent.config.stop_sandbox = False
+    setup.agent.config.skip_verification = True
+    result = await setup.agent.run(setup.request(), setup.body)
+    assert result.reward == 0
+    assert "/verify" not in setup.order
+    setup.sandbox.stop.assert_not_awaited()
+    setup.provider.aclose.assert_awaited_once()
+
+
+async def test_cleanup_failure_preserves_verifier_result(setup, caplog):
+    setup.sandbox.stop.side_effect = RuntimeError("sandbox already stopped")
+    result = await setup.agent.run(setup.request(), setup.body)
+    assert result.reward == 1
+    assert result.dsh_finish_reason == "completed"
+    assert "Could not clean up DSH sandbox connection" in caplog.text
+
+
+async def test_connection_failure_releases_provider(setup):
+    module.AsyncSandbox.connect.side_effect = TimeoutError("connect failed")
+    with pytest.raises(TimeoutError, match="connect failed"):
+        await setup.agent.run(setup.request(), setup.body)
+    setup.provider.aclose.assert_awaited_once()
+    setup.sandbox.stop.assert_not_awaited()
+
+
+async def test_responses_requires_prepared_run_context(setup):
+    with pytest.raises(HTTPException, match="/run"):
+        await setup.agent.responses(setup.request(), setup.body.responses_create_params)
+
+
+async def test_preparation_failure_closes_sandbox_without_calling_verifier(setup):
+    setup.sandbox.exec.side_effect = None
+    setup.sandbox.exec.return_value = SimpleNamespace(return_code=1)
+    with pytest.raises(RuntimeError, match="run directory"):
+        await setup.agent.run(setup.request(), setup.body)
+    setup.sandbox.stop.assert_awaited_once()
+    assert "/verify" not in setup.order
+
+
+@pytest.mark.parametrize("fault", ["missing-events", "partial-event", "partial-result", "runtime-error"])
+async def test_artifact_failures_cannot_report_success(setup, fault):
+    original = setup.sandbox.download.side_effect
+
+    async def download(remote, local):
+        if remote.endswith("events.jsonl"):
+            if fault == "missing-events":
+                raise FileNotFoundError(remote)
+            if fault == "partial-event":
+                setup.files[remote] += '\n{"payload":'
+        if remote.endswith("result.json") and fault == "runtime-error":
+            setup.files[remote] = json.dumps({"finish_reason": "completed", "error": "runtime shutdown failed"})
+        if remote.endswith("result.json") and fault == "partial-result":
+            setup.files[remote] = '{"finish_reason":'
+        await original(remote, local)
+
+    setup.sandbox.download.side_effect = download
+    result = await setup.agent.run(setup.request(), setup.body)
+    assert result.dsh_error
+    assert result.dsh_finish_reason == "error"
+    setup.sandbox.stop.assert_awaited_once()

--- a/responses_api_agents/deepseek_harness_agent/tests/test_runner.py
+++ b/responses_api_agents/deepseek_harness_agent/tests/test_runner.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from responses_api_agents.deepseek_harness_agent import runner
+
+
+@pytest.mark.parametrize("installed", [None, "0.0.0"])
+def test_bootstrap_installs_the_pin_in_an_isolated_venv(tmp_path, monkeypatch, installed):
+    metadata = Mock(return_value=installed) if installed else Mock(side_effect=runner.PackageNotFoundError)
+    monkeypatch.setattr(runner, "version", metadata)
+    execute = Mock()
+    replace = Mock()
+    monkeypatch.setattr(runner.subprocess, "run", execute)
+    monkeypatch.setattr(runner.os, "execv", replace)
+    runner.ensure_sdk(tmp_path)
+    python = str(tmp_path / "venv/bin/python")
+    assert execute.call_args_list[0].args[0][-2:] == ["venv", str(tmp_path / "venv")]
+    install = execute.call_args_list[1].args[0]
+    assert install[0] == python
+    assert install[-1] == "deepseek-harness-sdk==0.1.5rc1"
+    assert "--no-cache-dir" in install
+    assert replace.call_args.args[0] == python
+
+
+def test_bootstrap_failure_is_reported_without_starting_harness(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "ensure_sdk", Mock(side_effect=RuntimeError("package index unavailable")))
+    assert runner.run(tmp_path / "input.json") == 1
+    result = json.loads((tmp_path / "result.json").read_text())
+    assert result["finish_reason"] == "error"
+    assert result["error"] == "RuntimeError: package index unavailable"

--- a/responses_api_agents/deepseek_harness_agent/tests/test_sdk.py
+++ b/responses_api_agents/deepseek_harness_agent/tests/test_sdk.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the real pinned SDK and shell tool against a deterministic model endpoint."""
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.metadata import PackageNotFoundError, version
+from threading import Thread
+
+import pytest
+
+from nemo_gym.base_responses_api_model import _validate_chat_params
+from nemo_gym.chat_streaming import sanitize_streaming_chat_body
+from responses_api_agents.deepseek_harness_agent import runner
+from responses_api_agents.deepseek_harness_agent.trajectory import convert_events
+
+
+try:
+    sdk_available = version("deepseek-harness-sdk") == runner.DSH_VERSION
+except PackageNotFoundError:
+    sdk_available = False
+
+
+@pytest.mark.skipif(not sdk_available, reason=f"Requires deepseek-harness-sdk=={runner.DSH_VERSION}")
+@pytest.mark.parametrize("profile", ["sdk-minimal", "sdk"])
+def test_real_sdk_executes_tool_and_exports_gym_trajectory(tmp_path, profile, monkeypatch):
+    requests = []
+
+    class Model(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            cleaned, include_usage = sanitize_streaming_chat_body(body)
+            assert include_usage
+            body = _validate_chat_params(cleaned).model_dump(exclude_unset=True)
+            requests.append(body)
+            if len(requests) == 1:
+                tool = next(t["function"] for t in body["tools"] if t["function"]["name"] == "bash")
+                arguments = {"command": "printf 'sdk-ok' > proof.txt; cat proof.txt"}
+                if "description" in tool["parameters"]["properties"]:
+                    arguments["description"] = "Write and read the smoke-test artifact"
+                delta = {
+                    "role": "assistant",
+                    "reasoning_content": "I will run the command.",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_proof",
+                            "type": "function",
+                            "function": {
+                                "name": tool["name"],
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
+                    ],
+                }
+                finish = "tool_calls"
+            else:
+                delta = {"role": "assistant", "content": "sdk-ok"}
+                finish = "stop"
+            chunk = {
+                "id": f"chat_{len(requests)}",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": body["model"],
+                "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+            }
+            terminal = chunk | {
+                "choices": [{"index": 0, "delta": {}, "finish_reason": finish}],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 3, "total_tokens": 23},
+            }
+            payload = (f"data: {json.dumps(chunk)}\n\ndata: {json.dumps(terminal)}\n\ndata: [DONE]\n\n").encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    with ThreadingHTTPServer(("127.0.0.1", 0), Model) as server:
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        config = {
+            "prompt": "Write sdk-ok to proof.txt and read it back.",
+            "session_id": "sdk-smoke",
+            "harness": {
+                "model": "deepseek-v4-flash",
+                "profile": profile,
+                "base_url": f"http://127.0.0.1:{server.server_port}/v1",
+                "api_key": "test-only",
+                "env": {"DSH_PERMISSION_MODE": "danger-full-access"},
+                "initialize_timeout_seconds": 30,
+                "request_timeout_seconds": 20,
+            },
+        }
+        config_path = run_dir / "input.json"
+        config_path.write_text(json.dumps(config))
+        try:
+            monkeypatch.chdir(workspace)
+            exit_code = runner.run(config_path)
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+    summary = json.loads((run_dir / "result.json").read_text())
+    assert exit_code == 0, summary
+    assert summary["finish_reason"] == "completed"
+    assert (workspace / "proof.txt").read_text() == "sdk-ok"
+    assert len(requests) == 2
+    assert any(m["role"] == "tool" and "sdk-ok" in str(m["content"]) for m in requests[1]["messages"])
+    assert any(m.get("reasoning_content") == "I will run the command." for m in requests[1]["messages"])
+    notifications = [json.loads(line) for line in (run_dir / "events.jsonl").read_text().splitlines()]
+    output, usage = convert_events(notifications, "sdk-smoke")
+    assert [item.type for item in output] == ["reasoning", "function_call", "function_call_output", "message"]
+    assert output[1].call_id == output[2].call_id == "call_proof"
+    assert output[-1].content[0].text == "sdk-ok"
+    assert usage.total_tokens == 46
+    assert not (workspace / ".dsh").exists()

--- a/responses_api_agents/deepseek_harness_agent/trajectory.py
+++ b/responses_api_agents/deepseek_harness_agent/trajectory.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Project DSH's committed root-session messages; retain raw notifications separately."""
+
+from typing import Any
+
+from nemo_gym.openai_utils import (
+    NeMoGymFunctionCallOutput,
+    NeMoGymResponseFunctionToolCall,
+    NeMoGymResponseOutputItem,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+    NeMoGymResponseReasoningItem,
+    NeMoGymResponseUsage,
+    NeMoGymSummary,
+    accumulate_response_usage,
+)
+
+
+def convert_events(
+    notifications: list[dict[str, Any]], session_id: str
+) -> tuple[list[NeMoGymResponseOutputItem], NeMoGymResponseUsage | None]:
+    output = []
+    usage = None
+    for notification in notifications:
+        payload = notification["payload"]
+        if notification["method"] != "session.event" or payload.get("sessionId") != session_id:
+            continue
+        event = payload["event"]
+        data = event["data"]
+        if event["type"] not in {"assistant/message", "tool/result"}:
+            continue
+        for index, block in enumerate(data["message"]["content"]):
+            item_id = f"dsh_{session_id}_{event['seq']}_{index}"
+            if block["type"] == "text":
+                output.append(
+                    NeMoGymResponseOutputMessage(
+                        id=item_id,
+                        content=[NeMoGymResponseOutputText(text=block["text"], annotations=[])],
+                    )
+                )
+            elif block["type"] == "reasoning":
+                output.append(
+                    NeMoGymResponseReasoningItem(
+                        id=item_id, summary=[NeMoGymSummary(type="summary_text", text=block["text"])]
+                    )
+                )
+            elif block["type"] == "tool-call":
+                output.append(
+                    NeMoGymResponseFunctionToolCall(
+                        id=item_id, call_id=block["id"], name=block["name"], arguments=block["arguments"]
+                    )
+                )
+            elif block["type"] == "tool-result":
+                if any(part["type"] != "text" for part in block["content"]):
+                    raise ValueError("DSH currently supports text tool results only")
+                texts = [part["text"] for part in block["content"]]
+                output.append(NeMoGymFunctionCallOutput(call_id=block["toolCallId"], output="\n".join(texts)))
+            else:
+                raise ValueError(f"Unsupported DSH output block: {block['type']}")
+        if counts := data.get("usage"):
+            # DSH's inputTokens excludes cache reads and writes; Gym's includes them.
+            input_tokens = counts["inputTokens"] + counts.get("cacheReadTokens", 0) + counts.get("cacheWriteTokens", 0)
+            usage = accumulate_response_usage(
+                usage,
+                NeMoGymResponseUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=counts["outputTokens"],
+                    total_tokens=input_tokens + counts["outputTokens"],
+                    input_tokens_details={"cached_tokens": counts.get("cacheReadTokens")},
+                    output_tokens_details={"reasoning_tokens": counts.get("reasoningTokens")},
+                ),
+            )
+    return output, usage

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3036,7 +3036,7 @@ class TestVLLMConverter:
             )
         )
 
-        expected_output = test_data["expected_output"]
+        expected_output = test_data["expected_output"] | {"thinking": None}
         assert expected_output == chat_completion_create_params.model_dump(exclude=OPENAI_2_44_OPTIONAL_CHAT_FIELDS)
 
     def test_round_trip_chat_completions_return_token_id_information(self) -> None:
@@ -3142,7 +3142,7 @@ class TestVLLMConverter:
             )
         )
 
-        expected_output = test_data["expected_output_return_token_id_information"]
+        expected_output = test_data["expected_output_return_token_id_information"] | {"thinking": None}
         assert expected_output == chat_completion_create_params.model_dump(exclude=OPENAI_2_44_OPTIONAL_CHAT_FIELDS)
 
     def test_whitespace_round_trip_chat_completions(self, monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -255,6 +255,38 @@ class TestTokenMetadataValidation:
 
 
 class TestNeMoGymChatCompletionSchemas:
+    @pytest.mark.parametrize("field", ["reasoning_content", "reasoning"])
+    def test_thinking_tool_history_survives_streaming_validation(self, field):
+        from nemo_gym.chat_streaming import sanitize_streaming_chat_body
+
+        payload = {
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "model": "deepseek-v4-flash",
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "max",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    field: "Inspect the file.",
+                    "tool_calls": [
+                        {"id": "call-1", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+                    ],
+                }
+            ],
+        }
+        cleaned, include_usage = sanitize_streaming_chat_body(payload)
+        result = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(cleaned).model_dump(exclude_unset=True)
+        assert include_usage
+        assert result["messages"] == payload["messages"]
+        assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "max"
+
+    def test_thinking_configuration_still_validates_its_wire_values(self):
+        with pytest.raises(ValueError):
+            NeMoGymChatCompletionCreateParamsNonStreaming(messages=[], thinking={"type": "invalid"})
+
     def test_user_audio_and_file_content_parts_round_trip(self) -> None:
         payload = {
             "messages": [
@@ -1412,12 +1444,12 @@ def test_request_model_carries_every_sdk_request_field() -> None:
 
 
 def test_chat_request_field_set_matches_sdk_without_deprecated_fields() -> None:
-    """Keep the strict Chat request model aligned with the supported SDK fields.
+    """Keep the strict Chat request model aligned with SDK fields and Gym extensions.
 
     Deprecated fields remain disabled.
     """
     sdk_fields = set(get_type_hints(CompletionCreateParamsNonStreaming, include_extras=True))
-    expected = sdk_fields - {"function_call", "functions"}
+    expected = (sdk_fields - {"function_call", "functions"}) | {"thinking"}
     actual = set(NeMoGymChatCompletionCreateParamsNonStreaming.model_fields)
     assert actual == expected, (
         f"openai {openai.__version__} Chat request fields changed: "


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?
  Adds DeepSeek Harness as a Gym evaluation agent. Existing resources servers
  prepare the task sandbox and verify the resulting workspace, while the upstream
  harness handles model interaction and tool execution.

  - Pins the upstream SDK/runtime to 0.1.5rc1 and supports its official sdk
    and sdk-minimal profiles.

  - Connects to prepared task sandboxes through AsyncSandbox, preserving task
    metadata, session cookies, and verifier rewards.

  - Converts committed root-session messages, reasoning, tool calls/results, and
    usage into Gym responses. Retains raw SDK notifications and execution artifacts,
    including available evidence after failures.

  - Extends Chat Completions validation to preserve DeepSeek thinking configuration
    and reasoning fields in tool-call history.

  - Adds configuration, runtime requirements, usage documentation, and tests.

  The integration supports fresh text tasks. Benchmark-specific preparation and
  scoring remain in resources servers. Training token IDs and logprobs are outside
  this change's scope.

  Related: NVIDIA-NeMo/Gym#2577, NVIDIA-NeMo/Gym#2950.

  ## Validation

  - 424 targeted tests passed, covering the agent, published SDK runtime,
    Chat Completions schemas/streaming, sandbox connections, and model servers.
    Ruff lint and formatting checks passed.

  - Both profiles passed real-model OpenSandbox smoke rollouts through
    /run → /seed_session → agent execution → /verify, including code changes,
    tool execution, independent verification, and cleanup.

  - Completed a fixed pilot with DeepSeek V4 Flash through NVIDIA Inference Hub,
    using matched tasks and external budgets. All 120 verifier calibration
    controls passed.

Harness | SWE-bench Verified (50 tasks) | Terminal-Bench 2.1 (10 tasks)
-- | -- | --
DSH sdk | 31/50 (62%) | 6/10 (60%)
DSH sdk-minimal | 39/50 (78%) | 4/10 (40%)
OpenCode reference | 32/50 (64%) | 6/10 (60%)

  All harnesses used DeepSeek V4 Flash with matched tasks and external budgets.
  These are coverage-selected pilot results, not full-suite benchmark scores.

  These are coverage-selected pilot results. Verifiers completed for 179/180
  outcomes; one agent-damaged environment remained scored as zero. Timeouts and
  budget stops also remained in the denominator. Infrastructure retries and
  quarantined batches are documented in the README.

  Full-suite and repeated evaluations have not run. The H100 host used remote
  model inference, so these results do not measure local GPU inference performance.
## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
