### PR TITLE
fix(verifiers_agent): never store the policy server's session cookie

### DIFF
--- a/responses_api_agents/verifiers_agent/app.py
+++ b/responses_api_agents/verifiers_agent/app.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 import json
 import logging
 import traceback
+from http.cookiejar import CookieJar
 from typing import Any
 
 import verifiers as vf
 from fastapi import Body, Request, Response
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 from pydantic import ConfigDict, Field
 from verifiers.clients import NeMoRLChatCompletionsClient
 
@@ -154,6 +155,18 @@ class VerifiersAgentVerifyResponse(BaseVerifyResponse):
     reward: float
 
 
+class _NoStoreCookieJar(CookieJar):
+    """A cookie jar that drops every Set-Cookie, so no request ever carries one.
+
+    See VerifiersAgent._get_client: the policy server's session cookie decides
+    which vLLM engine serves a request, and a jar that remembers it would pin
+    every rollout in this process to one engine.
+    """
+
+    def set_cookie(self, cookie) -> None:
+        return None
+
+
 class VerifiersAgentConfig(BaseResponsesAPIAgentConfig):
     model_server: ModelServerRef
     model_name: str = Field(default="", description="Model name")
@@ -194,21 +207,52 @@ class VerifiersAgent(SimpleResponsesAPIAgent):
             self.envs_cache[vf_env_id] = vf.load_environment(vf_env_id, **self.config.vf_env_args)
         return self.envs_cache[vf_env_id]
 
+    def _policy_model_server_url(self) -> str:
+        server_config_dict = get_first_server_config_dict(
+            self.server_client.global_config_dict,
+            self.config.model_server.name,
+        )
+        model_server_url = f"http://{server_config_dict.host}:{server_config_dict.port}"
+
+        if not model_server_url.endswith("/v1"):
+            model_server_url = model_server_url.rstrip("/") + "/v1"
+
+        return model_server_url
+
     def _get_client(self) -> NeMoRLChatCompletionsClient:
+        """One shared policy client per process, with a cookie jar that never stores.
+
+        The vllm_model server picks a vLLM engine per session
+        (``sha256(session_id) % len(base_urls)`` in
+        responses_api_models/vllm_model/app.py ``_resolve_client``) and mints the
+        session id per cookie jar (nemo_gym/server_utils.py
+        ``setup_session_middleware``). openai's AsyncOpenAI sits on an httpx client
+        that persists cookies, so a plain shared client is one session and
+        therefore one engine: on CMH job 3670120 (2026-09-10) 512 concurrent
+        rollouts ran on 6 of 48 engines while 42 sat idle. Gym's own aiohttp
+        client avoids exactly this with a DummyCookieJar; ``_NoStoreCookieJar``
+        is the httpx equivalent. Every request is then a fresh session and the
+        router spreads them over every engine.
+
+        Why not a client per rollout: each rollout's single pooled connection sat
+        idle through its tool phases, the router's uvicorn closes idle
+        connections after 30 s, and the next turn raced that close -- CMH 3670792
+        aborted 468 of 512 rollouts with
+        ``APIConnectionError -> ReadError(BrokenResourceError)`` while the
+        shared-client runs before it had zero. One shared pool keeps connections
+        hot. The price is per-turn engine affinity, which Gym's own client does
+        not have either.
+        """
         cache_key = self.config.model_server.name
         if cache_key not in self.client_cache:
-            server_config_dict = get_first_server_config_dict(
-                self.server_client.global_config_dict,
-                self.config.model_server.name,
-            )
-            model_server_url = f"http://{server_config_dict.host}:{server_config_dict.port}"
-
-            if not model_server_url.endswith("/v1"):
-                model_server_url = model_server_url.rstrip("/") + "/v1"
-
             openai_client = AsyncOpenAI(
-                base_url=model_server_url,
+                base_url=self._policy_model_server_url(),
                 api_key="EMPTY",  # pragma: allowlist secret
+                # DefaultAsyncHttpxClient keeps the SDK's pool limits and redirect
+                # policy. Pass the bare CookieJar: httpx.Cookies adopts a CookieJar
+                # instance as-is but COPIES an httpx.Cookies into a fresh stdlib
+                # jar, which would silently discard the no-store behaviour.
+                http_client=DefaultAsyncHttpxClient(cookies=_NoStoreCookieJar()),
             )
             self.client_cache[cache_key] = NeMoRLChatCompletionsClient(openai_client)
 

--- a/responses_api_agents/verifiers_agent/tests/test_app.py
+++ b/responses_api_agents/verifiers_agent/tests/test_app.py
@@ -12,15 +12,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import httpx
+from openai import AsyncOpenAI
 
 from nemo_gym.config_types import ModelServerRef
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.verifiers_agent.app import (
     VerifiersAgent,
     VerifiersAgentConfig,
+    _NoStoreCookieJar,
 )
+
+
+POLICY_URL = "http://policy.test/v1"
+SESSION_COOKIE = "VLLMModel___policy_model=abc123; Path=/"
+
+
+def _policy_server_that_sets_a_session_cookie(seen_cookie_headers: list) -> httpx.MockTransport:
+    """Stand-in for Gym's vllm_model server.
+
+    Like the real one (SessionMiddleware + add_session_id in
+    nemo_gym/server_utils.py) it puts a session cookie on EVERY response, and
+    it records the Cookie header each request arrived with so a test can see
+    whether the client replayed it.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_cookie_headers.append(request.headers.get("cookie"))
+        body = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "m",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"},
+            ],
+        }
+        return httpx.Response(200, json=body, headers={"set-cookie": SESSION_COOKIE})
+
+    return httpx.MockTransport(handler)
+
+
+async def _three_chat_completions(openai_client: AsyncOpenAI) -> None:
+    for _ in range(3):
+        await openai_client.chat.completions.create(model="m", messages=[{"role": "user", "content": "hi"}])
 
 
 class TestApp:
@@ -108,3 +147,66 @@ class TestApp:
         assert output[1]["output"] == "4"
         assert output[2]["content"][0]["text"] == "answer"
         assert output[2]["prompt_token_ids"] == [3]
+
+
+class TestPolicyClient:
+    """The policy client decides which vLLM engine serves a rollout.
+
+    vllm_model routes a request to ``sha256(session_id) % n_engines`` and mints
+    the session id per cookie jar, so a client that replays Set-Cookie pins
+    every rollout in this process to one engine (CMH 3670120, 2026-09-10: 6 of
+    48 engines busy). These tests hold the two properties the fix relies on:
+    the client is shared (a hot connection pool; per-rollout clients aborted
+    468/512 rollouts on CMH 3670792 racing the router's keep-alive close) and
+    it never sends a cookie back.
+    """
+
+    @staticmethod
+    def _agent() -> VerifiersAgent:
+        config = VerifiersAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        )
+        return VerifiersAgent(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def test_policy_client_is_shared_across_rollouts(self) -> None:
+        agent = self._agent()
+        with patch.object(VerifiersAgent, "_policy_model_server_url", return_value=POLICY_URL):
+            first = agent._get_client()
+            second = agent._get_client()
+        assert first is second
+        assert str(first.client.base_url).rstrip("/") == POLICY_URL
+
+    def test_policy_client_never_replays_the_session_cookie(self) -> None:
+        agent = self._agent()
+        with patch.object(VerifiersAgent, "_policy_model_server_url", return_value=POLICY_URL):
+            openai_client = agent._get_client().client
+
+        # The jar must be ours. httpx.Cookies adopts a CookieJar instance but
+        # copies an httpx.Cookies into a fresh stdlib jar, which silently
+        # discards the subclass -- exactly the mistake this line catches.
+        assert isinstance(openai_client._client.cookies.jar, _NoStoreCookieJar)
+
+        seen = []
+        openai_client._client._transport = _policy_server_that_sets_a_session_cookie(seen)
+        asyncio.run(_three_chat_completions(openai_client))
+
+        assert seen == [None, None, None], seen
+
+    def test_a_default_openai_client_would_replay_the_session_cookie(self) -> None:
+        """Positive control: proves the previous test can fail.
+
+        The stock AsyncOpenAI sits on an httpx client that persists cookies, so
+        from the second request on it carries the session cookie back -- the
+        behaviour that pinned every rollout to one engine.
+        """
+        openai_client = AsyncOpenAI(base_url=POLICY_URL, api_key="EMPTY")  # pragma: allowlist secret
+        seen = []
+        openai_client._client._transport = _policy_server_that_sets_a_session_cookie(seen)
+        asyncio.run(_three_chat_completions(openai_client))
+
+        assert seen[0] is None
+        assert seen[1] == seen[2] == SESSION_COOKIE.split(";")[0]


### PR DESCRIPTION
## What does this PR do?

fixes severe rollout routing unbalance when training with verifiers_agent

## Context

vllm_model picks a vLLM engine per session (sha256(session_id) % len(base_urls) in _resolve_client) and mints the session id per cookie jar (server_utils.setup_session_middleware). openai.AsyncOpenAI sits on an httpx client that persists cookies, so the single client this agent shares across every rollout in its process was one session and therefore one engine.

Keep the shared client -- the pool has to stay hot -- and give it a CookieJar whose set_cookie is a no-op. Every request is then cookie-less, the router mints a fresh session id per request, and sha256 spreads them over every engine. This is what Gym's own aiohttp client already does with a DummyCookieJar. Pass the bare CookieJar: httpx.Cookies adopts a CookieJar instance as-is but copies an httpx.Cookies into a fresh stdlib jar, which would silently discard the no-store behaviour.

A client per rollout also spreads the load but each rollout's single pooled connection sat idle through its tool phases, the router's uvicorn closes idle connections after 30 s, and the next turn raced that close.

Tested by driving the client through an httpx.MockTransport that sets Set-Cookie on every reply: three consecutive chat completions send no Cookie header, the jar is _NoStoreCookieJar, and _get_client() returns one shared client. A positive control shows a stock AsyncOpenAI does replay the cookie from the second request on, so the suite is known to be sensitive; the cookie test fails if the cookies= argument is dropped.

Squashed from 19bfe2505, a100181eb and 2e7b26a91, without the configurable client timeouts those carried; those land separately.

<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->


<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
