### PR TITLE
fix(responses): report unknown usage detail counters as 0 in the synthesized SSE stream

### DIFF
--- a/nemo_gym/responses_streaming.py
+++ b/nemo_gym/responses_streaming.py
@@ -241,6 +241,18 @@ def _sse_event(payload: dict[str, Any]) -> str:
     return f"event: {payload['type']}\ndata: {json.dumps(payload)}\n\n"
 
 
+def _omit_unknown_usage_details(usage: dict[str, Any]) -> dict[str, Any]:
+    """Drop a usage detail object whose counter is null; strict SSE clients reject the null but accept the absence."""
+    usage = dict(usage)
+    for details_key, counter_key in (
+        ("input_tokens_details", "cached_tokens"),
+        ("output_tokens_details", "reasoning_tokens"),
+    ):
+        if (usage.get(details_key) or {}).get(counter_key) is None:
+            usage.pop(details_key, None)
+    return usage
+
+
 def synthesize_responses_sse(response_json: dict[str, Any], ns_map: Optional[NamespaceMap] = None) -> Iterator[str]:
     """Re-emit a complete Responses API response object as an SSE event stream.
 
@@ -255,6 +267,8 @@ def synthesize_responses_sse(response_json: dict[str, Any], ns_map: Optional[Nam
             namespace, name = ns_map[item["name"]]
             item = {**item, "namespace": namespace, "name": name}
         output_items.append(item)
+    if response_json.get("usage") is not None:
+        response_json = {**response_json, "usage": _omit_unknown_usage_details(response_json["usage"])}
 
     yield _sse_event(
         {"type": "response.created", "response": {**response_json, "status": "in_progress", "output": []}}

--- a/tests/unit_tests/test_responses_api_model_streaming.py
+++ b/tests/unit_tests/test_responses_api_model_streaming.py
@@ -564,6 +564,16 @@ class TestSynthesizeSSE:
         assert failed["error"] == {"code": "server_error", "message": "boom"}
         assert failed["output"] == []
 
+    def test_unknown_usage_details_are_omitted_from_the_wire(self) -> None:
+        response = _build_response([_message_item("hello")]).model_dump(mode="json")
+        response["usage"]["input_tokens_details"]["cached_tokens"] = None
+        events = self._events("".join(synthesize_responses_sse(response)))
+        for event in (events[0], events[-1]):
+            usage = event["response"]["usage"]
+            assert "input_tokens_details" not in usage
+            assert usage["output_tokens_details"] == {"reasoning_tokens": 0}
+            assert usage["total_tokens"] == 10
+
 
 # The streaming sanitizer intentionally removes these input item types.
 # The transcript preservation check excludes them.


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

Closes #3313 

A chat-backed model server reports `cached_tokens` and `reasoning_tokens` as `null` when the provider reports totals only, as vLLM does for a plain chat completion.
The streaming `/v1/responses` path copied that response verbatim into the SSE envelope, so `response.completed` carried `null` counters.
The Responses API declares both as required integers, and the Codex CLI (0.144.4) enforces that on the terminal event: the turn fails with `failed to parse ResponseCompleted: invalid type: null, expected i64` after the answer has been delivered, and Codex retries.

`synthesize_responses_sse` now reports an unknown detail counter as `0` in the SSE copy, so both required detail objects stay on the wire and the emitted usage passes `ResponseUsage.model_validate()` under the pinned openai==2.44.0. A reported count, including a reported zero, passes through unchanged. Only the synthesized SSE envelope changes; Gym's internal usage types and the non-streaming JSON still carry `null`, so the unknown-versus-zero distinction from #2583 survives inside Gym.

## Tests

```
uv run pytest tests/unit_tests/test_responses_api_model_streaming.py -q   # 165 passed
```

- New: `TestSynthesizeSSE::test_unknown_usage_details_are_reported_as_zero_on_the_wire`. A `null` `cached_tokens` is emitted as `0` in both response events, the emitted usage validates as `ResponseUsage`, and the caller's response keeps `null`.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
