### PR TITLE
[GDPVal] Add three reference anchors to the multistage overlay

### DIFF
--- a/resources_servers/gdpval/configs/gdpval_minimax_multistage_judge.yaml
+++ b/resources_servers/gdpval/configs/gdpval_minimax_multistage_judge.yaml
@@ -64,15 +64,20 @@ gdpval_resources_server:
       # multi-stage driver picks the `num_models` nearest anchors per stage.
       #
       # ANCHOR VINTAGE: Artificial Analysis GDPval-AA v2 live board, read
-      # 2026-09-09. Anchors are held FIXED in the fit, so a stale anchor shifts
+      # 2026-09-09 for the original nine, 2026-09-11 for the three Sep-2026
+      # additions (deepseek_v4_flash_0731, inkling_small, qwen35_122b). Anchors are held FIXED in the fit, so a stale anchor shifts
       # every candidate score by roughly the anchor error — the previous set was
       # 30-76 points above the current board and inflated results accordingly.
       # deepseek_v4_pro is the plain "DeepSeek V4 Pro (Reasoning, Max Effort)"
       # row (1223), NOT "DeepSeek V4 Pro 0813" (1493): the deliverables in this
       # reference set were collected 2026-07-04, before the 0813 release. Check
       # the variant, not just the family name, when refreshing.
-      # This is the ultra-v3 "9-ref no-gold" set (human_gold and gptoss_20b are
+      # This is the "12-ref no-gold" set (human_gold and gptoss_20b are
       # DELIBERATELY excluded — incomplete/missing deliverables inflate the fit).
+      # The top three anchors of the old nine-ref set stopped at 1223 while the
+      # AA board ran to 1764, so a frontier candidate was fitted by
+      # extrapolation past the ceiling; deepseek_v4_flash_0731 raises it to 1468
+      # and qwen35_122b closes the 905-992 gap.
       # Each deliverables_dir resolves to $GDPVAL_REFS_ROOT/<id>, defaulting to
       # the NEL /gdpval/refs/<id> container mounts, and holds that reference's
       # per-task `task_<task_id>/` deliverables. Three ways to point elsewhere:
@@ -91,9 +96,15 @@ gdpval_resources_server:
       #
       #   - one-off: ++...gdpval.reference_models.<id>.deliverables_dir=/abs/path
       reference_models:
+        deepseek_v4_flash_0731:
+          deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/deepseek_v4_flash_0731
+          elo: 1468
         deepseek_v4_pro:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/deepseek_v4_pro
           elo: 1223
+        inkling_small:
+          deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/inkling_small
+          elo: 1191
         glm51_fp8:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/glm51_fp8
           elo: 1181
@@ -106,6 +117,9 @@ gdpval_resources_server:
         qwen36_35b:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/qwen36_35b
           elo: 992
+        qwen35_122b:
+          deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/qwen35_122b
+          elo: 925
         qwen35_397b:
           deliverables_dir: ${oc.env:GDPVAL_REFS_ROOT,/gdpval/refs}/qwen35_397b
           elo: 905


### PR DESCRIPTION
The reference ladder stops at DeepSeek V4 Pro / 1223, and the AA GDPval-AA v2 board now runs to 1764. A candidate anywhere near the frontier therefore has no anchor above it, and since the anchors are held fixed by the fit, its elo falls out of a saturated win rate rather than out of the comparison — a model that beats every reference on nearly every task has no evidence separating 1300 from 1600.

The September Super-3.5 campaign shows it happening: Inkling-Small fitted at 1296–1338 against this ladder, where its own AA row reads 1191.

Three anchors added, elos from the AA board read 2026-09-11:

| key | elo | why |
|---|---|---|
| `deepseek_v4_flash_0731` | 1468 | new ceiling |
| `inkling_small` | 1191 | |
| `qwen35_122b` | 925 | closes the 905–992 gap |

`deepseek_v4_flash_0731` is AA's *DeepSeek V4 Flash 0731* row, not the April *DeepSeek V4 Flash* (1116) — the deliverables are from the 0731 release. The original nine are untouched and keep their 2026-09-09 reading.

Paired with the eval-factory MR that adds the same three to `configs/benchmarks/gym/gdpval/refs.yaml` and the corresponding mounts. Deliverables have to be staged under the refs root before either lands in a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)