### PR TITLE
feat(orchestration): auto-default model_call_capture_dir per benchmark

### DIFF
--- a/examples/slurm_vllm_1IN.yaml
+++ b/examples/slurm_vllm_1IN.yaml
@@ -49,6 +49,8 @@ driver:
           top_p: 0.9
         config_paths: # if services include pre-defined service types, some configs might be created and added to the command automatically
           - benchmarks/ifbench/config.yaml
+        observability_enabled: true # optional; auto-derives model_call_capture_dir
+        # from this benchmark's own real output directory unless set explicitly here
 job:
   output_path: /lustre/fsw/my-path
 

--- a/nemo_gym/orchestration/executors/slurm_script.py
+++ b/nemo_gym/orchestration/executors/slurm_script.py
@@ -16,6 +16,7 @@
 import re
 import shlex
 from pathlib import Path
+from typing import Any
 
 from nemo_gym.orchestration.api import (
     BenchmarkRunConfig,
@@ -239,6 +240,21 @@ def _node_totals(compute: SlurmComputeConfig) -> tuple[int, int]:
     return total_nodes, total_ntasks
 
 
+def _with_default_capture_dir(run: dict[str, Any], remote_bench_dir: Path) -> dict[str, Any]:
+    """Auto-derive model_call_capture_dir from this benchmark's own real output
+    directory when observability is on and the caller didn't set one.
+
+    Hydra interpolation resolves before remote_bench_dir exists (it's computed
+    here, in build_sbatch_script, well after SubmitConfig validation), so
+    there's no way for a YAML value to reference it -- this has to happen in
+    Python, once the real path is known. An explicit model_call_capture_dir in
+    run always wins over this default.
+    """
+    if run.get("observability_enabled") and "model_call_capture_dir" not in run:
+        return {**run, "model_call_capture_dir": str(remote_bench_dir / "model-calls")}
+    return run
+
+
 def build_sbatch_script(
     config: SubmitConfig,
     benchmark_name: str,
@@ -290,7 +306,8 @@ def build_sbatch_script(
 
     output_path = "+output_jsonl_fpath=artifacts/rollouts.jsonl"
     extra_flags = ["--model-type openai_model"] if config.driver.policy_model else []
-    gym_cmd = render_gym_cmd("eval run", "GYM_CMD", [output_path] + extra_flags + flatten_run_args(benchmark.run))
+    run_args = _with_default_capture_dir(benchmark.run, remote_bench_dir)
+    gym_cmd = render_gym_cmd("eval run", "GYM_CMD", [output_path] + extra_flags + flatten_run_args(run_args))
     entrypoint = render_driver_entrypoint(
         repo=gi.repo if gi else None,
         ref=gi.ref if gi else None,

--- a/nemo_gym/orchestration/executors/slurm_script.py
+++ b/nemo_gym/orchestration/executors/slurm_script.py
@@ -18,6 +18,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from nemo_gym.global_config import MODEL_CALL_CAPTURE_DIR_KEY_NAME, OBSERVABILITY_ENABLED_KEY_NAME
 from nemo_gym.orchestration.api import (
     BenchmarkRunConfig,
     NodePool,
@@ -250,8 +251,8 @@ def _with_default_capture_dir(run: dict[str, Any], remote_bench_dir: Path) -> di
     Python, once the real path is known. An explicit model_call_capture_dir in
     run always wins over this default.
     """
-    if run.get("observability_enabled") and "model_call_capture_dir" not in run:
-        return {**run, "model_call_capture_dir": str(remote_bench_dir / "model-calls")}
+    if run.get(OBSERVABILITY_ENABLED_KEY_NAME) and MODEL_CALL_CAPTURE_DIR_KEY_NAME not in run:
+        return {**run, MODEL_CALL_CAPTURE_DIR_KEY_NAME: str(remote_bench_dir / "model-calls")}
     return run
 
 

--- a/tests/unit_tests/test_cli_eval_submit.py
+++ b/tests/unit_tests/test_cli_eval_submit.py
@@ -236,7 +236,7 @@ class TestEvalSubmitConfigGroupComposition:
 
     def test_repeated_calls_do_not_leak_global_hydra_state(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
         """GlobalHydra must be reset between calls or the second `initialize_config_dir` raises."""
-        captured = _capture_submit(monkeypatch)
+        _capture_submit(monkeypatch)
         config_path = tmp_path / "submit.yaml"
         config_path.write_text(
             yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
@@ -244,5 +244,3 @@ class TestEvalSubmitConfigGroupComposition:
 
         _eval_submit(_args(config_path), overrides=[])
         _eval_submit(_args(config_path), overrides=[])
-
-        assert captured["config"].job.output_path == "/tmp/gym-jobs"

--- a/tests/unit_tests/test_cli_eval_submit.py
+++ b/tests/unit_tests/test_cli_eval_submit.py
@@ -236,7 +236,7 @@ class TestEvalSubmitConfigGroupComposition:
 
     def test_repeated_calls_do_not_leak_global_hydra_state(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
         """GlobalHydra must be reset between calls or the second `initialize_config_dir` raises."""
-        _capture_submit(monkeypatch)
+        captured = _capture_submit(monkeypatch)
         config_path = tmp_path / "submit.yaml"
         config_path.write_text(
             yaml.dump({"services": {"svc": SERVICE}, "compute": COMPUTE, "driver": DRIVER, "job": JOB})
@@ -244,3 +244,5 @@ class TestEvalSubmitConfigGroupComposition:
 
         _eval_submit(_args(config_path), overrides=[])
         _eval_submit(_args(config_path), overrides=[])
+
+        assert captured["config"].job.output_path == "/tmp/gym-jobs"

--- a/tests/unit_tests/test_slurm_script.py
+++ b/tests/unit_tests/test_slurm_script.py
@@ -28,6 +28,7 @@ from nemo_gym.orchestration.executors.slurm_script import (
     _render_pool_directives,
     _render_service_command,
     _resolve_env,
+    _with_default_capture_dir,
     build_sbatch_script,
 )
 from nemo_gym.orchestration.executors.utils import flatten_run_args as _flatten_run_args
@@ -334,8 +335,83 @@ def test_render_driver_entrypoint_install_and_prepare():
 
 
 # ---------------------------------------------------------------------------
+# _with_default_capture_dir
+# ---------------------------------------------------------------------------
+
+
+def test_with_default_capture_dir_injects_when_observability_on():
+    run = {"observability_enabled": True}
+    out = _with_default_capture_dir(run, Path("/remote/jobs/gym-job-20260729/gsm8k"))
+    assert out["model_call_capture_dir"] == "/remote/jobs/gym-job-20260729/gsm8k/model-calls"
+
+
+def test_with_default_capture_dir_explicit_value_wins():
+    run = {"observability_enabled": True, "model_call_capture_dir": "/custom/path"}
+    out = _with_default_capture_dir(run, Path("/remote/jobs/gym-job-20260729/gsm8k"))
+    assert out["model_call_capture_dir"] == "/custom/path"
+
+
+def test_with_default_capture_dir_no_injection_when_observability_off():
+    run = {"split": "benchmark"}
+    out = _with_default_capture_dir(run, Path("/remote/jobs/gym-job-20260729/gsm8k"))
+    assert "model_call_capture_dir" not in out
+
+
+def test_with_default_capture_dir_does_not_mutate_input():
+    run = {"observability_enabled": True}
+    _with_default_capture_dir(run, Path("/remote/jobs/gym-job-20260729/gsm8k"))
+    assert "model_call_capture_dir" not in run
+
+
+# ---------------------------------------------------------------------------
 # build_sbatch_script (integration)
 # ---------------------------------------------------------------------------
+
+
+def test_build_sbatch_script_auto_default_capture_dir(bench_dir):
+    config = SubmitConfig.model_validate(
+        {
+            "services": {"vllm_model": {"type": "vllm", "container": "vllm:latest", "model": "org/model"}},
+            "compute": {"cluster": {"type": "slurm", "account": "my-account", "hostname": "foo"}},
+            "driver": {
+                "container": "python:3.12",
+                "benchmarks": {"gsm8k": {"run": {"observability_enabled": True}}},
+            },
+            "job": {"output_path": "/remote/jobs"},
+        }
+    )
+    benchmark = config.driver.benchmarks["gsm8k"]
+    compute = next(iter(config.compute.values()))
+    script = build_sbatch_script(config, "gsm8k", benchmark, compute, bench_dir)
+    assert f"+model_call_capture_dir={bench_dir / 'model-calls'}" in script
+
+
+def test_build_sbatch_script_explicit_capture_dir_wins(bench_dir):
+    config = SubmitConfig.model_validate(
+        {
+            "services": {"vllm_model": {"type": "vllm", "container": "vllm:latest", "model": "org/model"}},
+            "compute": {"cluster": {"type": "slurm", "account": "my-account", "hostname": "foo"}},
+            "driver": {
+                "container": "python:3.12",
+                "benchmarks": {
+                    "gsm8k": {"run": {"observability_enabled": True, "model_call_capture_dir": "/custom/path"}}
+                },
+            },
+            "job": {"output_path": "/remote/jobs"},
+        }
+    )
+    benchmark = config.driver.benchmarks["gsm8k"]
+    compute = next(iter(config.compute.values()))
+    script = build_sbatch_script(config, "gsm8k", benchmark, compute, bench_dir)
+    assert "+model_call_capture_dir=/custom/path" in script
+    assert "model-calls" not in script
+
+
+def test_build_sbatch_script_no_capture_dir_when_observability_off(submit_config, bench_dir):
+    benchmark = submit_config.driver.benchmarks["gsm8k"]
+    compute = next(iter(submit_config.compute.values()))
+    script = build_sbatch_script(submit_config, "gsm8k", benchmark, compute, bench_dir)
+    assert "model_call_capture_dir" not in script
 
 
 def test_build_sbatch_script_contains_shebang(submit_config, bench_dir):


### PR DESCRIPTION
## Summary

Auto-derive `model_call_capture_dir` per benchmark when `observability_enabled: true` is set on a Slurm-submitted benchmark, instead of requiring the user to write it out by hand.

- `observability_enabled=true` requires an absolute `model_call_capture_dir` (`ModelCallCaptureConfig` validator), and it must be unique per submission — `CaptureStore` writes one file per `rollout_id`, not per submission, so a reused path silently merges different runs' captures into the same files.
- New `_with_default_capture_dir()` in `slurm_script.py` derives the path from each benchmark's own real remote output directory (`remote_bench_dir`, already computed once per benchmark in `build_sbatch_script`'s loop), giving a correct, collision-free path for free.
- An explicit `model_call_capture_dir` in the config always wins over the default, mirroring the existing `health_check.port`-from-`service.port` precedent (`VllmServiceConfig._default_health_check`).
- Has to happen in Python rather than via `${...}` Hydra interpolation: `remote_bench_dir` isn't known until well after `SubmitConfig` validation, by which point Hydra has already resolved every interpolation in the submitted YAML.

## Changes

- `nemo_gym/orchestration/executors/slurm_script.py` — `_with_default_capture_dir()`, wired into `build_sbatch_script`
- `examples/slurm_vllm_1IN.yaml` — updated example comment
- `tests/unit_tests/test_slurm_script.py` — unit + integration coverage for default injection, explicit override, and observability-off cases
- `tests/unit_tests/test_cli_eval_submit.py` — minor cleanup of a dead assertion

## Test plan

- [ ] `pytest tests/unit_tests/test_slurm_script.py -x`
- [ ] `pytest tests/unit_tests/test_cli_eval_submit.py -x`