### PR TITLE
fix(verifiers_agent): carry the rollout capture prefix on the model client

### DIFF
--- a/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
+++ b/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
@@ -95,7 +95,7 @@ C4, `V` evaluates the correlated Gym Model Server path; direct-provider alternat
 | `tau2` | V | V | X | V | X | X | X |
 | `tool_simulation_agent` | V | V | X | V | X | X | X |
 | `toolsandbox_agent` | V | V | X | V | X | X | X |
-| `verifiers_agent` | X | X | X | X | X | X | X |
+| `verifiers_agent` | V | V | X | V | X | X | X |
 
 ### Coverage notes
 
@@ -108,6 +108,11 @@ C4, `V` evaluates the correlated Gym Model Server path; direct-provider alternat
   - Raised failures omitted by Simple-derived agents.
   - Stirrup calls outside its policy path.
 - OpenClaw coverage includes its standalone resource-server path and the PinchBench sandbox benchmark path.
+- Verifiers C1, C2, and C4 cover the Gym Model Server path: the agent routes the client it
+  hands to `verifiers` through the rollout capture prefix, so calls the environment makes on its
+  own are captured and correlated. C5 and C6 are unavailable because the agent emits no
+  `ng_agent_observations`, so tool attempts carry no status or timing, and rollout-health checks
+  that read agent turns or bound calls stay unobserved.
 - OpenCode coverage includes both the standalone producer and the decoupled `opencode_sandboxed_agent` path. The
   decoupled path composes agent observations with verifier-sandbox evidence returned by its resources server.
 - Legacy OpenHands retains one cumulative root conversation, so its model-visible history remains partial. Its pinned

--- a/responses_api_agents/verifiers_agent/app.py
+++ b/responses_api_agents/verifiers_agent/app.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import traceback
-from typing import Any
+from typing import Any, Optional
 
 import verifiers as vf
 from fastapi import Body, Request, Response
@@ -28,7 +28,6 @@ from verifiers.clients import NeMoRLChatCompletionsClient
 from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
 from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, SimpleResponsesAPIAgent
 from nemo_gym.config_types import ModelServerRef
-from nemo_gym.global_config import get_first_server_config_dict
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -187,24 +186,31 @@ class VerifiersAgent(SimpleResponsesAPIAgent):
     config: VerifiersAgentConfig
 
     envs_cache: dict[str, Any] = Field(default_factory=dict)
-    client_cache: dict[str, NeMoRLChatCompletionsClient] = Field(default_factory=dict)
+    # Keyed by (model-server name, rollout id): the rollout id selects the
+    # capture prefix baked into the client's base_url.
+    client_cache: dict[tuple[str, Optional[str]], NeMoRLChatCompletionsClient] = Field(default_factory=dict)
 
     def _get_env(self, vf_env_id: str) -> vf.Environment:
         if vf_env_id not in self.envs_cache:
             self.envs_cache[vf_env_id] = vf.load_environment(vf_env_id, **self.config.vf_env_args)
         return self.envs_cache[vf_env_id]
 
-    def _get_client(self) -> NeMoRLChatCompletionsClient:
-        cache_key = self.config.model_server.name
-        if cache_key not in self.client_cache:
-            server_config_dict = get_first_server_config_dict(
-                self.server_client.global_config_dict,
-                self.config.model_server.name,
-            )
-            model_server_url = f"http://{server_config_dict.host}:{server_config_dict.port}"
+    def _get_client(self, body: Any = None) -> NeMoRLChatCompletionsClient:
+        """Return the model client for this run, carrying its capture prefix.
 
-            if not model_server_url.endswith("/v1"):
-                model_server_url = model_server_url.rstrip("/") + "/v1"
+        Model-call capture is keyed by the ``/ng-rollout/<id>`` URL prefix, so a
+        client built from the bare model-server root is never attributed to a
+        rollout: the capture store stays empty, the projected trajectory reports
+        ``model_call_capture_no_records``, and every rollout-health check
+        degrades to ``unobserved``. The cache is therefore keyed by rollout too —
+        one client per server would pin the first rollout's prefix onto all of
+        them. ``rollout_id_from_run`` returns ``None`` when capture is disabled,
+        which collapses this back to the unprefixed URL and a single cache entry.
+        """
+        rollout_id = self.rollout_id_from_run(body) if body is not None else None
+        cache_key = (self.config.model_server.name, rollout_id)
+        if cache_key not in self.client_cache:
+            model_server_url = self.resolve_model_base_url(self.config.model_server.name, rollout_id)
 
             openai_client = AsyncOpenAI(
                 base_url=model_server_url,
@@ -291,7 +297,7 @@ class VerifiersAgent(SimpleResponsesAPIAgent):
                 example_id=body.example_id,
             )
 
-            client = self._get_client()
+            client = self._get_client(body)
 
             # prefer NeMo RL generation config set in responses_create_params
             # https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/experience/rollouts.py#L1045-L1046

--- a/responses_api_agents/verifiers_agent/tests/test_app.py
+++ b/responses_api_agents/verifiers_agent/tests/test_app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from nemo_gym.config_types import ModelServerRef
 from nemo_gym.server_utils import ServerClient
@@ -108,3 +108,63 @@ class TestApp:
         assert output[1]["output"] == "4"
         assert output[2]["content"][0]["text"] == "answer"
         assert output[2]["prompt_token_ids"] == [3]
+
+    def test_client_base_url_carries_the_rollout_capture_prefix(self) -> None:
+        """Model-call capture is keyed by the ``/ng-rollout/<id>`` URL prefix.
+
+        Without it the capture store stays empty for every rollout, the projected
+        trajectory reports ``model_call_capture_no_records``, and every
+        rollout-health check degrades to ``unobserved`` -- a silently broken run
+        then looks identical to a healthy low-scoring one.
+        """
+        config = VerifiersAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        )
+        agent = VerifiersAgent(config=config, server_client=MagicMock(spec=ServerClient))
+
+        def fake_resolve(model_server_name: str, rollout_id: str | None = None) -> str:
+            prefix = f"/ng-rollout/{rollout_id}" if rollout_id else ""
+            return f"http://policy{prefix}/v1"
+
+        with (
+            patch.object(VerifiersAgent, "resolve_model_base_url", side_effect=fake_resolve) as resolve,
+            patch.object(VerifiersAgent, "rollout_id_from_run", lambda _self, body: body.rollout_id),
+        ):
+            first = agent._get_client(MagicMock(rollout_id="7-2"))
+            assert str(first.client.base_url).rstrip("/") == "http://policy/ng-rollout/7-2/v1"
+
+            # A second rollout must not reuse the first rollout's prefixed client.
+            second = agent._get_client(MagicMock(rollout_id="7-3"))
+            assert str(second.client.base_url).rstrip("/") == "http://policy/ng-rollout/7-3/v1"
+            assert second is not first
+
+            # Same rollout is still served from cache, not re-resolved.
+            assert agent._get_client(MagicMock(rollout_id="7-2")) is first
+            assert resolve.call_count == 2
+
+    def test_client_base_url_is_unprefixed_when_capture_is_disabled(self) -> None:
+        """``rollout_id_from_run`` returns ``None`` with capture off; URL is unchanged."""
+        config = VerifiersAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        )
+        agent = VerifiersAgent(config=config, server_client=MagicMock(spec=ServerClient))
+
+        def fake_resolve(model_server_name: str, rollout_id: str | None = None) -> str:
+            prefix = f"/ng-rollout/{rollout_id}" if rollout_id else ""
+            return f"http://policy{prefix}/v1"
+
+        with (
+            patch.object(VerifiersAgent, "resolve_model_base_url", side_effect=fake_resolve),
+            patch.object(VerifiersAgent, "rollout_id_from_run", lambda _self, body: None),
+        ):
+            client = agent._get_client(MagicMock())
+            assert str(client.client.base_url).rstrip("/") == "http://policy/v1"
+            assert agent._get_client(MagicMock()) is client


### PR DESCRIPTION
Model-call capture is keyed by the `/ng-rollout/<id>` URL prefix
(`nemo_gym/base_responses_api_model.py`, `_CaptureMiddleware`). But
`verifiers_agent/app.py:_get_client` built its base URL straight from the model
server's host and port:

```python
model_server_url = f"http://{server_config_dict.host}:{server_config_dict.port}"
```

so no model call was ever attributed to a rollout. Downstream: capture store
empty → trajectory carries `model_call_capture_no_records` and
`model_calls_unavailable` → **every rollout-health check degrades to
`unobserved`**.

The client cache was also keyed by model-server name alone, so even with the
prefix applied the first rollout's client would have been reused for every
later rollout.

### Why this is worth fixing rather than tolerating

An `unobserved` verdict is quiet. The run still prints a score, `failure_reason`
stays `null`, and `rollouts_failures.jsonl` stays empty (0 bytes). A
systematically broken run is then indistinguishable from a healthy low-scoring
one — and the checks that go dark are precisely the ones that would catch it:
`agent_turn_hollow`, `model_call_zero_completion_tokens`, `model_call_failed`,
`model_call_runaway_generation`.

### Fix

Resolve through the base class's `resolve_model_base_url(name, rollout_id)`,
which applies the prefix, and key the cache by `(model server, rollout id)`.
`rollout_id_from_run` returns `None` when capture is disabled, which collapses
this back to the previous unprefixed URL and a single cache entry — so the
no-observability path is unchanged.

### Verification

Real `gym eval run --benchmark automationbench --model-type vllm_model` against
a remote OpenAI-compatible endpoint, with `observability_enabled=true`:

| | before | after |
|---|---|---|
| capture files written | 0 | 1 per rollout |
| trajectory `model_calls` | 0 | 2 |
| reported tokens (prompt/completion) | 0 / 0 | 3153 / 966 |
| trajectory gaps | `model_call_capture_no_records`, `model_calls_unavailable`, `turns_unavailable`, `conversation_unavailable` | `turns_unavailable`, `conversation_unavailable` |

Two regression tests added; both fail on `main` and pass with the fix.
`pre-commit` clean.

### Scope — this is half the fix

Turn-level checks (`AGENT_TURNS`, and `BOUND_CALLS` via
`_canonical_model_call_references`) stay `unobserved` until the agent also emits
`ng_agent_observations` with an `AgentInvocation` carrying `conversation` and
`model_calls: list[ModelCallRef]`. The conversation is already reconstructed in
`_convert_trajectory_to_output`, but correlating verifiers' internal completions
back to captured `model_call_id`s needs design input. Proposed as a follow-up
rather than bolted on here.

## Open question for reviewers

`observability_enabled` defaults to `False`, and **no EFB gym recipe sets it**
(`grep -rn observability_enabled configs/ reviewed_configs/` → nothing). So
every gym benchmark on the EFB path currently runs health-blind, not just this
one. Should the harness warn when health checking runs with observability off,
instead of reporting `0 healthy, 0 unhealthy, N unobserved` as if it were a
pass? Happy to open that separately.
