### PR TITLE
feat(automationbench): make the benchmark discoverable and preparable

### DIFF
--- a/benchmarks/automationbench/config.yaml
+++ b/benchmarks/automationbench/config.yaml
@@ -1,0 +1,30 @@
+# AutomationBench as a runnable Gym benchmark.
+#
+# `environments/automationbench/config.yaml` defines the environment instance,
+# but that alone is not discoverable as a benchmark:
+#
+#   * `discover_benchmarks()` only scans the `benchmarks/` subdir of each
+#     component search root, so a config under `environments/` is never seen.
+#   * `_is_benchmark_config()` requires exactly one `type: benchmark` dataset;
+#     the environment config declares only `example` and `validation`.
+#
+# So `--benchmark automationbench`, `++split=benchmark` and any EFB
+# `install_on_the_fly` run resolve to nothing without this wrapper. It mirrors
+# how `benchmarks/ifbench/config.yaml` wraps `environments/instruction_following`:
+# chain to the environment config, inherit the instance, and declare the one
+# benchmark dataset. `prepare_script` points back at the environment's own
+# `prepare.py`, so there is a single copy of the data-prep logic.
+config_paths:
+  - environments/automationbench/config.yaml
+
+automationbench_benchmark:
+  _inherit_from: automationbench
+  responses_api_agents:
+    verifiers_agent:
+      datasets:
+        - name: automationbench
+          type: benchmark
+          jsonl_fpath: environments/automationbench/data/automationbench-600.jsonl
+          prepare_script: environments/automationbench/prepare.py
+          num_repeats: 1
+          license: MIT

--- a/environments/automationbench/prepare.py
+++ b/environments/automationbench/prepare.py
@@ -22,14 +22,18 @@ VF_ENV_ID = "automationbench_env"
 TOOLSET = "api"
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--domains", nargs="*", default=None, help="subset of domains (default: all public domains)")
-    parser.add_argument("--size", type=int, default=-1, help="number of tasks (-1 for the full taskset)")
-    parser.add_argument("--max-turns", type=int, default=50)
-    parser.add_argument("--out", type=Path, default=None)
-    args = parser.parse_args()
+def prepare(
+    domains: list[str] | None = None,
+    size: int = -1,
+    max_turns: int = 50,
+    out: Path | None = None,
+) -> Path:
+    """Write the taskset to JSONL and return the path written.
 
+    `gym eval prepare` imports this module and calls `prepare(**prepare_script_args)`,
+    requiring the returned path to equal the dataset's `jsonl_fpath`, so this is
+    the entry point the benchmark config points at. `main` is the CLI wrapper.
+    """
     try:
         import verifiers as vf  # noqa: F401
         from automationbench_env import load_environment
@@ -39,11 +43,11 @@ def main() -> None:
             "    uv pip install -e environments/automationbench"
         ) from exc
 
-    env = load_environment(domains=args.domains, max_turns=args.max_turns, toolset=TOOLSET)
+    env = load_environment(domains=domains, max_turns=max_turns, toolset=TOOLSET)
     dataset = env.dataset
-    n = len(dataset) if args.size < 0 else min(args.size, len(dataset))
+    n = len(dataset) if size < 0 else min(size, len(dataset))
 
-    out = args.out or Path(__file__).parent / "data" / f"automationbench-{n}.jsonl"
+    out = out or Path(__file__).parent / "data" / f"automationbench-{n}.jsonl"
     out.parent.mkdir(parents=True, exist_ok=True)
 
     with out.open("w") as f:
@@ -69,6 +73,18 @@ def main() -> None:
             f.write(json.dumps(output_row) + "\n")
 
     print(f"wrote {n} rows -> {out}")
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--domains", nargs="*", default=None, help="subset of domains (default: all public domains)")
+    parser.add_argument("--size", type=int, default=-1, help="number of tasks (-1 for the full taskset)")
+    parser.add_argument("--max-turns", type=int, default=50)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    prepare(domains=args.domains, size=args.size, max_turns=args.max_turns, out=args.out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Targets `cmunley1/ab-evals` rather than `main`, so the diff is just the wiring
and it lands inside #3187. Happy to fold it in however you prefer, or close
this if you'd rather take the change directly.

## Why

AutomationBench cannot currently be run through `gym` or EFB at all. Three
things block it, each verified against your branch:

1. **Not discoverable.** `discover_benchmarks()` only scans the `benchmarks/`
   subdir of each component search root, so a config under `environments/` is
   never seen. `'automationbench' in discover_benchmarks()` → `False`.
2. **No `type: benchmark` dataset.** `_is_benchmark_config()` requires exactly
   one; the environment config declares only `example` and `validation`, so it
   would not qualify even if moved.
3. **No `prepare()`.** `gym eval prepare` imports the prepare script as a
   module and calls `module.prepare(**prepare_script_args)`, requiring the
   returned path to equal the dataset's `jsonl_fpath`
   (`nemo_gym/cli/eval.py`). `prepare.py` exposes only an argparse `main()`,
   and `automationbench-600.jsonl` is gitignored — so an EFB
   `install_on_the_fly` run finds no data.

Net effect: `--benchmark automationbench`, `++split=benchmark` and any
Evaluator run resolve to nothing.

## What this does

Adds `benchmarks/automationbench/config.yaml`, mirroring how
`benchmarks/ifbench/config.yaml` wraps `environments/instruction_following` —
chain to the environment config, `_inherit_from` the instance, declare the one
benchmark dataset.

Rather than duplicating the row-building logic, `prepare()` is extracted from
`main()` so the benchmark config can point `prepare_script` back at the
environment's own script. `main()` becomes a thin CLI wrapper; the CLI
behaviour is unchanged. Also adds the `__init__.py` that every other
environment package has.

## Verified on your branch

```
gym eval prepare --benchmark automationbench   -> wrote 600 rows
gym eval run --benchmark automationbench --split benchmark --limit 1
   -> 1 rollout, task_source: automationbench_benchmark, 2 real tool calls
```

## Note for reviewers, not caused by this change

Benchmark discovery needs `allow_openai_version_skew=true` in this tree.
`verifiers` 0.3.1 requires `openai>=2.9.0` unbounded, which resolves to 3.13.0
against nemo-gym's `openai==2.44.0` pin. Without the flag **every** benchmark
fails to resolve, not just this one — worth a pin rather than a flag, but it
belongs in #3187's discussion rather than here.

Separately, I have #3321 open against `main` fixing the rollout-capture prefix
in `verifiers_agent`, which is what makes rollout-health checks report anything
other than `unobserved` for this benchmark. Independent of this PR.
