### PR TITLE
feat(orchestration): served_model_name on model-serving services

### DIFF
--- a/nemo_gym/orchestration/api.py
+++ b/nemo_gym/orchestration/api.py
@@ -55,6 +55,15 @@ class BaseModelServiceConfig(BaseServiceConfig):
 
     model: str
     port: int = 8000
+    # The name clients should address this model by, if different from `model`
+    # (e.g. `model` is a local checkpoint path like /checkpoint, but the engine
+    # is told to serve it under a human-readable name). Defaults to `model`
+    # when unset -- both the engine's own serving flag (vLLM:
+    # _vllm_base_flags's --served-model-name) and driver.policy_model's
+    # auto-wiring of policy_model_name (SubmitConfig.
+    # _resolve_and_validate_placements) read this field, so the two always
+    # agree on what name a request actually has to use.
+    served_model_name: str | None = None
 
 
 class VllmServiceConfig(BaseModelServiceConfig):
@@ -217,7 +226,7 @@ class SubmitConfig(_StrictModel):
                             f"but driver.policy_model is also set. Remove one."
                         )
                     benchmark.run["policy_base_url"] = f"http://localhost:{service.port}/v1"
-                    benchmark.run["policy_model_name"] = service.model
+                    benchmark.run["policy_model_name"] = service.served_model_name or service.model
                     # vLLM doesn't require auth; dummy key satisfies clients that require the header.
                     benchmark.run["policy_api_key"] = "dummy"  # pragma: allowlist secret
 

--- a/nemo_gym/orchestration/api.py
+++ b/nemo_gym/orchestration/api.py
@@ -55,14 +55,6 @@ class BaseModelServiceConfig(BaseServiceConfig):
 
     model: str
     port: int = 8000
-    # The name clients should address this model by, if different from `model`
-    # (e.g. `model` is a local checkpoint path like /checkpoint, but the engine
-    # is told to serve it under a human-readable name). Defaults to `model`
-    # when unset -- both the engine's own serving flag (vLLM:
-    # _vllm_base_flags's --served-model-name) and driver.policy_model's
-    # auto-wiring of policy_model_name (SubmitConfig.
-    # _resolve_and_validate_placements) read this field, so the two always
-    # agree on what name a request actually has to use.
     served_model_name: str | None = None
 
 

--- a/nemo_gym/orchestration/executors/slurm_script.py
+++ b/nemo_gym/orchestration/executors/slurm_script.py
@@ -134,6 +134,8 @@ def _vllm_base_flags(service: VllmServiceConfig) -> str:
         f" --port {service.port}"
         f" --tensor-parallel-size {service.tensor_parallel_size}"
     )
+    if service.served_model_name:
+        cmd += f" --served-model-name {shlex.quote(service.served_model_name)}"
     if service.pipeline_parallel_size > 1:
         cmd += f" --pipeline-parallel-size {service.pipeline_parallel_size}"
     if service.extra_args:

--- a/tests/unit_tests/test_orchestration_api.py
+++ b/tests/unit_tests/test_orchestration_api.py
@@ -77,6 +77,17 @@ def test_policy_model_injects_run_args():
     assert benchmark.run["policy_api_key"] == "dummy"  # pragma: allowlist secret
 
 
+def test_policy_model_injects_served_model_name_when_set():
+    config = SubmitConfig.model_validate(
+        _config(
+            services={"svc": {**SERVICE, "served_model_name": "my-model"}},
+            driver={**DRIVER, "policy_model": "svc"},
+        )
+    )
+    benchmark = config.driver.benchmarks["gsm8k"]
+    assert benchmark.run["policy_model_name"] == "my-model"
+
+
 def test_policy_model_conflict_raises():
     driver = {**DRIVER, "policy_model": "svc", "benchmarks": {"gsm8k": {"run": {"policy_base_url": "http://other"}}}}
     with pytest.raises(ValidationError, match="already sets"):

--- a/tests/unit_tests/test_slurm_script.py
+++ b/tests/unit_tests/test_slurm_script.py
@@ -215,6 +215,33 @@ def test_build_vllm_command_no_extra_args_by_default(vllm_service):
     assert cmd.endswith("--tensor-parallel-size 1")
 
 
+def test_build_vllm_command_served_model_name():
+    service = VllmServiceConfig(
+        type="vllm",
+        container="vllm:latest",
+        model="/checkpoint",
+        served_model_name="super-bf16",
+    )
+    cmd = _build_vllm_command(service)
+    assert "--served-model-name super-bf16" in cmd
+
+
+def test_build_vllm_command_no_served_model_name_by_default(vllm_service):
+    cmd = _build_vllm_command(vllm_service)
+    assert "--served-model-name" not in cmd
+
+
+def test_build_vllm_command_served_model_name_quoted_if_needed():
+    service = VllmServiceConfig(
+        type="vllm",
+        container="vllm:latest",
+        model="/checkpoint",
+        served_model_name="name with spaces",
+    )
+    cmd = _build_vllm_command(service)
+    assert "--served-model-name 'name with spaces'" in cmd
+
+
 # ---------------------------------------------------------------------------
 # _build_vllm_ray_command - single instance, TP/PP spans nodes (uses Ray core)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add `served_model_name` to `BaseModelServiceConfig` so vLLM (and any future model-serving service type) can be told to serve a model under a name different from its `model` field, and so `driver.policy_model` auto-wiring picks up that same name.

- Previously, `driver.policy_model`'s auto-wiring set `policy_model_name` from `service.model` verbatim (`SubmitConfig._resolve_and_validate_placements`), with no way to account for `extra_args` telling the engine to serve under a different name (e.g. `--served-model-name super-bf16` when `model:` is a local checkpoint path like `/checkpoint`). The evaluation harness then requested the model by the wrong name and vLLM rejected it, since it only recognizes the name(s) it was actually told to serve under.
- New `served_model_name: str | None` field on `BaseModelServiceConfig` (not `VllmServiceConfig`-specific, so any future model-serving service type gets this for free) becomes the single source of truth for both sides: `_vllm_base_flags` emits `--served-model-name` from it, and `policy_model_name` auto-wiring reads the same field.
- Falls back to `model` when unset, so existing configs are unaffected.

## Changes

- `nemo_gym/orchestration/api.py` — `served_model_name` field on `BaseModelServiceConfig`; `policy_model_name` auto-wiring uses `service.served_model_name or service.model`
- `nemo_gym/orchestration/executors/slurm_script.py` — `_vllm_base_flags` emits `--served-model-name` (shell-quoted) when set
- `tests/unit_tests/test_orchestration_api.py`, `tests/unit_tests/test_slurm_script.py` — coverage for the new field, its default fallback, and quoting

## Test plan

- [ ] `pytest tests/unit_tests/test_orchestration_api.py -x`
- [ ] `pytest tests/unit_tests/test_slurm_script.py -x`