### PR TITLE
[Gym] Give uv a lock timeout that covers a cold concurrent install

### DIFF
--- a/nemo_gym/cli/setup_command.py
+++ b/nemo_gym/cli/setup_command.py
@@ -30,6 +30,7 @@ from nemo_gym.global_config import (
     PYTHON_VERSION_KEY_NAME,
     SKIP_VENV_IF_PRESENT_KEY_NAME,
     UV_CACHE_DIR_KEY_NAME,
+    UV_LOCK_TIMEOUT_KEY_NAME,
     UV_PIP_SET_PYTHON_KEY_NAME,
     UV_VENV_DIR_KEY_NAME,
     get_global_config_dict,
@@ -213,6 +214,11 @@ def run_command(
     custom_env["PYTHONPATH"] = ":".join(py_path_entries)
 
     custom_env["UV_CACHE_DIR"] = global_config_dict[UV_CACHE_DIR_KEY_NAME]
+    # Servers start concurrently and contend for the lock on that shared cache, so the wait has to
+    # cover a cold install of the slowest one rather than uv's 300s default.
+    uv_lock_timeout = global_config_dict.get(UV_LOCK_TIMEOUT_KEY_NAME)
+    if uv_lock_timeout is not None:
+        custom_env["UV_LOCK_TIMEOUT"] = str(uv_lock_timeout)
 
     log_dir = global_config_dict.get(NEMO_GYM_LOG_DIR_KEY_NAME)
     if log_dir:

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -88,6 +88,7 @@ UVICORN_TIMEOUT_WORKER_HEALTHCHECK = "uvicorn_timeout_worker_healthcheck"
 MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME = "model_endpoint_readiness_timeout_seconds"
 ALLOW_OPENAI_VERSION_SKEW_KEY_NAME = "allow_openai_version_skew"
 UV_CACHE_DIR_KEY_NAME = "uv_cache_dir"
+UV_LOCK_TIMEOUT_KEY_NAME = "uv_lock_timeout_seconds"
 UV_VENV_DIR_KEY_NAME = "uv_venv_dir"
 RESULTS_DIR_KEY_NAME = "results_dir"
 CACHE_DIR_KEY_NAME = "cache_dir"
@@ -133,6 +134,7 @@ NEMO_GYM_RESERVED_TOP_LEVEL_KEYS = [
     MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME,
     ALLOW_OPENAI_VERSION_SKEW_KEY_NAME,
     UV_CACHE_DIR_KEY_NAME,
+    UV_LOCK_TIMEOUT_KEY_NAME,
     UV_VENV_DIR_KEY_NAME,
     RESULTS_DIR_KEY_NAME,
     CACHE_DIR_KEY_NAME,
@@ -1263,6 +1265,13 @@ Found global config dict yaml:
             # Runtime subprocesses inherit the configured cache directory.
             if not parse_config.offline:
                 environ["UV_CACHE_DIR"] = global_config_dict[UV_CACHE_DIR_KEY_NAME]
+            # Every server installs into that one shared cache, and they all start at once, so
+            # exactly one holds uv's distribution-cache lock while the rest wait out its cold
+            # resolve and download. uv's own default is 300s, which is shorter than a cold install
+            # of a large dependency set - the waiters then abort and the run dies during spinup.
+            global_config_dict.setdefault(UV_LOCK_TIMEOUT_KEY_NAME, 1800)
+            if not parse_config.offline:
+                environ["UV_LOCK_TIMEOUT"] = str(global_config_dict[UV_LOCK_TIMEOUT_KEY_NAME])
             # By default, build the directories in their individual folders using the root repository
             # e.g. WORKING_DIR/responses_api_models/my_server
             # Deliberately anchored at WORKING_DIR rather than the cache root: venv

--- a/tests/unit_tests/test_cli_setup_command.py
+++ b/tests/unit_tests/test_cli_setup_command.py
@@ -416,6 +416,28 @@ class TestCLISetupCommandRunCommand:
         assert popen.call_args.kwargs["stdout"] == "isolated stdout"
         assert popen.call_args.kwargs["stderr"] == "isolated stderr"
 
+    def test_uv_lock_timeout_is_propagated_to_server_processes(self, monkeypatch: MonkeyPatch) -> None:
+        popen, _ = self._setup(monkeypatch)
+
+        run_command(
+            command="my command",
+            working_dir_path=Path("/my path"),
+            global_config_dict={"uv_cache_dir": "shared cache", "uv_lock_timeout_seconds": 1800},
+        )
+
+        assert popen.call_args.kwargs["env"]["UV_LOCK_TIMEOUT"] == "1800"
+
+    def test_uv_lock_timeout_absent_when_unconfigured(self, monkeypatch: MonkeyPatch) -> None:
+        popen, _ = self._setup(monkeypatch)
+
+        run_command(
+            command="my command",
+            working_dir_path=Path("/my path"),
+            global_config_dict={"uv_cache_dir": "shared cache"},
+        )
+
+        assert "UV_LOCK_TIMEOUT" not in popen.call_args.kwargs["env"]
+
 
 class TestGetNemoGymInstallFlags:
     """Test _get_nemo_gym_install_flags helper function."""

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -44,6 +44,7 @@ from nemo_gym.global_config import (
     DEFAULT_HEAD_SERVER_PORT,
     NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     USE_ABSOLUTE_IP,
+    UV_LOCK_TIMEOUT_KEY_NAME,
     GlobalConfigDictParser,
     GlobalConfigDictParserConfig,
     _openai_version_matches_nemo_gym_constraint,
@@ -81,6 +82,7 @@ class TestGlobalConfig:
             "model_endpoint_readiness_timeout_seconds": 600,
             "allow_openai_version_skew": False,
             "uv_cache_dir": str(CACHE_DIR.expanduser().resolve() / "uv"),
+            "uv_lock_timeout_seconds": 1800,
             "uv_venv_dir": str(WORKING_DIR),
             "results_dir": str(RESULTS_DIR.expanduser().resolve()),
             "cache_dir": str(CACHE_DIR.expanduser().resolve()),
@@ -115,6 +117,7 @@ class TestGlobalConfig:
     def test_offline_resolution_uses_invalid_port_without_probing(self, monkeypatch: MonkeyPatch) -> None:
         self._mock_versions_for_testing(monkeypatch)
         monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+        monkeypatch.delenv("UV_LOCK_TIMEOUT", raising=False)
         probe = MagicMock(side_effect=AssertionError("offline resolution must not probe sockets"))
         hostname = MagicMock(side_effect=AssertionError("offline resolution must not resolve hostnames"))
         setup_exporters = MagicMock(side_effect=AssertionError("offline resolution must not start exporters"))
@@ -143,6 +146,26 @@ class TestGlobalConfig:
         hostname.assert_not_called()
         setup_exporters.assert_not_called()
         assert "UV_CACHE_DIR" not in nemo_gym.global_config.environ
+        assert "UV_LOCK_TIMEOUT" not in nemo_gym.global_config.environ
+        assert config[UV_LOCK_TIMEOUT_KEY_NAME] == 1800
+
+    def test_uv_lock_timeout_is_exported_and_overridable(self, monkeypatch: MonkeyPatch) -> None:
+        self._mock_versions_for_testing(monkeypatch)
+        monkeypatch.setattr(nemo_gym.global_config, "environ", dict())
+        self._mock_parse_environment(monkeypatch, DictConfig({}))
+
+        default_config = get_global_config_dict()
+
+        assert default_config[UV_LOCK_TIMEOUT_KEY_NAME] == 1800
+        assert nemo_gym.global_config.environ["UV_LOCK_TIMEOUT"] == "1800"
+
+        monkeypatch.setattr(nemo_gym.global_config, "environ", dict())
+        self._mock_parse_environment(monkeypatch, DictConfig({UV_LOCK_TIMEOUT_KEY_NAME: 60}))
+
+        overridden_config = get_global_config_dict()
+
+        assert overridden_config[UV_LOCK_TIMEOUT_KEY_NAME] == 60
+        assert nemo_gym.global_config.environ["UV_LOCK_TIMEOUT"] == "60"
 
     def _mock_parse_environment(self, monkeypatch: MonkeyPatch, config_dict: "DictConfig") -> None:
         """Standard parser mocks (no env var, no .env.yaml, fixed hydra config)."""
@@ -154,7 +177,7 @@ class TestGlobalConfig:
         monkeypatch.setattr(nemo_gym.global_config.Path, "exists", exists_mock)
 
         hydra_main_mock = MagicMock()
-        hydra_main_mock.return_value = lambda fn: (lambda: fn(config_dict))
+        hydra_main_mock.return_value = lambda fn: lambda: fn(config_dict)
         monkeypatch.setattr(nemo_gym.global_config.hydra, "main", hydra_main_mock)
 
     def _mock_openai_topology(self, monkeypatch: MonkeyPatch, parent_version: str) -> None:
@@ -326,7 +349,7 @@ b: 2
         # Override OmegaConf.load to avoid file reads.
         omegaconf_load_mock = MagicMock()
         original_load = OmegaConf.load
-        omegaconf_load_mock.side_effect = lambda path: (DictConfig({}) if "env" in str(path) else original_load(path))
+        omegaconf_load_mock.side_effect = lambda path: DictConfig({}) if "env" in str(path) else original_load(path)
         monkeypatch.setattr(nemo_gym.server_utils.OmegaConf, "load", omegaconf_load_mock)
 
         global_config_dict = get_global_config_dict()
@@ -373,7 +396,7 @@ config_paths:
 
         omegaconf_load_mock = MagicMock()
         original_load = OmegaConf.load
-        omegaconf_load_mock.side_effect = lambda path: (DictConfig({}) if "env" in str(path) else original_load(path))
+        omegaconf_load_mock.side_effect = lambda path: DictConfig({}) if "env" in str(path) else original_load(path)
         monkeypatch.setattr(nemo_gym.server_utils.OmegaConf, "load", omegaconf_load_mock)
 
         get_global_config_dict()
@@ -463,7 +486,7 @@ config_paths:
         # Override OmegaConf.load to avoid file reads.
         omegaconf_load_mock = MagicMock()
         original_load = OmegaConf.load
-        omegaconf_load_mock.side_effect = lambda path: (DictConfig({}) if "env" in str(path) else original_load(path))
+        omegaconf_load_mock.side_effect = lambda path: DictConfig({}) if "env" in str(path) else original_load(path)
         monkeypatch.setattr(nemo_gym.server_utils.OmegaConf, "load", omegaconf_load_mock)
 
     def test_get_global_config_dict_config_paths_later_sibling_wins(


### PR DESCRIPTION
Three of four super-3.5 GDPVal arms died at startup last week with `Timeout (300s) when waiting for lock` on the uv distribution cache, and it read as a random server dying — the judge on two arms, `policy_model_reasoning_off` on a third. The fourth arm ran the identical Gym SHA to completion, so it was never the pinned code.

Cause is in Gym's own bring-up. `gym env start` launches every configured server in parallel and `run_command` forces one shared `UV_CACHE_DIR` onto all of them, so all 7 servers run their own `uv venv` + `uv pip install` against a single cache. One wins the distribution-cache lock and holds it through a cold resolve and download; the rest block and hit uv's 300s default. Measured cold resolves in those jobs ran 2m38s to 6m, so the ceiling was simply lower than the serialized work it was gating. Whether a run survives is a race against download speed.

Gym is what forces the shared cache, so it should own the timeout that implies. Adds `uv_lock_timeout_seconds`, default 1800, exported as `UV_LOCK_TIMEOUT` to the parent env and to every server process, overridable like any other config key.

Not GDPVal-specific — any config that starts several servers concurrently can hit it, and a larger server fan-out just means more dice rolls per job. Targeting `gdpval-devel` since that is where the failures surfaced; it belongs on `main` too.