### PR TITLE
Adithyare/gym skip verification

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -96,6 +96,15 @@ class GlobalAIOHTTPAsyncClientConfig(BaseModel):
         default=3,
         description=("TCP_KEEPCNT: number of unanswered probes before the kernel drops the connection."),
     )
+    global_aiohttp_client_total_timeout_seconds: Optional[float] = Field(
+        default=None,
+        description=(
+            "aiohttp ClientTimeout.total for every request the global client makes (model servers, "
+            "resources servers, agents). None (default) keeps the previous behaviour: no timeout, so a "
+            "request whose response is never written stalls its rollout forever. Set it above the "
+            "longest legitimate rollout (e.g. 5400 for 131k-token generations)."
+        ),
+    )
 
 
 def get_global_aiohttp_client(
@@ -155,7 +164,7 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
                 probes=cfg.global_aiohttp_tcp_keepalive_probes,
             ),
         ),
-        timeout=ClientTimeout(),
+        timeout=ClientTimeout(total=cfg.global_aiohttp_client_total_timeout_seconds),
         cookie_jar=DummyCookieJar(),
     )
 

--- a/responses_api_agents/conversational_tool_use/simulation/app.py
+++ b/responses_api_agents/conversational_tool_use/simulation/app.py
@@ -114,8 +114,10 @@ class ConversationalToolUseAgentVerifyResponse(BaseVerifyResponse):
 
     @model_validator(mode="after")
     def require_result_for_scored_rollout(self) -> "ConversationalToolUseAgentVerifyResponse":
-        failure_class = (self.model_extra or {}).get(NG_FAILURE_CLASS_KEY)
-        if failure_class != TRANSIENT_FAILURE_CLASS and self.result is None:
+        extra = self.model_extra or {}
+        failure_class = extra.get(NG_FAILURE_CLASS_KEY)
+        # skip_verification returns the request echoed back with a fixed reward and no typed result.
+        if failure_class != TRANSIENT_FAILURE_CLASS and self.result is None and not extra.get("verification_skipped"):
             raise ValueError("scored conversational tool-use responses require a typed result")
         return self
 

--- a/responses_api_agents/conversational_tool_use/simulation/app.py
+++ b/responses_api_agents/conversational_tool_use/simulation/app.py
@@ -358,6 +358,12 @@ class ConversationalToolUseAgent(SimpleResponsesAPIAgent):
                     "response": response_payload,
                 }
             )
+            if self.config.skip_verification:
+                session_needs_discard = False
+                return ConversationalToolUseAgentVerifyResponse.model_validate(
+                    verify_request.model_dump()
+                    | {"reward": float(self.config.skip_verification_reward), "verification_skipped": True}
+                )
             try:
                 verify_response = await self.server_client.post(
                     server_name=self.config.resources_server.name,

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -511,6 +511,12 @@ class FinanceAgent(SimpleResponsesAPIAgent):
             body.model_dump() | {"response": await get_response_json(response)}
         )
 
+        if self.config.skip_verification:
+            return FinanceAgentVerifyResponse.model_validate(
+                verify_request.model_dump()
+                | {"reward": float(self.config.skip_verification_reward), "verification_skipped": True}
+            )
+
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",

--- a/responses_api_agents/image_tools_agent/app.py
+++ b/responses_api_agents/image_tools_agent/app.py
@@ -371,14 +371,20 @@ class ImageToolsAgent(SimpleResponsesAPIAgent):
         verify_request_body = body.model_dump()
         verify_request_body["response"] = _final_assistant_response(model_response).model_dump()
         verify_request = ImageToolsAgentVerifyRequest.model_validate(verify_request_body)
-        verify_response = await self.server_client.post(
-            server_name=resource_name,
-            url_path="/verify",
-            json=verify_request.model_dump(),
-            cookies=resource_cookies,
-        )
-        await raise_for_status(verify_response)
-        verify_response_json = await get_response_json(verify_response)
+        if self.config.skip_verification:
+            verify_response_json = verify_request.model_dump() | {
+                "reward": float(self.config.skip_verification_reward),
+                "verification_skipped": True,
+            }
+        else:
+            verify_response = await self.server_client.post(
+                server_name=resource_name,
+                url_path="/verify",
+                json=verify_request.model_dump(),
+                cookies=resource_cookies,
+            )
+            await raise_for_status(verify_response)
+            verify_response_json = await get_response_json(verify_response)
 
         base_reward = float(verify_response_json.get("reward", 0.0))
         aux_reward = float(rollout_info["image_tools_aux_reward"])

--- a/responses_api_agents/non_executing_simple_agent/app.py
+++ b/responses_api_agents/non_executing_simple_agent/app.py
@@ -119,6 +119,12 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
             body.model_dump() | {"response": await get_response_json(response)}
         )
 
+        if self.config.skip_verification:
+            return NonExecutingSimpleAgentVerifyResponse.model_validate(
+                verify_request.model_dump()
+                | {"reward": float(self.config.skip_verification_reward), "verification_skipped": True}
+            )
+
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",

--- a/responses_api_agents/opencode_agent/app.py
+++ b/responses_api_agents/opencode_agent/app.py
@@ -801,14 +801,21 @@ class OpenCodeAgent(SimpleResponsesAPIAgent):
                 AgentObservationBundle.model_validate(raw_observations) if isinstance(raw_observations, dict) else None
             )
 
-            verify_resp = await self.server_client.post(
-                server_name=self.config.resources_server.name,
-                url_path="/verify",
-                json=body.model_dump() | {"response": agent_resp_json},
-                cookies=cookies,
-            )
-            await raise_for_status(verify_resp)
-            verify_json = await get_response_json(verify_resp)
+            if self.config.skip_verification:
+                verify_json = body.model_dump() | {
+                    "response": agent_resp_json,
+                    "reward": float(self.config.skip_verification_reward),
+                    "verification_skipped": True,
+                }
+            else:
+                verify_resp = await self.server_client.post(
+                    server_name=self.config.resources_server.name,
+                    url_path="/verify",
+                    json=body.model_dump() | {"response": agent_resp_json},
+                    cookies=cookies,
+                )
+                await raise_for_status(verify_resp)
+                verify_json = await get_response_json(verify_resp)
 
             gym_resp = NeMoGymResponse.model_validate(agent_resp_json)
             turns = sum(

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -224,6 +224,11 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         verify_request_data["solutions"] = solutions
         # /verify requires a response; record the last sub-step's generation (empty if none ran).
         verify_request_data["response"] = last_response_json if last_response_json is not None else _empty_response()
+        if self.config.skip_verification:
+            return verify_request_data | {
+                "reward": float(self.config.skip_verification_reward),
+                "verification_skipped": True,
+            }
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",


### PR DESCRIPTION
What does this PR do?

Makes skip_verification work for every agent, not only simple_agent, and adds an opt-in total timeout for the global aiohttp client.

Motivation. On-policy distillation (OPD) trains from teacher log-probs and never reads rewards. With skip_verification: true the intent is that no verifier backend has to be stood up: no LLM judges, no SEC filing cache, no test-data files, no sandboxes. Today only simple_agent honors the flag. The custom agents POST /verify unconditionally, so a multi-domain OPD run has to provision, or stub, every verifier just to get rollouts through. In our 5-teacher, 46-env run this cost several failed bring-up attempts (missing test_data_fpath, an unauthenticated judge proxy returning 500s, missing hidden-test files).

Changes.

1. skip_verification honored in finance_agent, image_tools_agent, scicode_agent, opencode_agent, non_executing_simple_agent, and conversational_tool_use/simulation. Each mirrors the existing simple_agent behavior: skip the /verify POST and return the verify request echoed back with reward = skip_verification_reward and verification_skipped: True. image_tools_agent still adds its auxiliary image reward on top. Behavior with the flag unset is unchanged.
2. ConversationalToolUseAgentVerifyResponse accepts a response without a typed result when verification_skipped is set. Previously its validator raised, since skipped responses carry no scored result.
3. New global config key global_aiohttp_client_total_timeout_seconds (default None, meaning no timeout, identical to current behavior). When set, it becomes ClientTimeout.total for every request the global client makes. Motivation: with no timeout anywhere, a single model-server request whose response never arrives stalls a rollout forever; in a 128-node run this blocked the trainer's refit for over an hour on one request. Setting it to a value above the longest legitimate rollout turns that into a failed rollout the collector can retry.

Validated on a 128-node NeMo-RL OPD run: 77 training steps across 46 environments with skip_verification: true and zero judge or verifier backends configured; zero verification-related failures.

Checklist

- [x] I have read the contributing guidelines.
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally. No new tests yet; the skip path mirrors simple_agent, which is covered. Can add per-agent unit tests on request.
- [ ] Pre-commit checks pass locally. Not run on the cluster; will run before marking ready for review.
- [ ] All commits have DCO sign-off. Will amend with git commit -s before final push.