### PR TITLE
fix: bound validation error logging

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -15,6 +15,7 @@
 import asyncio
 import atexit
 import json
+import logging
 import resource
 import socket
 import sys
@@ -82,9 +83,60 @@ from nemo_gym.telemetry._fallbacks import is_span_group_enabled, safe_set_span_a
 from nemo_gym.telemetry.span_groups import GymSpanGroup
 
 
+logger = logging.getLogger(__name__)
+
 _GLOBAL_AIOHTTP_CLIENT: Union[None, ClientSession] = None
 _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG: bool = False
 _UPSTREAM_ERROR_LOG_BODY_CHARS = 2000
+# Bound both the raw request prefix and its escaped representation to 4 KiB.
+_VALIDATION_ERROR_LOG_BODY_CHARS = 4096
+_VALIDATION_ERROR_LOG_MAX_ERRORS = 20
+
+
+async def _log_validation_exception(request: Request, exc: RequestValidationError) -> None:
+    errors = exc.errors()
+    error_summaries = [
+        {
+            "type": error.get("type"),
+            "loc": error.get("loc"),
+            "msg": error.get("msg"),
+        }
+        for error in errors[:_VALIDATION_ERROR_LOG_MAX_ERRORS]
+    ]
+
+    try:
+        body = await request.body()
+    except Exception:
+        logger.warning(
+            "Request validation failed; request body unavailable",
+            extra={
+                "validation_error_count": len(errors),
+                "validation_errors": error_summaries,
+                "validation_errors_truncated": len(errors) > len(error_summaries),
+            },
+        )
+        return
+
+    raw_prefix = body[:_VALIDATION_ERROR_LOG_BODY_CHARS]
+    rendered_prefix = json.dumps(raw_prefix.decode("utf-8", errors="replace"), ensure_ascii=True)
+    escaped_prefix = rendered_prefix[:_VALIDATION_ERROR_LOG_BODY_CHARS]
+    logger.warning(
+        "Request validation failed",
+        extra={
+            "request_body_size_bytes": len(body),
+            "request_body_prefix": escaped_prefix,
+            "request_body_truncated": len(body) > len(raw_prefix) or len(rendered_prefix) > len(escaped_prefix),
+            "validation_error_count": len(errors),
+            "validation_errors": error_summaries,
+            "validation_errors_truncated": len(errors) > len(error_summaries),
+        },
+    )
+
+
+async def _validation_exception_handler(request: Request, exc: RequestValidationError) -> Response:
+    await _log_validation_exception(request, exc)
+    return await request_validation_exception_handler(request, exc)
+
 
 NEMO_GYM_MODEL_SERVER_NAME_ENV_VAR_NAME = "NEMO_GYM_MODEL_SERVER_NAME"
 NEMO_GYM_MODEL_SERVER_BASE_URL_ENV_VAR_NAME = "NEMO_GYM_MODEL_SERVER_BASE_URL"
@@ -1040,14 +1092,7 @@ repr(e): {repr(e)}"""
         # caller's CLIENT span.
         server.instrument_app_for_telemetry(app)
 
-        @app.exception_handler(RequestValidationError)
-        async def validation_exception_handler(request: Request, exc):
-            print(
-                f"""Hit validation exception! Errors: {json.dumps(exc.errors(), indent=4)}
-Full body: {json.dumps(exc.body, indent=4)}
-"""
-            )
-            return await request_validation_exception_handler(request, exc)
+        app.exception_handler(RequestValidationError)(_validation_exception_handler)
 
         profiling_config = ProfilingMiddlewareConfig.model_validate(global_config_dict)
         if profiling_config.profiling_enabled:

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -13,15 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import logging
 import multiprocessing
 import socket
 from concurrent.futures import ProcessPoolExecutor
 from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import ClientOSError, ClientResponseError, RequestInfo
+from fastapi import Request
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from multidict import CIMultiDict, CIMultiDictProxy
 from omegaconf import OmegaConf
-from pytest import CaptureFixture, MonkeyPatch, raises
+from pytest import CaptureFixture, LogCaptureFixture, MonkeyPatch, mark, raises
 from yarl import URL
 
 import nemo_gym.global_config
@@ -44,7 +48,9 @@ from nemo_gym.server_utils import (
     ServerClient,
     SimpleServer,
     _format_upstream_error_log,
+    _log_validation_exception,
     _make_keepalive_socket_factory,
+    _validation_exception_handler,
     initialize_ray,
     raise_for_status,
 )
@@ -787,6 +793,115 @@ class TestServerUtils:
         assert "api_key=secret" not in message
         assert message.endswith("…")
         assert len(message) < 2200
+
+    @mark.parametrize(
+        "body",
+        [
+            b"",
+            b'{"nested":{"value":"small"}}',
+            b"not-json\nwith-control-\x00",
+            b'{"credentials":{"password":"secret"}}',
+            b'{"payload":"' + b"x" * (2 * 1024 * 1024) + b'"}',
+        ],
+        ids=["empty", "small-json", "non-json-control", "credentials", "multi-megabyte"],
+    )
+    async def test_validation_exception_log_bounds_body_before_rendering(
+        self, body: bytes, caplog: LogCaptureFixture, monkeypatch: MonkeyPatch
+    ) -> None:
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=body)
+        errors = [
+            {
+                "type": "missing",
+                "loc": ("body", "required_field"),
+                "msg": "Field required",
+                "input": {"password": "value that must not be copied into the error log"},
+            }
+        ]
+        exc = RequestValidationError(errors, body={"original": "body"})
+        rendered_body_sizes = []
+        json_dumps = nemo_gym.server_utils.json.dumps
+
+        def tracking_json_dumps(value, *args, **kwargs):
+            if isinstance(value, str):
+                rendered_body_sizes.append(len(value))
+            return json_dumps(value, *args, **kwargs)
+
+        monkeypatch.setattr(nemo_gym.server_utils.json, "dumps", tracking_json_dumps)
+
+        with caplog.at_level(logging.WARNING, logger="nemo_gym.server_utils"):
+            await _log_validation_exception(request, exc)
+
+        record = caplog.records[-1]
+        assert record.request_body_size_bytes == len(body)
+        assert rendered_body_sizes == [min(len(body), nemo_gym.server_utils._VALIDATION_ERROR_LOG_BODY_CHARS)]
+        assert len(record.request_body_prefix) <= nemo_gym.server_utils._VALIDATION_ERROR_LOG_BODY_CHARS
+        assert record.request_body_truncated is (len(body) > nemo_gym.server_utils._VALIDATION_ERROR_LOG_BODY_CHARS)
+        assert record.validation_error_count == 1
+        assert record.validation_errors == [
+            {
+                "type": "missing",
+                "loc": ("body", "required_field"),
+                "msg": "Field required",
+            }
+        ]
+        assert "value that must not be copied into the error log" not in str(record.validation_errors)
+        if body == b"not-json\nwith-control-\x00":
+            assert "\n" not in record.request_body_prefix
+            assert "\x00" not in record.request_body_prefix
+            assert "\\n" in record.request_body_prefix
+            assert "\\u0000" in record.request_body_prefix
+
+    async def test_validation_exception_log_bounds_error_count(self, caplog: LogCaptureFixture) -> None:
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=b"{}")
+        errors = [
+            {
+                "type": "missing",
+                "loc": ("body", f"field_{index}"),
+                "msg": "Field required",
+                "input": None,
+            }
+            for index in range(nemo_gym.server_utils._VALIDATION_ERROR_LOG_MAX_ERRORS + 5)
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="nemo_gym.server_utils"):
+            await _log_validation_exception(request, RequestValidationError(errors))
+
+        record = caplog.records[-1]
+        assert record.validation_error_count == len(errors)
+        assert len(record.validation_errors) == nemo_gym.server_utils._VALIDATION_ERROR_LOG_MAX_ERRORS
+        assert record.validation_errors_truncated is True
+
+    async def test_validation_exception_logging_failure_does_not_mask_422(self, caplog: LogCaptureFixture) -> None:
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(side_effect=RuntimeError("body unavailable"))
+        errors = [{"type": "missing", "loc": ("body", "field"), "msg": "Field required", "input": {}}]
+        exc = RequestValidationError(errors, body={"field": None})
+
+        with caplog.at_level(logging.WARNING, logger="nemo_gym.server_utils"):
+            await _log_validation_exception(request, exc)
+
+        record = caplog.records[-1]
+        assert record.getMessage() == "Request validation failed; request body unavailable"
+        assert record.validation_error_count == 1
+        assert exc.errors() == errors
+        assert exc.body == {"field": None}
+
+    async def test_validation_exception_handler_preserves_fastapi_response(self, caplog: LogCaptureFixture) -> None:
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=b'{"field":null}')
+        exc = RequestValidationError(
+            [{"type": "missing", "loc": ("body", "required"), "msg": "Field required", "input": None}]
+        )
+        expected = await request_validation_exception_handler(request, exc)
+
+        with caplog.at_level(logging.WARNING, logger="nemo_gym.server_utils"):
+            actual = await _validation_exception_handler(request, exc)
+
+        assert actual.status_code == expected.status_code == 422
+        assert actual.body == expected.body
+        assert actual.headers == expected.headers
 
     async def test_exception_middleware_logs_upstream_error_without_debug(
         self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]


### PR DESCRIPTION
## What does this PR do?

Caps validation-failure request-body logging at 4 KiB before decoding or rendering. It records the original body size and truncation status, bounds validation error metadata, escapes control characters, and preserves FastAPI's standard 422 response.

Closes #3007.
Supersedes #3056 and applies its fix cleanly on current `main`, with additional boundedness, privacy, and failure-path coverage.

## Validation

All acceptance criteria from #3007 are covered:

- [x] Applies a documented 4 KiB maximum to rejected-body log content.
- [x] Includes original byte size and truncation status as structured log fields.
- [x] Caps raw bytes before decoding and rendering, avoiding a full intermediate rendered copy.
- [x] Preserves FastAPI's standard 422 status, response bytes, and headers.
- [x] Covers empty, small, non-JSON, nested, and multi-megabyte rejected bodies.
- [x] Covers credentials and control characters without increasing disclosure: Pydantic `input`, headers, and cookies are not logged; query-, path-, and header-only failures do not read or log the body.
- [x] Focused server utility and validation-handler tests pass: `uv run --extra dev pytest tests/unit_tests/test_server_utils.py -q` — 46 passed.

Additional validation:

- Validation errors are limited to 20 entries, location paths to 8 items, and string fields to 256 characters.
- Escaped prefixes remain bounded and valid at escape boundaries.
- Body errors are detected across the full error list even when logged summaries are capped.
- Body-read and logger failures do not mask the standard 422 response.
- `uv run pre-commit run --all-files` — passed.
- DCO sign-off is present.

## Benchmark

The #3007 benchmark plan was run on an AMD Ryzen Threadripper 3960X with Python 3.13.14. Both versions used the same validation error and exact 1 KiB, 2 MiB, and 8 MiB bodies. The benchmark ran 200 iterations for 1 KiB and 100 iterations for larger bodies. CPU is process time per diagnostic call, allocation is traced peak memory, and emitted bytes are bytes written by the old `print` path or new logger path to a `%message` plus newline counting sink.

| Body | Version | CPU/op | Peak allocation | Emitted bytes | p50 | p95 | p99 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 KiB | Before | 0.008 ms | 0.003 MiB | 1,245 | 0.007 ms | 0.009 ms | 0.014 ms |
| 1 KiB | After | 0.127 ms | 0.007 MiB | 1,195 | 0.125 ms | 0.134 ms | 0.153 ms |
| 2 MiB | Before | 6.351 ms | 4.501 MiB | 2,097,373 | 6.344 ms | 6.382 ms | 6.423 ms |
| 2 MiB | After | 0.433 ms | 0.023 MiB | 4,263 | 0.429 ms | 0.446 ms | 0.458 ms |
| 8 MiB | Before | 26.948 ms | 18.001 MiB | 8,388,829 | 26.875 ms | 27.262 ms | 28.743 ms |
| 8 MiB | After | 0.434 ms | 0.023 MiB | 4,263 | 0.429 ms | 0.457 ms | 0.471 ms |

A 64-request bounded burst confirmed emitted bytes scale with request count and the cap, not body size:

| Body | Version | Total time | Total emitted bytes |
| --- | --- | ---: | ---: |
| 1 KiB | Before | 0.872 ms | 79,680 |
| 1 KiB | After | 8.142 ms | 76,480 |
| 2 MiB | Before | 237.128 ms | 134,231,872 |
| 2 MiB | After | 27.279 ms | 272,832 |
| 8 MiB | Before | 1,265.332 ms | 536,885,056 |
| 8 MiB | After | 27.501 ms | 272,832 |

Valid-request throughput showed no conclusive regression: before and after ranges overlapped, and the changed handler is not invoked for valid requests. End-to-end invalid requests returned identical 422 status, body bytes, and headers.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
