### PR TITLE
fix(nemotron_3.5_super): make P/D router balance thresholds configurable

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -38,6 +38,14 @@ WORKER_SERVER_PORT=8001
 ROUTER_PREFILL_POLICY="${ROUTER_PREFILL_POLICY:-cache_aware}"
 ROUTER_DECODE_POLICY="${ROUTER_DECODE_POLICY:-cache_aware}"
 ROUTER_INTRA_NODE_DATA_PARALLEL_SIZE="${ROUTER_INTRA_NODE_DATA_PARALLEL_SIZE:-1}"
+# cache_aware drops prefix affinity for shortest-queue routing once the in-flight
+# spread between the busiest and idlest worker exceeds BOTH thresholds. The tight
+# defaults below assume the per-request affinity check from vllm-project/router#238
+# (see README, "vllm-router patch"). On a stock router the check is fleet-wide, so at
+# ~1000 concurrent sessions these values keep it in shortest-queue mode and prefix
+# cache hits collapse; use the upstream defaults (32 / 1.5) there.
+ROUTER_BALANCE_ABS_THRESHOLD="${ROUTER_BALANCE_ABS_THRESHOLD:-4}"
+ROUTER_BALANCE_REL_THRESHOLD="${ROUTER_BALANCE_REL_THRESHOLD:-1.1}"
 
 eval_command=$(cat <<EOF
 set -euo pipefail
@@ -139,8 +147,8 @@ if (( SLURM_PROCID == 0 )); then
     router_args=( \
         --prefill-policy $ROUTER_PREFILL_POLICY \
         --decode-policy $ROUTER_DECODE_POLICY \
-        --balance-abs-threshold 4 \
-        --balance-rel-threshold 1.1 \
+        --balance-abs-threshold $ROUTER_BALANCE_ABS_THRESHOLD \
+        --balance-rel-threshold $ROUTER_BALANCE_REL_THRESHOLD \
         --vllm-pd-disaggregation \
         --host \$this_node_hostname \
         --port $ROUTER_SERVER_PORT \


### PR DESCRIPTION
## What does this PR do?

Exposes the vllm-router `cache_aware` balance thresholds in `sbatch_external_vllm.sh` as environment knobs, following the `ROUTER_*_POLICY` pattern from #3193:

- `ROUTER_BALANCE_ABS_THRESHOLD` (default 4)
- `ROUTER_BALANCE_REL_THRESHOLD` (default 1.1)

Defaults are the values #2979 hard-coded, so existing callers see no behaviour change.

## Why

The hard-coded 4 / 1.1 assume the per-request affinity check from vllm-project/router#238 (pinned into the eval container by #3080/#3107). On a **stock** vllm-router the imbalance check is fleet-wide: with ~1000 concurrent OpenCode sessions over 4 prefill workers the spread exceeds 4 requests almost permanently, `cache_aware` stays in shortest-queue mode, and conversation prefixes miss the cache.

Measured on SWE-bench Pro (Super 3.5, 4P/6D, same serving image with the stock router, same vLLM flags, only the thresholds differ):

| thresholds | prefix-cache hit (run mean) | gen tok/s | 2193 rollouts |
| --- | --- | --- | --- |
| 4 / 1.1 (current) | 65% | ~1000 | TIMEOUT at 4h, 2181–2189 done (5 runs) |
| 32 / 1.5 (upstream defaults, via these knobs) | 84% | ~1400 | COMPLETED in 3h25m |

Deployments that ship the #238 router keep the tight defaults; deployments on a stock router set the upstream defaults through the environment without patching the launcher.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (shell launcher; `bash -n` clean).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`).
- [x] All commits have DCO sign-off (`git commit -s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
